### PR TITLE
fix(settings): clear leaderboard data when emptying database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 
 ## [Unreleased]
 
+### Fixed
+
+- Settings **Empty database** now clears all application SQLite tables, including evaluation prompts and evaluations that feed the leaderboard.
+- Leaderboard view now clears stale displayed rows immediately after the database is emptied from settings.
+
 ## [0.3.1] - 2026-05-02
 
 ### Changed

--- a/backend/src/services/system-settings.ts
+++ b/backend/src/services/system-settings.ts
@@ -103,26 +103,20 @@ export function setEnvEntry(key: string, value: string | null): EnvEntry[] {
 
 export function clearDatabase(): void {
   const db = getDb();
-  const tables = [
-    'metric_samples',
-    'test_result_documents',
-    'test_results',
-    'runs',
-    'active_tests',
-    'instantiated_tests',
-    'test_template_versions',
-    'test_templates',
-    'suites',
-    'profiles',
-    'models',
-    'test_definitions',
-    'inference_servers'
-  ];
+  const tables = db
+    .prepare(`
+      SELECT name
+      FROM sqlite_schema
+      WHERE type = 'table'
+        AND name NOT LIKE 'sqlite_%'
+      ORDER BY name
+    `)
+    .all() as Array<{ name: string }>;
 
   db.pragma('foreign_keys = OFF');
   const clear = db.transaction(() => {
-    for (const table of tables) {
-      db.prepare(`DELETE FROM ${table}`).run();
+    for (const { name } of tables) {
+      db.prepare(`DELETE FROM "${name.replace(/"/g, '""')}"`).run();
     }
   });
   try {

--- a/backend/tests/integration/leaderboard.test.ts
+++ b/backend/tests/integration/leaderboard.test.ts
@@ -208,4 +208,23 @@ describe('GET /leaderboard', () => {
     const unfiltered = await app.inject({ method: 'GET', url: '/leaderboard', headers: AUTH_HEADERS });
     expect(unfiltered.json().entries).toHaveLength(2);
   });
+
+  it('returns empty entries after clearing the database from settings', async () => {
+    const app = createServer();
+    seedEvaluation({ modelName: 'model-before-clear', scores: 5, tags: ['cleanup'] });
+
+    const populated = await app.inject({ method: 'GET', url: '/leaderboard', headers: AUTH_HEADERS });
+    expect(populated.json().entries).toHaveLength(1);
+
+    const clearResponse = await app.inject({ method: 'POST', url: '/system/clear-db', headers: AUTH_HEADERS });
+    expect(clearResponse.statusCode).toBe(200);
+
+    const cleared = await app.inject({ method: 'GET', url: '/leaderboard', headers: AUTH_HEADERS });
+    expect(cleared.statusCode).toBe(200);
+    expect(cleared.json().entries).toEqual([]);
+
+    const db = getDb();
+    expect(db.prepare('SELECT COUNT(*) AS count FROM evaluations').get()).toEqual({ count: 0 });
+    expect(db.prepare('SELECT COUNT(*) AS count FROM eval_prompts').get()).toEqual({ count: 0 });
+  });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -310,6 +310,7 @@ export function App() {
     setSettingsError(null);
     try {
       await clearDatabase();
+      window.dispatchEvent(new CustomEvent('database:cleared'));
       setSettingsMessage('Database cleared.');
     } catch (err) {
       setSettingsError(err instanceof Error ? err.message : 'Unable to clear database');

--- a/frontend/src/pages/Leaderboard.tsx
+++ b/frontend/src/pages/Leaderboard.tsx
@@ -48,8 +48,20 @@ export function Leaderboard({ setView }: LeaderboardProps) {
     listModels().then(setModelRecords).catch(() => {});
 
     const handleSaved = () => fetchLeaderboard(activeFilters);
+    const handleDatabaseCleared = () => {
+      setEntries([]);
+      setModelRecords([]);
+      setActiveFilters({});
+      setHasActiveFilters(false);
+      setError(null);
+      setLoading(false);
+    };
     window.addEventListener('evaluations:saved', handleSaved);
-    return () => window.removeEventListener('evaluations:saved', handleSaved);
+    window.addEventListener('database:cleared', handleDatabaseCleared);
+    return () => {
+      window.removeEventListener('evaluations:saved', handleSaved);
+      window.removeEventListener('database:cleared', handleDatabaseCleared);
+    };
   }, []);
 
   function handleApply(filterValues: LeaderboardFilterValues) {


### PR DESCRIPTION
Clear all application SQLite tables from the settings empty-database action, including evaluation prompts and evaluations, and reset stale leaderboard UI state after a successful clear.