### PR TITLE
fix(architecture): inspect MLX models from config metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 
 - Settings **Empty database** now clears all application SQLite tables, including evaluation prompts and evaluations that feed the leaderboard.
 - Leaderboard view now clears stale displayed rows immediately after the database is emptied from settings.
+- Architecture inspection errors now show visible, non-empty diagnostics in the model detail page instead of leaving only a red button state.
+- MLX architecture inspection now uses config-backed estimation directly, avoiding PyTorch-dependent `AutoModel` construction and allowing models such as `/inferencerlabs/Qwen3-Coder-30B-A3B-Instruct-MLX-6.5bit` to inspect successfully from `config.json`.
+- Architecture inspector subprocess failures now include captured output or an explicit timeout diagnostic when the Python process exits or is killed without a structured error.
 
 ## [0.3.1] - 2026-05-02
 

--- a/backend/src/adapters/architecture-inspector.ts
+++ b/backend/src/adapters/architecture-inspector.ts
@@ -209,9 +209,12 @@ export function parseStructuredInspectorError(stderr: string): InspectorError | 
         return { code: 'unregistered_architecture' };
       }
       if (payload.error === 'inspection_failed') {
+        const message = typeof payload.message === 'string' && payload.message.trim()
+          ? payload.message.trim()
+          : 'Inspection failed';
         return {
           code: 'inspection_failed',
-          message: typeof payload.message === 'string' ? payload.message : 'Inspection failed',
+          message,
         };
       }
     } catch {
@@ -223,6 +226,24 @@ export function parseStructuredInspectorError(stderr: string): InspectorError | 
 
 export function scrubInspectionStderr(stderr: string, token: string): string {
   return token ? stderr.replace(new RegExp(escapeRegex(token), 'g'), '[REDACTED]') : stderr;
+}
+
+interface InspectionProcessResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  signal: NodeJS.Signals | null;
+  timedOut: boolean;
+}
+
+export function inspectorFailureMessage(result: InspectionProcessResult, token: string): string {
+  const output = scrubInspectionStderr(`${result.stderr}\n${result.stdout}`.trim(), token).trim();
+  const excerpt = output ? ` Last inspector output: ${output.slice(0, 500)}` : '';
+  if (result.timedOut) {
+    return `Inspector process timed out after 60 seconds.${excerpt}`;
+  }
+  const signal = result.signal ? `, signal ${result.signal}` : '';
+  return output || `Inspector process failed without diagnostic output (exit code ${result.exitCode}${signal}).`;
 }
 
 async function _spawnInspection(opts: InspectOptions): Promise<ArchitectureTree | InspectorError> {
@@ -255,42 +276,53 @@ async function _spawnInspection(opts: InspectOptions): Promise<ArchitectureTree 
   };
   if (token) childEnv['HF_TOKEN'] = token;
 
-  const result = await new Promise<{ stdout: string; stderr: string; exitCode: number }>((resolve) => {
+  const result = await new Promise<InspectionProcessResult>((resolve) => {
+    let timedOut = false;
     const proc = spawn('bash', ['-lc', command], {
       env: { ...process.env, ...childEnv },
-      cwd: repoRoot
+      cwd: repoRoot,
+      detached: process.platform !== 'win32',
     });
 
     let stdout = '';
     let stderr = '';
 
     const timeout = setTimeout(() => {
-      proc.kill('SIGKILL');
+      timedOut = true;
       _deleteCacheFiles(sanitizedId);
+      try {
+        if (process.platform !== 'win32' && proc.pid) {
+          process.kill(-proc.pid, 'SIGKILL');
+        } else {
+          proc.kill('SIGKILL');
+        }
+      } catch {
+        try { proc.kill('SIGKILL'); } catch { /* ignore */ }
+      }
     }, 60_000);
 
     proc.stdout.on('data', (chunk) => { stdout += (chunk as Buffer).toString(); });
     proc.stderr.on('data', (chunk) => { stderr += (chunk as Buffer).toString(); });
-    proc.on('close', (code) => {
+    proc.on('close', (code, signal) => {
       clearTimeout(timeout);
-      resolve({ stdout, stderr, exitCode: code ?? 1 });
+      resolve({ stdout, stderr, exitCode: code ?? 1, signal, timedOut });
     });
   });
 
   if (result.exitCode !== 0) {
     _deleteCacheFiles(sanitizedId);
-    const structuredError = parseStructuredInspectorError(result.stderr);
+    const combinedOutput = `${result.stderr}\n${result.stdout}`;
+    const structuredError = parseStructuredInspectorError(combinedOutput);
     if (structuredError) {
       return structuredError;
     }
-    const scrubbed = scrubInspectionStderr(result.stderr, token);
-    if (result.stderr.includes('unregistered_architecture')) {
+    if (combinedOutput.includes('unregistered_architecture')) {
       return { code: 'unregistered_architecture' };
     }
-    if (result.stderr.includes('hf_token_required') || result.stderr.includes('401') || result.stderr.includes('403')) {
+    if (combinedOutput.includes('hf_token_required') || combinedOutput.includes('401') || combinedOutput.includes('403')) {
       return { code: 'hf_token_required' };
     }
-    return { code: 'inspection_failed', message: scrubbed.slice(0, 500) };
+    return { code: 'inspection_failed', message: inspectorFailureMessage(result, token) };
   }
 
   let tree: ArchitectureTree;

--- a/backend/src/api/routes/architecture.ts
+++ b/backend/src/api/routes/architecture.ts
@@ -46,6 +46,13 @@ function isInspectorError(v: ArchitectureTree | InspectorError): v is InspectorE
   return 'code' in v && !('schema_version' in v);
 }
 
+function inspectionFailureMessage(err: InspectorError): string {
+  if ('message' in err && typeof err.message === 'string' && err.message.trim()) {
+    return err.message.trim();
+  }
+  return 'Inspection failed.';
+}
+
 function errorToHttp(err: InspectorError): { status: number; body: { error: string; code: string } } {
   switch (err.code) {
     case 'inspection_in_progress':
@@ -76,7 +83,7 @@ function errorToHttp(err: InspectorError): { status: number; body: { error: stri
       return {
         status: 500,
         body: {
-          error: (err as { code: string; message?: string }).message ?? 'Inspection failed.',
+          error: inspectionFailureMessage(err),
           code: (err as { code: string }).code,
         },
       };

--- a/backend/src/scripts/inspect_architecture.py
+++ b/backend/src/scripts/inspect_architecture.py
@@ -694,10 +694,7 @@ def main() -> None:
         model_source = args.model_path if args.format_ in {"mlx", "gptq", "awq", "safetensors"} and args.model_path else args.model_id
         if args.format_ == "mlx":
             mlx_config = _read_config_dict(model_source, args.hf_token)
-            if _uses_config_first_mlx_fallback(mlx_config):
-                result = inspect_config_fallback(model_source, mlx_config, "mlx")
-            else:
-                result = inspect_transformers(model_source, args.hf_token, args.trust_remote_code, "mlx")
+            result = inspect_config_fallback(model_source, mlx_config, "mlx")
         elif args.format_ in {"gptq", "awq", "safetensors"}:
             result = inspect_transformers(model_source, args.hf_token, args.trust_remote_code, args.format_)
         else:

--- a/backend/tests/unit/architecture-inspector.test.ts
+++ b/backend/tests/unit/architecture-inspector.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   DATA_DIR,
   ArchitectureTree,
+  inspectorFailureMessage,
   parseStructuredInspectorError,
   readCachedTree,
   sanitizeModelId,
@@ -235,6 +236,13 @@ describe('inspector subprocess errors', () => {
     });
   });
 
+  it('normalizes structured inspection failures with empty messages', () => {
+    expect(parseStructuredInspectorError('{"error": "inspection_failed", "message": ""}\n')).toEqual({
+      code: 'inspection_failed',
+      message: 'Inspection failed',
+    });
+  });
+
   it('does not inject redaction markers when no token is configured', () => {
     const stderr = '{"error": "inspection_failed", "message": "\'ministral3\'"}\n';
     expect(scrubInspectionStderr(stderr, '')).toBe(stderr);
@@ -242,5 +250,25 @@ describe('inspector subprocess errors', () => {
 
   it('redacts configured Hugging Face tokens from subprocess stderr', () => {
     expect(scrubInspectionStderr('token hf_secret appeared', 'hf_secret')).toBe('token [REDACTED] appeared');
+  });
+
+  it('reports timeout failures with captured inspector output', () => {
+    expect(inspectorFailureMessage({
+      stdout: '',
+      stderr: 'Retrying config.json download',
+      exitCode: 1,
+      signal: 'SIGKILL',
+      timedOut: true,
+    }, '')).toBe('Inspector process timed out after 60 seconds. Last inspector output: Retrying config.json download');
+  });
+
+  it('uses stdout as a fallback diagnostic for process failures', () => {
+    expect(inspectorFailureMessage({
+      stdout: 'late stdout diagnostic',
+      stderr: '',
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+    }, '')).toBe('late stdout diagnostic');
   });
 });

--- a/backend/tests/unit/architecture-routes.test.ts
+++ b/backend/tests/unit/architecture-routes.test.ts
@@ -198,6 +198,20 @@ describe('Architecture routes', () => {
       expect(response.statusCode).toBe(422);
     });
 
+    it('returns a visible fallback message for inspection failures with empty diagnostics', async () => {
+      vi.mocked(inspector.readCachedTree).mockReturnValue({ code: 'not_cached' });
+      vi.mocked(inspector.runInspection).mockResolvedValueOnce({ code: 'inspection_failed', message: '' });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: archUrl(seed.modelIdA),
+        headers: authHeader(),
+      });
+
+      expect(response.statusCode).toBe(500);
+      expect(response.json()).toEqual({ code: 'inspection_failed', error: 'Inspection failed.' });
+    });
+
     it('returns 404 for model not in DB', async () => {
       const response = await app.inject({
         method: 'POST',

--- a/backend/tests/unit/inspect-architecture-python.test.ts
+++ b/backend/tests/unit/inspect-architecture-python.test.ts
@@ -65,6 +65,27 @@ describe('inspect_architecture.py config fallback', () => {
     expect(tree.root.children.some((child: any) => child.name === 'lm_head')).toBe(true);
   });
 
+  it('uses config fallback for generic MLX models without requiring PyTorch', () => {
+    writeConfig(tmpDir, {
+      model_type: 'qwen3',
+      architectures: ['Qwen3ForCausalLM'],
+      vocab_size: 100,
+      hidden_size: 16,
+      intermediate_size: 32,
+      num_hidden_layers: 2,
+      num_attention_heads: 4,
+      tie_word_embeddings: true,
+    });
+
+    const tree = inspect(tmpDir, 'mlx');
+
+    expect(tree.format).toBe('mlx');
+    expect(tree.inspection_method).toBe('config_fallback');
+    expect(tree.root.type).toBe('Qwen3ForCausalLM');
+    expect(tree.root.children.find((child: any) => child.name === 'layers').children).toHaveLength(2);
+    expect(tree.warnings.join(' ')).toContain('Tied embeddings');
+  });
+
   it('preserves composite root architecture while estimating nested decoder and vision blocks', () => {
     writeConfig(tmpDir, {
       model_type: 'vision_text',

--- a/frontend/src/pages/ModelDetails.tsx
+++ b/frontend/src/pages/ModelDetails.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { ArchitectureTree, ApiError, inspectArchitecture, patchSettings } from '../services/architecture-api.js';
+import { ArchitectureTree, inspectArchitecture, patchSettings } from '../services/architecture-api.js';
 import { ModelRecord, listModels } from '../services/models-api.js';
 import { ArchitectureTreeView } from '../components/ArchitectureTree.js';
 
@@ -45,6 +45,20 @@ type InspectionState =
   | { status: 'done'; tree: ArchitectureTree }
   | { status: 'error'; code: string; message: string };
 
+function inspectionErrorFrom(err: unknown): { code: string; message: string } {
+  if (err && typeof err === 'object') {
+    const maybeError = err as { code?: unknown; error?: unknown; message?: unknown };
+    const code = typeof maybeError.code === 'string' && maybeError.code.trim() ? maybeError.code.trim() : 'unknown';
+    const message = [maybeError.error, maybeError.message]
+      .find((value) => typeof value === 'string' && value.trim()) as string | undefined;
+    return { code, message: message?.trim() ?? 'Architecture inspection failed.' };
+  }
+  if (err instanceof Error && err.message.trim()) {
+    return { code: 'unknown', message: err.message.trim() };
+  }
+  return { code: 'unknown', message: 'Architecture inspection failed.' };
+}
+
 export function ModelDetails({ serverId, modelId, onBack }: ModelDetailsProps) {
   const [record, setRecord] = useState<ModelRecord | null>(null);
   const [inspection, setInspection] = useState<InspectionState>({ status: 'idle' });
@@ -68,11 +82,11 @@ export function ModelDetails({ serverId, modelId, onBack }: ModelDetailsProps) {
       const tree = await inspectArchitecture(serverId, modelId);
       setInspection({ status: 'done', tree });
     } catch (err) {
-      const apiErr = err as ApiError;
+      const apiErr = inspectionErrorFrom(err);
       if (apiErr.code === 'unregistered_architecture') {
         setShowTrustSection(true);
       }
-      setInspection({ status: 'error', code: apiErr.code ?? 'unknown', message: apiErr.error ?? 'Inspection failed.' });
+      setInspection({ status: 'error', code: apiErr.code, message: apiErr.message });
     }
   }
 
@@ -148,10 +162,14 @@ export function ModelDetails({ serverId, modelId, onBack }: ModelDetailsProps) {
           ) : null}
 
           {inspection.status === 'error' ? (
-            <div className="error">
-              {inspection.code === 'hf_token_required'
-                ? 'This model requires a Hugging Face API token. Add your token in Settings → Environment.'
-                : inspection.message}
+            <div className="error" role="alert">
+              <strong>Architecture inspection failed.</strong>
+              <p>
+                {inspection.code === 'hf_token_required'
+                  ? 'This model requires a Hugging Face API token. Add your token in Settings → Environment.'
+                  : inspection.message}
+              </p>
+              {inspection.code !== 'unknown' ? <p className="muted">Error code: {inspection.code}</p> : null}
               <div className="actions" style={{ marginTop: '0.5rem' }}>
                 <button type="button" onClick={handleInspect}>
                   Retry

--- a/frontend/src/services/architecture-api.ts
+++ b/frontend/src/services/architecture-api.ts
@@ -56,11 +56,21 @@ function archPath(sid: string, mid: string, suffix = ''): string {
 
 async function parseApiError(response: Response): Promise<ApiError> {
   try {
-    const payload = (await response.json()) as Partial<ApiError>;
-    return { code: payload.code ?? 'unknown', error: payload.error ?? `Request failed: ${response.status}` };
+    const payload = (await response.json()) as Partial<ApiError> & { message?: string; detail?: string };
+    const error = firstNonEmptyString(payload.error, payload.message, payload.detail, `Request failed: ${response.status}`);
+    return { code: firstNonEmptyString(payload.code, 'unknown'), error };
   } catch {
     return { code: 'unknown', error: `Request failed: ${response.status}` };
   }
+}
+
+function firstNonEmptyString(...values: Array<unknown>): string {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+  }
+  return 'Request failed';
 }
 
 export async function inspectArchitecture(sid: string, mid: string): Promise<ArchitectureTree> {

--- a/frontend/tests/unit/architecture-api.test.ts
+++ b/frontend/tests/unit/architecture-api.test.ts
@@ -63,6 +63,34 @@ test('inspectArchitecture preserves provenance metadata from estimated trees', a
   expect(result.warnings).toContain('estimated from config');
 });
 
+test('inspectArchitecture preserves backend message fields on errors', async () => {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: false,
+    status: 500,
+    json: async () => ({ code: 'inspection_failed', message: 'Failed to read MLX config.json: network error' }),
+  } as Response);
+  vi.stubGlobal('fetch', fetchMock);
+
+  await expect(inspectArchitecture('server-1', 'org/model')).rejects.toEqual({
+    code: 'inspection_failed',
+    error: 'Failed to read MLX config.json: network error',
+  });
+});
+
+test('inspectArchitecture falls back to HTTP status when error payload is empty', async () => {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: false,
+    status: 500,
+    json: async () => ({ code: '', error: '' }),
+  } as Response);
+  vi.stubGlobal('fetch', fetchMock);
+
+  await expect(inspectArchitecture('server-1', 'org/model')).rejects.toEqual({
+    code: 'unknown',
+    error: 'Request failed: 500',
+  });
+});
+
 test('patchSettings keeps JSON content-type because it sends a JSON body', async () => {
   const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ trust_remote_code: true }));
   vi.stubGlobal('fetch', fetchMock);


### PR DESCRIPTION
Route MLX inspection through config-backed estimation, surface non-empty inspection errors in the model detail page, and include captured subprocess output or timeout diagnostics when the inspector fails.