### PR TITLE
feat(layout): new-sidebar

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@ dist/
 build/
 coverage/
 *.min.js
+specs/new-layouts/**/wireframes/*.jsx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 ### Changed
 
 - Frontend styling now loads the new design-system foundation tokens, vendored IBM Plex fonts, and shared component primitives for cards, buttons, inputs, health pills, metrics, and architecture-tree surfaces.
+- The frontend shell now uses React Router with a 220px always-expanded five-item sidebar, URL-backed Catalog/Results sub-tabs, legacy route redirects, and sidebar health/count status instead of the former global metric-card header.
 
 ### Fixed
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
     "echarts": "^6.0.0",
     "echarts-for-react": "^3.0.6",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.30.3"
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,92 +1,142 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { Navigate, Route, Routes, useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 
+import packageInfo from '../package.json';
+import { MergedPageHeader } from './components/MergedPageHeader.js';
+import { Sidebar } from './components/Sidebar.js';
 import { CompareRuns } from './pages/CompareRuns.js';
 import { Evaluate } from './pages/Evaluate.js';
+import { InferenceServers } from './pages/InferenceServers.js';
 import { Leaderboard } from './pages/Leaderboard.js';
 import { ModelDetails } from './pages/ModelDetails.js';
 import { Models } from './pages/Models.js';
+import { ResultsDashboard } from './pages/ResultsDashboard.js';
+import { RunHistory } from './pages/RunHistory.js';
 import { RunSingle } from './pages/RunSingle.js';
 import { Templates } from './pages/Templates.js';
-import { InferenceServers } from './pages/InferenceServers.js';
-import { ResultsDashboard } from './pages/ResultsDashboard.js';
+import { catalogSearch, legacyRedirectSearch, normalizeCatalogTab, normalizeResultsTab, resultsSearch } from './navigation.js';
 import { apiGet } from './services/api.js';
-import { InferenceServerRecord, listInferenceServers } from './services/inference-servers-api.js';
 import { InferenceServerHealth, getConnectivityConfig, getInferenceServerHealth } from './services/connectivity-api.js';
-import { EnvEntry, clearDatabase, listEnvEntries, setEnvEntry } from './services/system-api.js';
+import { InferenceServerRecord, listInferenceServers } from './services/inference-servers-api.js';
+import { clearDatabase, EnvEntry, listEnvEntries, setEnvEntry } from './services/system-api.js';
+import { listTemplates } from './services/templates-api.js';
 
-type View = 'servers' | 'run-single' | 'templates' | 'models' | 'models-detail' | 'compare' | 'results-dashboard' | 'evaluate' | 'leaderboard';
-
-type ModelDetailState = { serverId: string; modelId: string };
-
-type SystemMetrics = {
-  cpu: {
-    usage_percent: number | null;
-    cores: number;
-    load_1m: number;
-    load_5m: number;
-    load_15m: number;
-  };
-  memory: {
-    total_bytes: number;
-    free_bytes: number;
-    used_bytes: number;
-    used_percent: number;
-  };
-  gpu: {
-    available: boolean;
-    utilization_percent: number | null;
-    memory_used_mb: number | null;
-    memory_total_mb: number | null;
-  };
+type SystemHealthMetrics = {
   db: {
     ok: boolean;
   };
 };
 
-type LlmParams = Record<string, unknown> | null;
-const PARAM_OVERRIDES_KEY = 'aitestbench:param-overrides';
-
-function formatBytes(value: number): string {
-  if (value <= 0) {
-    return '0 B';
-  }
-  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
-  const index = Math.min(Math.floor(Math.log(value) / Math.log(1024)), units.length - 1);
-  const scaled = value / Math.pow(1024, index);
-  return `${scaled.toFixed(index >= 2 ? 1 : 0)} ${units[index]}`;
+function LegacyRedirect({ target }: { target: string }) {
+  const location = useLocation();
+  return <Navigate to={legacyRedirectSearch(target, location.search)} replace />;
 }
 
-function pickParamValue(params: LlmParams, keys: string[]): unknown {
-  if (!params) {
-    return null;
-  }
-  for (const key of keys) {
-    const value = params[key];
-    if (value !== undefined && value !== null) {
-      return value;
+function CatalogRoute({ servers, connectivity }: { servers: InferenceServerRecord[]; connectivity: Record<string, InferenceServerHealth> }) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const activeTab = normalizeCatalogTab(searchParams.get('tab'));
+  const selectedServerId = searchParams.get('serverId');
+  const selectedModelId = searchParams.get('modelId');
+
+  useEffect(() => {
+    if (searchParams.get('tab') === activeTab) {
+      return;
     }
-  }
-  return null;
+    const next = new URLSearchParams(searchParams);
+    next.set('tab', activeTab);
+    setSearchParams(next, { replace: true });
+  }, [activeTab, searchParams, setSearchParams]);
+
+  const reachable = servers.filter((server) => connectivity[server.inference_server.server_id]?.ok).length;
+
+  return (
+    <>
+      <MergedPageHeader
+        title="Catalog"
+        subtitle={`Servers and models · ${reachable} reachable`}
+        tabs={[
+          { id: 'servers', label: 'Servers', sub: `${servers.length} servers` },
+          { id: 'models', label: 'Models' }
+        ]}
+        activeTab={activeTab}
+        onTabChange={(tab) => {
+          const next = new URLSearchParams(searchParams);
+          next.set('tab', tab);
+          setSearchParams(next);
+        }}
+      />
+      {activeTab === 'servers' ? (
+        <InferenceServers />
+      ) : selectedServerId && selectedModelId ? (
+        <ModelDetails
+          serverId={selectedServerId}
+          modelId={selectedModelId}
+          onBack={() => navigate({ pathname: '/catalog', search: catalogSearch('models') })}
+        />
+      ) : (
+        <Models
+          onModelSelect={(serverId, modelId) => {
+            navigate({ pathname: '/catalog', search: catalogSearch('models', { serverId, modelId }) });
+          }}
+        />
+      )}
+    </>
+  );
 }
 
-function formatNumericParam(value: unknown, digits = 2): string {
-  if (typeof value === 'number' && Number.isFinite(value)) {
-    const fixed = value.toFixed(digits);
-    return digits > 0 ? fixed.replace(/\.0+$/, '') : fixed;
-  }
-  if (typeof value === 'string' && value.trim() !== '' && !Number.isNaN(Number(value))) {
-    return value;
-  }
-  return 'N/A';
+function ResultsRoute({ runCount }: { runCount: number | null }) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const activeTab = normalizeResultsTab(searchParams.get('tab'));
+
+  useEffect(() => {
+    if (searchParams.get('tab') === activeTab) {
+      return;
+    }
+    const next = new URLSearchParams(searchParams);
+    next.set('tab', activeTab);
+    setSearchParams(next, { replace: true });
+  }, [activeTab, searchParams, setSearchParams]);
+
+  return (
+    <>
+      <MergedPageHeader
+        title="Results"
+        subtitle={`${runCount ?? 0} recorded runs`}
+        tabs={[
+          { id: 'dashboard', label: 'Dashboard' },
+          { id: 'leaderboard', label: 'Leaderboard' },
+          { id: 'history', label: 'History', sub: `${runCount ?? 0} runs` }
+        ]}
+        activeTab={activeTab}
+        onTabChange={(tab) => setSearchParams({ tab })}
+      />
+      {activeTab === 'leaderboard' ? (
+        <Leaderboard
+          setView={(view) => {
+            if (view === 'evaluate') {
+              navigate('/evaluate');
+            }
+          }}
+        />
+      ) : activeTab === 'history' ? (
+        <RunHistory />
+      ) : (
+        <ResultsDashboard />
+      )}
+    </>
+  );
+}
+
+function RunRoute() {
+  const [searchParams] = useSearchParams();
+  return searchParams.get('legacy') === 'compare' ? <CompareRuns /> : <RunSingle />;
 }
 
 export function App() {
-  const [view, setView] = useState<View>('servers');
-  const [modelDetail, setModelDetail] = useState<ModelDetailState | null>(null);
   const [healthStatus, setHealthStatus] = useState<'unknown' | 'up' | 'down'>('unknown');
-  const [systemMetrics, setSystemMetrics] = useState<SystemMetrics | null>(null);
-  const [metricsError, setMetricsError] = useState(false);
-  const [paramOverrides, setParamOverrides] = useState<Record<string, unknown> | null>(null);
+  const [dbStatus, setDbStatus] = useState<'unknown' | 'up' | 'down'>('unknown');
   const [showSettings, setShowSettings] = useState(false);
   const [settingsEntries, setSettingsEntries] = useState<EnvEntry[]>([]);
   const [settingsError, setSettingsError] = useState<string | null>(null);
@@ -97,6 +147,8 @@ export function App() {
   const [servers, setServers] = useState<InferenceServerRecord[]>([]);
   const [serversError, setServersError] = useState(false);
   const [connectivity, setConnectivity] = useState<Record<string, InferenceServerHealth>>({});
+  const [templateCount, setTemplateCount] = useState<number | null>(null);
+  const [runCount, setRunCount] = useState<number | null>(null);
 
   useEffect(() => {
     let isActive = true;
@@ -123,22 +175,27 @@ export function App() {
   }, []);
 
   useEffect(() => {
-    const loadOverrides = () => {
-      const raw = localStorage.getItem(PARAM_OVERRIDES_KEY);
-      if (!raw) {
-        setParamOverrides(null);
-        return;
-      }
+    let isActive = true;
+    const checkDatabase = async () => {
       try {
-        setParamOverrides(JSON.parse(raw) as Record<string, unknown>);
+        const data = await apiGet<SystemHealthMetrics>('/system/metrics');
+        if (isActive) {
+          setDbStatus(data.db.ok ? 'up' : 'down');
+        }
       } catch {
-        setParamOverrides(null);
+        if (isActive) {
+          setDbStatus('down');
+        }
       }
     };
-    loadOverrides();
-    const handleUpdate = () => loadOverrides();
-    window.addEventListener('param-overrides:updated', handleUpdate);
-    return () => window.removeEventListener('param-overrides:updated', handleUpdate);
+
+    checkDatabase();
+    const intervalId = window.setInterval(checkDatabase, 15000);
+
+    return () => {
+      isActive = false;
+      window.clearInterval(intervalId);
+    };
   }, []);
 
   useEffect(() => {
@@ -200,18 +257,39 @@ export function App() {
       }
     };
 
-    const handleServersUpdated = () => {
-      fetchServers();
-    };
-
     fetchServers();
     const intervalId = window.setInterval(fetchServers, 10000);
-    window.addEventListener('inference-servers:updated', handleServersUpdated);
+    window.addEventListener('inference-servers:updated', fetchServers);
 
     return () => {
       isActive = false;
       window.clearInterval(intervalId);
-      window.removeEventListener('inference-servers:updated', handleServersUpdated);
+      window.removeEventListener('inference-servers:updated', fetchServers);
+    };
+  }, []);
+
+  useEffect(() => {
+    let isActive = true;
+    const refreshCounts = async () => {
+      const [templatesResult, runsResult] = await Promise.allSettled([
+        listTemplates(),
+        apiGet<Record<string, unknown>[]>('/runs')
+      ]);
+      if (!isActive) {
+        return;
+      }
+      setTemplateCount(templatesResult.status === 'fulfilled' ? templatesResult.value.length : null);
+      setRunCount(runsResult.status === 'fulfilled' ? runsResult.value.length : null);
+    };
+
+    refreshCounts();
+    const intervalId = window.setInterval(refreshCounts, 30000);
+    window.addEventListener('database:cleared', refreshCounts);
+
+    return () => {
+      isActive = false;
+      window.clearInterval(intervalId);
+      window.removeEventListener('database:cleared', refreshCounts);
     };
   }, []);
 
@@ -230,77 +308,18 @@ export function App() {
       .finally(() => setSettingsBusy(false));
   }, [showSettings]);
 
-  useEffect(() => {
-    let isActive = true;
-    const fetchMetrics = async () => {
-      try {
-        const data = await apiGet<SystemMetrics>('/system/metrics');
-        if (isActive) {
-          setSystemMetrics(data);
-          setMetricsError(false);
-        }
-      } catch {
-        if (isActive) {
-          setMetricsError(true);
-        }
+  const sidebarHealth = useMemo(() => {
+    const failed = servers.filter((server) => connectivity[server.inference_server.server_id]?.ok === false).length;
+    return {
+      backend: healthStatus,
+      database: dbStatus,
+      servers: {
+        total: servers.length,
+        failed,
+        unavailable: serversError
       }
     };
-
-    fetchMetrics();
-    const intervalId = window.setInterval(fetchMetrics, 5000);
-
-    return () => {
-      isActive = false;
-      window.clearInterval(intervalId);
-    };
-  }, []);
-
-  const cpuValue =
-    systemMetrics?.cpu.usage_percent != null ? `${systemMetrics.cpu.usage_percent.toFixed(1)}%` : 'N/A';
-  const memoryValue = systemMetrics
-    ? `${formatBytes(systemMetrics.memory.used_bytes)} / ${formatBytes(systemMetrics.memory.total_bytes)}`
-    : 'N/A';
-  const memoryPercent =
-    systemMetrics?.memory.used_percent != null ? `${systemMetrics.memory.used_percent.toFixed(1)}%` : null;
-  const gpuValue =
-    systemMetrics?.gpu.available && systemMetrics.gpu.utilization_percent != null
-      ? `${systemMetrics.gpu.utilization_percent.toFixed(0)}%`
-      : 'N/A';
-  const gpuMemoryValue =
-    systemMetrics?.gpu.available && systemMetrics.gpu.memory_used_mb != null && systemMetrics.gpu.memory_total_mb != null
-      ? `${systemMetrics.gpu.memory_used_mb.toFixed(0)} / ${systemMetrics.gpu.memory_total_mb.toFixed(0)} MB`
-      : null;
-  const dbStatus = systemMetrics ? (systemMetrics.db.ok ? 'up' : 'down') : 'unknown';
-  const llmParams = paramOverrides ?? null;
-  const temperatureValue = formatNumericParam(
-    pickParamValue(paramOverrides ?? llmParams, ['temperature', 'temp']),
-    2
-  );
-  const topPValue = formatNumericParam(
-    pickParamValue(paramOverrides ?? llmParams, ['top_p', 'topP']),
-    2
-  );
-  const topKValue = formatNumericParam(
-    pickParamValue(paramOverrides ?? llmParams, ['top_k', 'topK']),
-    0
-  );
-  const contextWindowValue = formatNumericParam(
-    pickParamValue(paramOverrides ?? llmParams, [
-      'context_window',
-      'context_window_tokens',
-      'max_context_tokens',
-      'context_length'
-    ]),
-    0
-  );
-  const streamValue = (() => {
-    const value = pickParamValue(paramOverrides ?? llmParams, ['stream']);
-    if (typeof value === 'boolean') {
-      return value ? 'On' : 'Off';
-    }
-    return 'N/A';
-  })();
-  const navClass = (active: boolean) => (active ? 'nav-btn is-active' : 'nav-btn');
+  }, [connectivity, dbStatus, healthStatus, servers, serversError]);
 
   async function handleClearDb() {
     const confirmed = window.confirm('Clear all database tables? This cannot be undone.');
@@ -350,294 +369,31 @@ export function App() {
 
   return (
     <div className="app-shell">
-      <header className="app-header">
-        <div>
-          <div className="brand-row">
-            <p className="eyebrow">AITestBench</p>
-          </div>
-        </div>
-        <div className="header-metrics">
-          <div className="metric-card">
-            <div className="metric-card__row">
-              <span>CPU</span>
-              <strong>{metricsError ? 'Unavailable' : cpuValue}</strong>
-            </div>
-            <div className="metric-card__row">
-              <span>Memory</span>
-              <strong>
-                {metricsError ? 'Unavailable' : memoryValue}
-                {!metricsError && memoryPercent ? ` (${memoryPercent})` : ''}
-              </strong>
-            </div>
-            <div className="metric-card__row">
-              <span>GPU</span>
-              <strong>
-                {metricsError ? 'Unavailable' : gpuValue}
-                {!metricsError && gpuMemoryValue ? ` · ${gpuMemoryValue}` : ''}
-              </strong>
-            </div>
-          </div>
-          <div className="metric-card">
-            <div className="header-status">
-              <div className={`health health--${healthStatus}`}>
-                <span className="health__dot" aria-hidden="true" />
-                <span>
-                  Backend:{' '}
-                  {healthStatus === 'up'
-                    ? 'Online'
-                    : healthStatus === 'down'
-                      ? 'Offline'
-                      : 'Checking'}
-                </span>
-              </div>
-              <div className={`health health--${dbStatus}`}>
-                <span className="health__dot" aria-hidden="true" />
-                <span>
-                  DB:{' '}
-                  {dbStatus === 'up' ? 'Online' : dbStatus === 'down' ? 'Offline' : 'Checking'}
-                </span>
-              </div>
-            </div>
-          </div>
-          <div className="metric-card">
-            <div className="param-grid">
-              <div className="metric-card__row">
-                <span>Temperature</span>
-                <strong>{temperatureValue}</strong>
-              </div>
-              <div className="metric-card__row">
-                <span>Top P</span>
-                <strong>{topPValue}</strong>
-              </div>
-              <div className="metric-card__row">
-                <span>Top K</span>
-                <strong>{topKValue}</strong>
-              </div>
-              <div className="metric-card__row">
-                <span>Context Window</span>
-                <strong>{contextWindowValue}</strong>
-              </div>
-              <div className="metric-card__row">
-                <span>Stream</span>
-                <strong>{streamValue}</strong>
-              </div>
-            </div>
-            <p className="status-rail-footnote">
-              {paramOverrides ? 'Overrides from Run Single' : 'No overrides set'}
-            </p>
-          </div>
-          <div className="metric-card">
-            {serversError ? (
-              <div className="health health--failed">
-                <span className="health__dot" aria-hidden="true" />
-                <span>Servers unavailable</span>
-              </div>
-            ) : servers.length === 0 ? (
-              <div className="health health--pending">
-                <span className="health__dot" aria-hidden="true" />
-                <span>No servers</span>
-              </div>
-            ) : (
-              <div className="header-servers-list">
-                {servers.map((server) => {
-                  const health = connectivity[server.inference_server.server_id];
-                  const statusClass = health ? (health.ok ? 'ok' : 'failed') : 'pending';
-                  const responseLabel =
-                    health?.response_time_ms != null ? ` (${health.response_time_ms} ms)` : '';
-                  return (
-                    <div key={server.inference_server.server_id} className={`health health--${statusClass}`}>
-                      <span className="health__dot" aria-hidden="true" />
-                      <span>{`${server.inference_server.display_name}${responseLabel}`}</span>
-                    </div>
-                  );
-                })}
-              </div>
-            )}
-          </div>
-        </div>
-      </header>
-      <div className="app-body">
-        <aside className="app-nav">
-          <div className="nav-section">
-            <button
-              type="button"
-              className={navClass(view === 'servers')}
-              onClick={() => setView('servers')}
-              aria-label="Inference servers"
-              title="Inference servers"
-            >
-              <svg viewBox="0 0 24 24" aria-hidden="true">
-                <rect x="4" y="5" width="16" height="6" rx="2" fill="none" stroke="currentColor" strokeWidth="1.5" />
-                <rect x="4" y="13" width="16" height="6" rx="2" fill="none" stroke="currentColor" strokeWidth="1.5" />
-              </svg>
-            </button>
-            <button
-              type="button"
-              className={navClass(view === 'models')}
-              onClick={() => setView('models')}
-              aria-label="Models"
-              title="Models"
-            >
-              <svg viewBox="0 0 24 24" aria-hidden="true">
-                <path
-                  d="M5 7c0-2 7-4 7-4s7 2 7 4-7 4-7 4-7-2-7-4z"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                />
-                <path
-                  d="M5 12c0 2 7 4 7 4s7-2 7-4"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                />
-                <path
-                  d="M5 17c0 2 7 4 7 4s7-2 7-4"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                />
-              </svg>
-            </button>
-            <button
-              type="button"
-              className={navClass(view === 'templates')}
-              onClick={() => setView('templates')}
-              aria-label="Templates"
-              title="Templates"
-            >
-              <svg viewBox="0 0 24 24" aria-hidden="true">
-                <path
-                  d="M6 4h9l3 3v13H6V4z"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                  strokeLinejoin="round"
-                />
-                <path d="M9 9h6M9 13h6M9 17h6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-              </svg>
-            </button>
-            <button
-              type="button"
-              className={navClass(view === 'run-single')}
-              onClick={() => setView('run-single')}
-              aria-label="Run"
-              title="Run"
-            >
-              <svg viewBox="0 0 24 24" aria-hidden="true">
-                <path
-                  d="M8 5l11 7-11 7V5z"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </button>
-            <button
-              type="button"
-              className={navClass(view === 'compare')}
-              onClick={() => setView('compare')}
-              aria-label="Compare"
-              title="Compare"
-            >
-              <svg viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M5 7h14M5 12h10M5 17h6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-              </svg>
-            </button>
-            <button
-              type="button"
-              className={navClass(view === 'results-dashboard')}
-              onClick={() => setView('results-dashboard')}
-              aria-label="Results dashboard"
-              title="Results dashboard"
-            >
-              <svg viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M4 18h16M7 14l3-3 2 2 4-5" stroke="currentColor" strokeWidth="1.5" fill="none" />
-              </svg>
-            </button>
-            <button
-              type="button"
-              className={navClass(view === 'evaluate')}
-              onClick={() => setView('evaluate')}
-              aria-label="Evaluate"
-              title="Evaluate"
-            >
-              <svg viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M4 20l6-6m0 0l2-5 3 3 5-8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" fill="none" />
-                <circle cx="10" cy="14" r="1" fill="currentColor" />
-              </svg>
-            </button>
-            <button
-              type="button"
-              className={navClass(view === 'leaderboard')}
-              onClick={() => setView('leaderboard')}
-              aria-label="Leaderboard"
-              title="Leaderboard"
-            >
-              <svg viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M12 3l2 5h5l-4 3 1 5-4-3-4 3 1-5-4-3h5z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" fill="none" />
-              </svg>
-            </button>
-          </div>
-          <div className="nav-footer">
-            <button
-              type="button"
-              className={navClass(showSettings)}
-              onClick={() => setShowSettings(true)}
-              aria-label="Settings"
-              title="Settings"
-            >
-              <svg viewBox="0 0 24 24" aria-hidden="true">
-                <path
-                  d="M12 8.5a3.5 3.5 0 1 1 0 7 3.5 3.5 0 0 1 0-7z"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                />
-                <path
-                  d="M4 12l2.2-.5a6.9 6.9 0 0 1 1-2L6 7l2-2 2.5 1.2a6.9 6.9 0 0 1 2-.8L12 3h2l.5 2.4a6.9 6.9 0 0 1 2 .8L19 5l2 2-1.2 2.5a6.9 6.9 0 0 1 .8 2L23 12v2l-2.4.5a6.9 6.9 0 0 1-.8 2L21 19l-2 2-2.5-1.2a6.9 6.9 0 0 1-2 .8L14 23h-2l-.5-2.4a6.9 6.9 0 0 1-2-.8L7 21l-2-2 1.2-2.5a6.9 6.9 0 0 1-.8-2L3 14v-2l2.4-.5a6.9 6.9 0 0 1 .8-2L5 7l2-2 2.5 1.2a6.9 6.9 0 0 1 2-.8L12 3h2"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="1.2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </button>
-          </div>
-        </aside>
-        <main className="app-main">
-          {view === 'servers' ? (
-            <InferenceServers />
-          ) : view === 'run-single' ? (
-            <RunSingle />
-          ) : view === 'templates' ? (
-            <Templates />
-          ) : view === 'models' ? (
-            <Models
-              onModelSelect={(serverId, modelId) => {
-                setModelDetail({ serverId, modelId });
-                setView('models-detail');
-              }}
-            />
-          ) : view === 'models-detail' && modelDetail ? (
-            <ModelDetails
-              serverId={modelDetail.serverId}
-              modelId={modelDetail.modelId}
-              onBack={() => setView('models')}
-            />
-          ) : view === 'results-dashboard' ? (
-            <ResultsDashboard />
-          ) : view === 'evaluate' ? (
-            <Evaluate />
-          ) : view === 'leaderboard' ? (
-            <Leaderboard setView={(v) => setView(v as View)} />
-          ) : (
-            <CompareRuns />
-          )}
-        </main>
-      </div>
+      <Sidebar
+        version={packageInfo.version}
+        health={sidebarHealth}
+        templateCount={templateCount}
+        runCount={runCount}
+        onSettings={() => setShowSettings(true)}
+      />
+      <main className="app-main">
+        <Routes>
+          <Route path="/" element={<Navigate to="/catalog?tab=servers" replace />} />
+          <Route path="/catalog" element={<CatalogRoute servers={servers} connectivity={connectivity} />} />
+          <Route path="/templates" element={<Templates />} />
+          <Route path="/run" element={<RunRoute />} />
+          <Route path="/results" element={<ResultsRoute runCount={runCount} />} />
+          <Route path="/runs/:id" element={<Navigate to={{ pathname: '/results', search: resultsSearch('history') }} replace />} />
+          <Route path="/evaluate" element={<Evaluate />} />
+          <Route path="/servers" element={<LegacyRedirect target="servers" />} />
+          <Route path="/models" element={<LegacyRedirect target="models" />} />
+          <Route path="/run-single" element={<LegacyRedirect target="run-single" />} />
+          <Route path="/compare" element={<LegacyRedirect target="compare" />} />
+          <Route path="/dashboard" element={<LegacyRedirect target="dashboard" />} />
+          <Route path="/leaderboard" element={<LegacyRedirect target="leaderboard" />} />
+          <Route path="*" element={<Navigate to="/catalog?tab=servers" replace />} />
+        </Routes>
+      </main>
       {showSettings ? (
         <div className="modal-overlay" role="dialog" aria-modal="true">
           <div className="modal-card settings-card">
@@ -658,7 +414,7 @@ export function App() {
               <h4>Database</h4>
               <p className="muted">Clear all tables in the current SQLite database.</p>
               <button type="button" onClick={handleClearDb} disabled={settingsBusy}>
-                {settingsBusy ? 'Working…' : 'Empty database'}
+                {settingsBusy ? 'Working...' : 'Empty database'}
               </button>
             </div>
             <div className="divider" />

--- a/frontend/src/components/MergedPageHeader.tsx
+++ b/frontend/src/components/MergedPageHeader.tsx
@@ -1,0 +1,36 @@
+import { ReactNode } from 'react';
+
+import { SubTab, SubTabBar } from './SubTabBar.js';
+
+interface MergedPageHeaderProps {
+  title: string;
+  subtitle: string;
+  tabs?: SubTab[];
+  activeTab?: string;
+  onTabChange?: (id: string) => void;
+  action?: ReactNode;
+}
+
+export function MergedPageHeader({
+  title,
+  subtitle,
+  tabs,
+  activeTab,
+  onTabChange,
+  action
+}: MergedPageHeaderProps) {
+  return (
+    <header className="merged-page-header">
+      <div className="merged-page-header__row">
+        <div>
+          <h1>{title}</h1>
+          <p>{subtitle}</p>
+        </div>
+        {action ? <div className="merged-page-header__action">{action}</div> : null}
+      </div>
+      {tabs && activeTab && onTabChange ? (
+        <SubTabBar tabs={tabs} active={activeTab} onChange={onTabChange} />
+      ) : null}
+    </header>
+  );
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,0 +1,109 @@
+import { NavLink } from 'react-router-dom';
+
+interface SidebarHealth {
+  backend: 'unknown' | 'up' | 'down';
+  database: 'unknown' | 'up' | 'down';
+  servers: {
+    total: number;
+    failed: number;
+    unavailable: boolean;
+  };
+}
+
+interface SidebarProps {
+  version: string;
+  health: SidebarHealth;
+  templateCount: number | null;
+  runCount: number | null;
+  onSettings: () => void;
+}
+
+const navItems = [
+  { to: '/catalog?tab=servers', section: '/catalog', label: 'Catalog', sub: 'Servers · Models' },
+  { to: '/templates', section: '/templates', label: 'Templates', sub: 'JSON · Python', badge: 'templates' },
+  { to: '/run', section: '/run', label: 'Run', sub: '1-8 models' },
+  { to: '/results?tab=dashboard', section: '/results', label: 'Results', sub: 'Dash · Board · History', badge: 'runs' },
+  { to: '/evaluate', section: '/evaluate', label: 'Evaluate', sub: 'Score queue' }
+] as const;
+
+function statusLabel(status: 'unknown' | 'up' | 'down') {
+  if (status === 'up') {
+    return 'Online';
+  }
+  if (status === 'down') {
+    return 'Offline';
+  }
+  return 'Checking';
+}
+
+function serverStatus(health: SidebarHealth['servers']): 'unknown' | 'up' | 'down' {
+  if (health.unavailable) {
+    return 'down';
+  }
+  if (health.total === 0) {
+    return 'unknown';
+  }
+  return health.failed > 0 ? 'down' : 'up';
+}
+
+function RegLightRow({
+  status,
+  label,
+  detail
+}: {
+  status: 'unknown' | 'up' | 'down';
+  label: string;
+  detail?: string;
+}) {
+  return (
+    <div className={`sidebar-health-row sidebar-health-row--${status}`}>
+      <span className="sidebar-health-row__dot" aria-hidden="true" />
+      <span>{label}</span>
+      {detail ? <strong>{detail}</strong> : null}
+    </div>
+  );
+}
+
+export function Sidebar({ version, health, templateCount, runCount, onSettings }: SidebarProps) {
+  return (
+    <aside className="sidebar" aria-label="Primary navigation">
+      <div className="sidebar-brand">
+        <strong>AITestBench</strong>
+        <span>v{version}</span>
+      </div>
+      <nav className="sidebar-nav">
+        {navItems.map((item) => (
+          <NavLink
+            key={item.section}
+            to={item.to}
+            className={({ isActive }) => (isActive ? 'sidebar-item is-active' : 'sidebar-item')}
+          >
+            <span className="sidebar-item__main">
+              <span>{item.label}</span>
+              {item.badge === 'templates' && templateCount !== null ? <b>{templateCount}</b> : null}
+              {item.badge === 'runs' && runCount !== null ? <b>{runCount}</b> : null}
+            </span>
+            <span className="sidebar-item__sub">{item.sub}</span>
+          </NavLink>
+        ))}
+      </nav>
+      <div className="sidebar-spacer" />
+      <div className="sidebar-health">
+        <div className="sidebar-health__label">Health</div>
+        <RegLightRow status={health.backend} label="Backend" detail={statusLabel(health.backend)} />
+        <RegLightRow status={health.database} label="Database" detail={statusLabel(health.database)} />
+        <RegLightRow
+          status={serverStatus(health.servers)}
+          label={`${health.servers.total} servers`}
+          detail={health.servers.failed > 0 ? `${health.servers.failed} issues` : undefined}
+        />
+      </div>
+      <div className="sidebar-settings">
+        <button type="button" onClick={onSettings}>
+          <span aria-hidden="true">S</span>
+          <strong>Settings</strong>
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/frontend/src/components/SubTabBar.tsx
+++ b/frontend/src/components/SubTabBar.tsx
@@ -1,0 +1,31 @@
+export interface SubTab {
+  id: string;
+  label: string;
+  sub?: string;
+}
+
+interface SubTabBarProps {
+  tabs: SubTab[];
+  active: string;
+  onChange: (id: string) => void;
+}
+
+export function SubTabBar({ tabs, active, onChange }: SubTabBarProps) {
+  return (
+    <div className="sub-tab-bar" role="tablist">
+      {tabs.map((tab) => (
+        <button
+          key={tab.id}
+          type="button"
+          role="tab"
+          aria-selected={tab.id === active}
+          className={tab.id === active ? 'sub-tab is-active' : 'sub-tab'}
+          onClick={() => onChange(tab.id)}
+        >
+          <span>{tab.label}</span>
+          {tab.sub ? <small>{tab.sub}</small> : null}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,4 +1,5 @@
 import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 
 import { App } from './App.js';
 import './styles/index.css';
@@ -10,4 +11,8 @@ if (!root) {
   throw new Error('Root element not found');
 }
 
-createRoot(root).render(<App />);
+createRoot(root).render(
+  <BrowserRouter>
+    <App />
+  </BrowserRouter>
+);

--- a/frontend/src/navigation.ts
+++ b/frontend/src/navigation.ts
@@ -1,0 +1,53 @@
+export type CatalogTab = 'servers' | 'models';
+export type ResultsTab = 'dashboard' | 'leaderboard' | 'history';
+
+export function normalizeCatalogTab(value: string | null): CatalogTab {
+  return value === 'models' ? 'models' : 'servers';
+}
+
+export function normalizeResultsTab(value: string | null): ResultsTab {
+  if (value === 'leaderboard' || value === 'history') {
+    return value;
+  }
+  return 'dashboard';
+}
+
+export function catalogSearch(tab: CatalogTab, params?: { serverId?: string | null; modelId?: string | null }): string {
+  const search = new URLSearchParams({ tab });
+  if (params?.serverId) {
+    search.set('serverId', params.serverId);
+  }
+  if (params?.modelId) {
+    search.set('modelId', params.modelId);
+  }
+  return `?${search.toString()}`;
+}
+
+export function resultsSearch(tab: ResultsTab): string {
+  return `?${new URLSearchParams({ tab }).toString()}`;
+}
+
+export function legacyRedirectSearch(target: string, currentSearch = ''): { pathname: string; search: string } {
+  const params = new URLSearchParams(currentSearch);
+  switch (target) {
+    case 'servers':
+      params.set('tab', 'servers');
+      return { pathname: '/catalog', search: `?${params.toString()}` };
+    case 'models':
+      params.set('tab', 'models');
+      return { pathname: '/catalog', search: `?${params.toString()}` };
+    case 'run-single':
+      return { pathname: '/run', search: currentSearch };
+    case 'compare':
+      params.set('legacy', 'compare');
+      return { pathname: '/run', search: `?${params.toString()}` };
+    case 'dashboard':
+      params.set('tab', 'dashboard');
+      return { pathname: '/results', search: `?${params.toString()}` };
+    case 'leaderboard':
+      params.set('tab', 'leaderboard');
+      return { pathname: '/results', search: `?${params.toString()}` };
+    default:
+      return { pathname: '/catalog', search: '?tab=servers' };
+  }
+}

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -26,96 +26,7 @@ body {
 .app-shell {
   min-height: 100vh;
   display: flex;
-  flex-direction: column;
-}
-
-
-.app-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 10px 20px;
-  border-bottom: 2px solid var(--border-header);
-  background: var(--bg-header);
-  box-shadow: var(--shadow-header);
-}
-
-.app-header h1 {
-  margin: 0;
-}
-
-.brand-row {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.header-metrics {
-  display: flex;
-  justify-content: flex-end;
-  align-items: flex-start;
-  gap: 12px;
-}
-
-.header-servers-list {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.header-status {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.metric-card {
-  background: var(--paper-1);
-  border: 1px solid var(--border-default);
-  border-radius: var(--r-card-sm);
-  padding: var(--s-5) var(--s-6);
-  min-width: 220px;
-  box-shadow: var(--shadow-metrics);
-}
-
-.metrics-title {
-  margin: 0 0 8px;
-  font-size: 11px;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--ink-3);
-}
-
-.param-section {
-  margin-top: 8px;
-}
-
-.param-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(140px, 1fr));
-  gap: 8px 12px;
-  align-items: start;
-}
-
-.metric-card__row {
-  display: flex;
-  justify-content: space-between;
-  gap: 12px;
-  font-size: 12px;
-  color: var(--ink-6);
-  padding: 2px 0;
-}
-
-.metric-card__row strong,
-.metric-card__row .v {
-  font-weight: 600;
-  color: var(--ink-8);
-}
-
-.status-rail-footnote {
-  margin: 4px 0 0;
-  font-size: 11px;
-  color: var(--ink-2);
+  background: var(--bg-page);
 }
 
 .subhead {
@@ -151,68 +62,8 @@ body {
 
 .app-main {
   flex: 1;
-  padding: 2px 0 48px;
-}
-
-.app-body {
-  display: grid;
-  grid-template-columns: 72px minmax(0, 1fr);
-  gap: 16px;
-}
-
-.app-nav {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  padding: 24px 12px;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.nav-section {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  align-items: center;
-}
-
-.nav-footer {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  align-items: center;
-}
-
-.app-nav button {
-  text-align: center;
-  background: transparent;
-  border: 1px solid var(--border-nav);
-  color: var(--ink-9);
-  border-radius: 14px;
-  padding: 10px;
-  width: 44px;
-  height: 44px;
-  display: grid;
-  place-items: center;
-  box-shadow: var(--shadow-nav);
-  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
-}
-
-.app-nav button.is-active {
-  border-color: var(--border-nav-active);
-  background: var(--bg-nav-active);
-  box-shadow: var(--shadow-nav-active);
-}
-
-.app-nav button:active {
-  transform: translateY(2px);
-  box-shadow: var(--shadow-nav-press);
-}
-
-.app-nav svg {
-  width: 20px;
-  height: 20px;
-  display: block;
+  min-width: 0;
+  padding: 0 0 48px;
 }
 
 .page {
@@ -238,6 +89,251 @@ h2 {
 
 .page-header {
   margin-bottom: 20px;
+}
+
+.sidebar {
+  position: sticky;
+  top: 0;
+  width: 220px;
+  flex: 0 0 220px;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0;
+  padding: 0;
+  background: var(--paper-2);
+  border-right: 1px solid var(--paper-7);
+  z-index: 4;
+}
+
+.sidebar-brand {
+  padding: 16px;
+  border-bottom: 1px solid var(--paper-7);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.sidebar-brand strong {
+  font-size: 14px;
+  line-height: 1.2;
+  color: var(--ink-9);
+}
+
+.sidebar-brand span {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--ink-3);
+}
+
+.sidebar-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px;
+}
+
+.sidebar-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-height: 56px;
+  padding: 10px 12px;
+  border: 1.5px solid transparent;
+  border-radius: 8px;
+  color: var(--ink-9);
+  text-decoration: none;
+  background: transparent;
+  transition: background var(--t-fast) var(--ease-out), border-color var(--t-fast) var(--ease-out);
+}
+
+.sidebar-item:hover {
+  background: var(--paper-3);
+}
+
+.sidebar-item.is-active {
+  background: var(--bg-selected);
+  border-color: var(--border-selected);
+}
+
+.sidebar-item__main {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.sidebar-item__main b {
+  border-radius: 999px;
+  padding: 1px 6px;
+  background: var(--ink-9);
+  color: var(--paper-1);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  line-height: 1.4;
+}
+
+.sidebar-item__sub {
+  color: var(--ink-3);
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  letter-spacing: 1px;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.sidebar-spacer {
+  flex: 1;
+}
+
+.sidebar-health {
+  padding: 12px;
+  border-top: 1px solid var(--paper-7);
+}
+
+.sidebar-health__label {
+  margin-bottom: 8px;
+  color: var(--ink-3);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.sidebar-health-row {
+  display: grid;
+  grid-template-columns: 8px minmax(0, 1fr) auto;
+  gap: 8px;
+  align-items: center;
+  min-height: 24px;
+  color: var(--ink-6);
+  font-size: 12px;
+}
+
+.sidebar-health-row__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: var(--ink-3);
+}
+
+.sidebar-health-row--up .sidebar-health-row__dot {
+  background: #2d8a4e;
+}
+
+.sidebar-health-row--down .sidebar-health-row__dot {
+  background: #b94a48;
+}
+
+.sidebar-health-row strong {
+  color: var(--ink-3);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
+}
+
+.sidebar-settings {
+  padding: 10px;
+  border-top: 1px solid var(--paper-7);
+}
+
+.sidebar-settings button {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border: 0;
+  background: transparent;
+  color: var(--ink-9);
+  cursor: pointer;
+  padding: 8px 6px;
+  text-align: left;
+}
+
+.sidebar-settings button:hover {
+  background: var(--paper-3);
+}
+
+.sidebar-settings span {
+  width: 24px;
+  height: 24px;
+  border-radius: 999px;
+  display: inline-grid;
+  place-items: center;
+  background: var(--ink-9);
+  color: var(--paper-1);
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+
+.sidebar-settings strong {
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.merged-page-header {
+  background: var(--paper-1);
+  border-bottom: 1px solid var(--paper-7);
+  padding: 14px 24px 0;
+}
+
+.merged-page-header__row {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.merged-page-header h1 {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 600;
+}
+
+.merged-page-header p {
+  margin: 4px 0 12px;
+  color: var(--ink-3);
+  font-size: 12px;
+}
+
+.merged-page-header__action {
+  flex: 0 0 auto;
+}
+
+.sub-tab-bar {
+  display: inline-flex;
+  gap: 0;
+  min-height: 40px;
+}
+
+.sub-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  background: transparent;
+  color: var(--ink-6);
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.sub-tab.is-active {
+  border-bottom-color: var(--border-selected);
+  color: var(--ink-9);
+  font-weight: 700;
+}
+
+.sub-tab small {
+  color: var(--ink-3);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 400;
 }
 
 .filters-row {

--- a/frontend/tests/e2e/architecture-inspect.spec.ts
+++ b/frontend/tests/e2e/architecture-inspect.spec.ts
@@ -126,8 +126,7 @@ async function seedHfModel(
 }
 
 async function navigateToModelDetail(page: import('@playwright/test').Page, serverId: string, modelId: string) {
-  await page.goto('/');
-  await page.getByRole('button', { name: 'Models', exact: true }).click();
+  await page.goto('/catalog?tab=models');
   await page.waitForLoadState('networkidle');
   await page.locator('#server-filter').selectOption(serverId);
   await page.locator('#model-filter').selectOption(modelId);

--- a/frontend/tests/e2e/compare.spec.ts
+++ b/frontend/tests/e2e/compare.spec.ts
@@ -1,9 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 test('loads comparison page', async ({ page }) => {
-  await page.goto('/');
-
-  await page.getByRole('button', { name: 'Compare' }).click();
+  await page.goto('/run?legacy=compare');
 
   await expect(page.getByRole('heading', { name: 'Compare Runs' })).toBeVisible();
   await expect(page.getByLabel('Filter')).toBeVisible();

--- a/frontend/tests/e2e/evaluate.spec.ts
+++ b/frontend/tests/e2e/evaluate.spec.ts
@@ -2,8 +2,7 @@ import { expect, test } from '@playwright/test';
 
 test.describe('Evaluate page', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/');
-    await page.getByRole('button', { name: 'Evaluate' }).click();
+    await page.goto('/evaluate');
     await expect(page.getByRole('heading', { name: 'Evaluate' })).toBeVisible();
   });
 
@@ -117,8 +116,7 @@ test('Evaluate page model menu uses discovered server models when model records 
     await route.fulfill({ contentType: 'application/json', body: JSON.stringify([]) });
   });
 
-  await page.goto('/');
-  await page.getByRole('button', { name: 'Evaluate' }).click();
+  await page.goto('/evaluate');
   const formSelects = page.locator('.evaluation-form select');
   const serverSelect = formSelects.first();
   const modelSelect = formSelects.nth(1);

--- a/frontend/tests/e2e/leaderboard.spec.ts
+++ b/frontend/tests/e2e/leaderboard.spec.ts
@@ -65,16 +65,14 @@ async function getOrCreateServer(request: APIRequestContext): Promise<string> {
 
 test.describe('Leaderboard page — empty state', () => {
   test('shows informative empty state message and CTA when no evaluations', async ({ page }) => {
-    await page.goto('/');
-    await page.getByRole('button', { name: 'Leaderboard', exact: true }).click();
+    await page.goto('/results?tab=leaderboard');
     await expect(page.getByRole('heading', { name: 'Leaderboard' })).toBeVisible();
     await expect(page.getByText('No evaluations yet.')).toBeVisible();
     await expect(page.getByRole('button', { name: 'Create your first evaluation' })).toBeVisible();
   });
 
   test('CTA navigates to Evaluate page', async ({ page }) => {
-    await page.goto('/');
-    await page.getByRole('button', { name: 'Leaderboard', exact: true }).click();
+    await page.goto('/results?tab=leaderboard');
     const cta = page.getByRole('button', { name: 'Create your first evaluation' });
     if (await cta.isVisible()) {
       await cta.click();
@@ -89,8 +87,7 @@ test.describe('Leaderboard page — populated state', () => {
     const serverId = await getOrCreateServer(request);
     await seedEvaluation(request, { serverId, modelName: 'e2e-model-leaderboard' });
 
-    await page.goto('/');
-    await page.getByRole('button', { name: 'Leaderboard', exact: true }).click();
+    await page.goto('/results?tab=leaderboard');
 
     await expect(
       page.locator('.leaderboard-table tbody').getByText('e2e-model-leaderboard')
@@ -100,8 +97,7 @@ test.describe('Leaderboard page — populated state', () => {
   test('SC-003: leaderboard updates within 3s after evaluations:saved event', async ({ page, request }) => {
     const serverId = await getOrCreateServer(request);
 
-    await page.goto('/');
-    await page.getByRole('button', { name: 'Leaderboard', exact: true }).click();
+    await page.goto('/results?tab=leaderboard');
     await page.waitForLoadState('networkidle');
 
     const modelName = `e2e-sc003-${Date.now()}`;
@@ -123,8 +119,7 @@ test.describe('Leaderboard filters', () => {
   test('apply date range — only in-range evaluations reflected', async ({ page, request }) => {
     const serverId = await getOrCreateServer(request);
 
-    await page.goto('/');
-    await page.getByRole('button', { name: 'Leaderboard', exact: true }).click();
+    await page.goto('/results?tab=leaderboard');
 
     await page.locator('input[type="date"]').first().fill('2030-01-01');
     await page.locator('input[type="date"]').last().fill('2030-12-31');
@@ -138,8 +133,7 @@ test.describe('Leaderboard filters', () => {
     const modelName = `e2e-filter-clear-${Date.now()}`;
     await seedEvaluation(request, { serverId, modelName });
 
-    await page.goto('/');
-    await page.getByRole('button', { name: 'Leaderboard', exact: true }).click();
+    await page.goto('/results?tab=leaderboard');
 
     await page.locator('input[type="date"]').first().fill('2030-01-01');
     await page.getByRole('button', { name: 'Apply' }).click();
@@ -152,8 +146,7 @@ test.describe('Leaderboard filters', () => {
   });
 
   test('filter-specific empty state is distinct from generic empty state', async ({ page }) => {
-    await page.goto('/');
-    await page.getByRole('button', { name: 'Leaderboard', exact: true }).click();
+    await page.goto('/results?tab=leaderboard');
 
     await page.locator('input[type="date"]').first().fill('2030-01-01');
     await page.getByRole('button', { name: 'Apply' }).click();

--- a/frontend/tests/e2e/models.spec.ts
+++ b/frontend/tests/e2e/models.spec.ts
@@ -87,8 +87,7 @@ test.describe('US1 — Quantized Provider filter and clean model names', () => {
       quantized_provider: 'inferencerlabs'
     });
 
-    await page.goto('/');
-    await page.getByRole('button', { name: 'Models', exact: true }).click();
+    await page.goto('/catalog?tab=models');
     await page.waitForLoadState('networkidle');
 
     const quantizedSelect = page.locator('#quantized-provider-filter');
@@ -113,8 +112,7 @@ test.describe('US1 — Quantized Provider filter and clean model names', () => {
       quantized_provider: 'lmstudio-community'
     });
 
-    await page.goto('/');
-    await page.getByRole('button', { name: 'Models', exact: true }).click();
+    await page.goto('/catalog?tab=models');
     await page.waitForLoadState('networkidle');
 
     const modelSelect = page.locator('#model-filter');
@@ -142,8 +140,7 @@ test.describe('US1 — Quantized Provider filter and clean model names', () => {
       quantized_provider: 'inferencerlabs'
     });
 
-    await page.goto('/');
-    await page.getByRole('button', { name: 'Models', exact: true }).click();
+    await page.goto('/catalog?tab=models');
     await page.waitForLoadState('networkidle');
 
     const quantizedSelect = page.locator('#quantized-provider-filter');
@@ -176,8 +173,7 @@ test.describe('US2 — Capability tags filter', () => {
       use_case: { thinking: false, coding: false, instruct: false, mixture_of_experts: false }
     });
 
-    await page.goto('/');
-    await page.getByRole('button', { name: 'Models', exact: true }).click();
+    await page.goto('/catalog?tab=models');
     await page.waitForLoadState('networkidle');
 
     await page.locator('input[type="checkbox"][value="thinking"]').check();
@@ -204,8 +200,7 @@ test.describe('US2 — Capability tags filter', () => {
       use_case: { thinking: true, coding: false, instruct: false, mixture_of_experts: false }
     });
 
-    await page.goto('/');
-    await page.getByRole('button', { name: 'Models', exact: true }).click();
+    await page.goto('/catalog?tab=models');
     await page.waitForLoadState('networkidle');
 
     await page.locator('input[type="checkbox"][value="thinking"]').check();
@@ -228,8 +223,7 @@ test.describe('US2 — Capability tags filter', () => {
       display_name: 'No Tags Model'
     });
 
-    await page.goto('/');
-    await page.getByRole('button', { name: 'Models', exact: true }).click();
+    await page.goto('/catalog?tab=models');
     await page.waitForLoadState('networkidle');
 
     await page.locator('input[type="checkbox"][value="thinking"]').check();
@@ -253,8 +247,7 @@ test.describe('US4 — Update modal with enriched metadata fields', () => {
       display_name: 'Update Test Model'
     });
 
-    await page.goto('/');
-    await page.getByRole('button', { name: 'Models', exact: true }).click();
+    await page.goto('/catalog?tab=models');
     await page.waitForLoadState('networkidle');
 
     await page.locator('#server-filter').selectOption(serverId);
@@ -284,8 +277,7 @@ test.describe('US4 — Update modal with enriched metadata fields', () => {
       display_name: 'Cap Test Model'
     });
 
-    await page.goto('/');
-    await page.getByRole('button', { name: 'Models', exact: true }).click();
+    await page.goto('/catalog?tab=models');
     await page.waitForLoadState('networkidle');
 
     await page.locator('#server-filter').selectOption(serverId);
@@ -315,8 +307,7 @@ test.describe('US4 — Update modal with enriched metadata fields', () => {
       display_name: 'Reload Test'
     });
 
-    await page.goto('/');
-    await page.getByRole('button', { name: 'Models', exact: true }).click();
+    await page.goto('/catalog?tab=models');
     await page.waitForLoadState('networkidle');
 
     await page.locator('#server-filter').selectOption(serverId);
@@ -370,8 +361,7 @@ test.describe('US3 — Format filter', () => {
     });
     expect(patchResponse.ok()).toBe(true);
 
-    await page.goto('/');
-    await page.getByRole('button', { name: 'Models', exact: true }).click();
+    await page.goto('/catalog?tab=models');
     await page.waitForLoadState('networkidle');
     await page.locator('#server-filter').selectOption(serverId);
 
@@ -417,8 +407,7 @@ test.describe('US3 — Format filter', () => {
       format: 'GGUF'
     });
 
-    await page.goto('/');
-    await page.getByRole('button', { name: 'Models', exact: true }).click();
+    await page.goto('/catalog?tab=models');
     await page.waitForLoadState('networkidle');
 
     await page.locator('#format-filter').selectOption('MLX');
@@ -439,8 +428,7 @@ test.describe('US3 — Format filter', () => {
       display_name: 'No Format Model'
     });
 
-    await page.goto('/');
-    await page.getByRole('button', { name: 'Models', exact: true }).click();
+    await page.goto('/catalog?tab=models');
     await page.waitForLoadState('networkidle');
 
     await page.locator('#format-filter').selectOption('MLX');
@@ -466,8 +454,7 @@ test.describe('US3 — Format filter', () => {
       format: 'GGUF'
     });
 
-    await page.goto('/');
-    await page.getByRole('button', { name: 'Models', exact: true }).click();
+    await page.goto('/catalog?tab=models');
     await page.waitForLoadState('networkidle');
 
     await page.locator('#format-filter').selectOption('MLX');
@@ -497,8 +484,7 @@ test.describe('US3 — Format filter', () => {
       quantized_provider: 'lmstudio-community'
     });
 
-    await page.goto('/');
-    await page.getByRole('button', { name: 'Models', exact: true }).click();
+    await page.goto('/catalog?tab=models');
     await page.waitForLoadState('networkidle');
 
     await page.locator('#quantized-provider-filter').selectOption('lmstudio-community');

--- a/frontend/tests/e2e/navigation-shell.spec.ts
+++ b/frontend/tests/e2e/navigation-shell.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from '@playwright/test';
+
+test('sidebar exposes five top-level destinations and follows active routes', async ({ page }) => {
+  await page.goto('/catalog?tab=servers');
+
+  const nav = page.getByRole('navigation', { name: 'Primary navigation' });
+  await expect(nav.getByRole('link')).toHaveCount(5);
+  await expect(nav.locator('.sidebar-item__main span:first-child')).toHaveText([
+    'Catalog',
+    'Templates',
+    'Run',
+    'Results',
+    'Evaluate'
+  ]);
+
+  for (const [href, label] of [
+    ['/catalog?tab=servers', 'Catalog'],
+    ['/templates', 'Templates'],
+    ['/run', 'Run'],
+    ['/results?tab=dashboard', 'Results'],
+    ['/evaluate', 'Evaluate']
+  ] as const) {
+    await page.goto(href);
+    await expect(nav.getByRole('link', { name: new RegExp(`^${label}`) })).toHaveClass(/is-active/);
+  }
+});
+
+test('merged page sub-tabs preserve route state', async ({ page }) => {
+  await page.goto('/catalog?tab=servers');
+  await page.getByRole('tab', { name: /Models/ }).click();
+  await expect(page).toHaveURL(/\/catalog\?tab=models/);
+
+  await page.goto('/results?tab=dashboard');
+  await page.getByRole('tab', { name: /Leaderboard/ }).click();
+  await expect(page).toHaveURL(/\/results\?tab=leaderboard/);
+  await page.getByRole('tab', { name: /History/ }).click();
+  await expect(page).toHaveURL(/\/results\?tab=history/);
+});
+
+test('legacy routes redirect to the new IA contract', async ({ page }) => {
+  for (const [legacyPath, expected] of [
+    ['/servers', /\/catalog\?tab=servers/],
+    ['/models', /\/catalog\?tab=models/],
+    ['/run-single', /\/run$/],
+    ['/compare', /\/run\?legacy=compare/],
+    ['/dashboard', /\/results\?tab=dashboard/],
+    ['/leaderboard', /\/results\?tab=leaderboard/]
+  ] as const) {
+    await page.goto(legacyPath);
+    await expect(page).toHaveURL(expected);
+  }
+});
+
+test('settings opens from the sidebar footer', async ({ page }) => {
+  await page.goto('/catalog?tab=servers');
+  await page.getByRole('button', { name: /Settings/ }).click();
+  await expect(page.getByRole('dialog')).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
+});

--- a/frontend/tests/e2e/results-dashboard.spec.ts
+++ b/frontend/tests/e2e/results-dashboard.spec.ts
@@ -80,8 +80,7 @@ test('results dashboard filter and render flow', async ({ page }) => {
     });
   });
 
-  await page.goto('/');
-  await page.getByRole('button', { name: 'Results dashboard' }).click();
+  await page.goto('/results?tab=dashboard');
 
   await expect(page.getByRole('heading', { name: 'Results Dashboard' })).toBeVisible();
   await expect(page.getByLabel('Runtime')).toBeVisible();

--- a/frontend/tests/e2e/run-single-template-types.spec.ts
+++ b/frontend/tests/e2e/run-single-template-types.spec.ts
@@ -101,14 +101,13 @@ test('supports JSON and Python template types', async ({ page, request }) => {
       })
       .toBe(serverDisplayName);
 
-    await page.goto('/');
     const serversResponse = page.waitForResponse(
       (response) =>
         response.request().method() === 'GET' &&
         response.url().includes('/inference-servers') &&
         response.ok()
     );
-    await page.getByRole('button', { name: 'Run', exact: true }).click();
+    await page.goto('/run');
     await serversResponse;
     await expect(page.getByRole('heading', { name: 'Run Single Test' })).toBeVisible();
 

--- a/frontend/tests/e2e/run-single-templates.spec.ts
+++ b/frontend/tests/e2e/run-single-templates.spec.ts
@@ -66,14 +66,13 @@ test('instantiates templates in Run', async ({ page, request }) => {
       })
       .toBe(serverDisplayName);
 
-    await page.goto('/');
     const serversResponse = page.waitForResponse(
       (response) =>
         response.request().method() === 'GET' &&
         response.url().includes('/inference-servers') &&
         response.ok()
     );
-    await page.getByRole('button', { name: 'Run', exact: true }).click();
+    await page.goto('/run');
     await serversResponse;
 
     const inferenceServerSelect = page.getByRole('combobox', { name: 'Inference server', exact: true });

--- a/frontend/tests/e2e/templates-crud.spec.ts
+++ b/frontend/tests/e2e/templates-crud.spec.ts
@@ -40,8 +40,7 @@ test('creates, updates, and deletes templates from the dashboard', async ({ page
   );
 
   try {
-    await page.goto('/');
-    await page.getByRole('button', { name: 'Templates' }).click();
+    await page.goto('/templates');
     const createForm = page
       .locator('form')
       .filter({ has: page.getByRole('heading', { name: 'Create template' }) });

--- a/frontend/tests/unit/navigation.test.ts
+++ b/frontend/tests/unit/navigation.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from 'vitest';
+
+import {
+  catalogSearch,
+  legacyRedirectSearch,
+  normalizeCatalogTab,
+  normalizeResultsTab,
+  resultsSearch
+} from '../../src/navigation.js';
+
+test('catalog tabs default to servers and accept models', () => {
+  expect(normalizeCatalogTab(null)).toBe('servers');
+  expect(normalizeCatalogTab('bad-tab')).toBe('servers');
+  expect(normalizeCatalogTab('models')).toBe('models');
+});
+
+test('results tabs default to dashboard and accept known tabs', () => {
+  expect(normalizeResultsTab(null)).toBe('dashboard');
+  expect(normalizeResultsTab('invalid')).toBe('dashboard');
+  expect(normalizeResultsTab('leaderboard')).toBe('leaderboard');
+  expect(normalizeResultsTab('history')).toBe('history');
+});
+
+test('catalog detail search keeps slash-bearing model ids in query params', () => {
+  expect(catalogSearch('models', { serverId: 'local', modelId: 'org/model/name' })).toBe(
+    '?tab=models&serverId=local&modelId=org%2Fmodel%2Fname'
+  );
+});
+
+test('results search encodes tab state', () => {
+  expect(resultsSearch('history')).toBe('?tab=history');
+});
+
+test('legacy redirects map old routes to new route contract', () => {
+  expect(legacyRedirectSearch('servers')).toEqual({ pathname: '/catalog', search: '?tab=servers' });
+  expect(legacyRedirectSearch('models', '?serverId=s1')).toEqual({
+    pathname: '/catalog',
+    search: '?serverId=s1&tab=models'
+  });
+  expect(legacyRedirectSearch('run-single')).toEqual({ pathname: '/run', search: '' });
+  expect(legacyRedirectSearch('compare', '?modelId=org%2Fmodel')).toEqual({
+    pathname: '/run',
+    search: '?modelId=org%2Fmodel&legacy=compare'
+  });
+  expect(legacyRedirectSearch('dashboard')).toEqual({ pathname: '/results', search: '?tab=dashboard' });
+  expect(legacyRedirectSearch('leaderboard')).toEqual({ pathname: '/results', search: '?tab=leaderboard' });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,8 @@
         "echarts": "^6.0.0",
         "echarts-for-react": "^3.0.6",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^6.30.3"
       },
       "devDependencies": {
         "@playwright/test": "^1.55.0",
@@ -477,6 +478,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
@@ -4189,6 +4199,38 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
+      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.2",
+        "react-router": "6.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/read-cache": {


### PR DESCRIPTION
- Added react-router-dom and wrapped the frontend in BrowserRouter.
- Replaced the old 8-icon/state-machine shell with a 220px expanded 5-item sidebar: Catalog, Templates, Run, Results, Evaluate.
 - Added Sidebar, SubTabBar, MergedPageHeader, and route helpers.
- Added URL-backed routes and redirects:
- /catalog?tab=servers|models
- /results?tab=dashboard|leaderboard|history
- /run, /run?legacy=compare
- legacy redirects for /servers, /models, /run-single, /compare, /dashboard, /leaderboard
- Moved model details into Catalog query params with encoded serverId/modelId.
- Removed global CPU/memory/GPU/LLM metric cards; sidebar now shows Backend, Database, and server health/count.
- Updated E2E specs away from old nav-button assumptions and added a focused navigation-shell.spec.ts.
- Updated CHANGELOG.md.
- Ignored docs-only design wireframe JSX from lint.