### PR TITLE
feat(layout): new-sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 ### Added
 
 - Backend run groups now persist grouped Run executions, instantiate selected templates per target, launch child runs concurrently, expose `/run-groups` create/read/cancel endpoints, and isolate per-target failures.
+- Results now has a run-backed `/results-view/query` API and `/results-view/runs/:runId` detail API for the merged Dashboard/History experience, including filter metadata, scorecards, chart series, recent runs, dense history rows, and drawer data.
+- Evaluation detail is now available at `GET /evaluations/:evaluationId` so leaderboard rows can open a detail drawer for the representative evaluation.
 
 ### Changed
 
@@ -16,6 +18,8 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 - The frontend shell now uses React Router with a 220px always-expanded five-item sidebar, URL-backed Catalog/Results sub-tabs, legacy route redirects, and sidebar health/count status instead of the former global metric-card header.
 - Catalog now replaces the legacy Inference Servers and Models bodies with a merged Servers/Models funnel, URL-backed server/model filters, server health view, slide-over add/edit drawer, card grids, and a full-width model inspector layout.
 - Run now uses a unified 1-8 model workflow with query-backed model chips, shared template/options controls, single-target detail rendering, multi-target comparison columns, and summary aggregation.
+- Results now uses a single merged Dashboard/Leaderboard/History page with a shared 240px filter rail, URL-owned tab/filter/sort/pagination/detail state, export/share/reset actions, run detail drawers for Dashboard and History, and evaluation detail drawers for Leaderboard.
+- Leaderboard remains backed by `evaluations` while accepting server, model, score range, sort, and group query parameters, including grouping by server and `inference_config.quantization_level`.
 - Inference server authentication can now use stored raw bearer/custom-header tokens for backend probes and runs while preserving the existing `token_env` fallback.
 
 ### Fixed

--- a/backend/src/api/routes/evaluations.ts
+++ b/backend/src/api/routes/evaluations.ts
@@ -1,6 +1,9 @@
 import { FastifyInstance } from 'fastify';
 
 import { EvaluationValidationError, createEvaluation, listEvaluations } from '../../services/evaluation-service.js';
+import * as evalPromptModel from '../../models/eval-prompt.js';
+import * as evaluationModel from '../../models/evaluation.js';
+import { getDb } from '../../models/db.js';
 
 export function registerEvaluationsRoutes(app: FastifyInstance): void {
   app.post('/evaluations', async (request, reply) => {
@@ -63,5 +66,30 @@ export function registerEvaluationsRoutes(app: FastifyInstance): void {
     });
 
     reply.code(200).send(result);
+  });
+
+  app.get('/evaluations/:evaluationId', async (request, reply) => {
+    const { evaluationId } = request.params as { evaluationId: string };
+    const evaluation = evaluationModel.getById(evaluationId);
+    if (!evaluation) {
+      reply.code(404).send({ error: 'Evaluation not found' });
+      return;
+    }
+    const prompt = evalPromptModel.getById(evaluation.prompt_id);
+    const server = getDb()
+      .prepare('SELECT server_id, display_name FROM inference_servers WHERE server_id = ?')
+      .get(evaluation.server_id) as { server_id: string; display_name: string } | undefined;
+    reply.code(200).send({
+      evaluation,
+      prompt,
+      server: server ?? null,
+      composite_score:
+        (evaluation.accuracy_score +
+          evaluation.relevance_score +
+          evaluation.coherence_score +
+          evaluation.completeness_score +
+          evaluation.helpfulness_score) /
+        5
+    });
   });
 }

--- a/backend/src/api/routes/leaderboard.ts
+++ b/backend/src/api/routes/leaderboard.ts
@@ -12,6 +12,12 @@ export function registerLeaderboardRoutes(app: FastifyInstance): void {
       date_from?: string;
       date_to?: string;
       tags?: string;
+      server_ids?: string;
+      model_names?: string;
+      score_min?: string;
+      score_max?: string;
+      sort_by?: string;
+      group_by?: string;
     };
 
     if (query.date_from && !isValidIsoDate(query.date_from)) {
@@ -27,11 +33,38 @@ export function registerLeaderboardRoutes(app: FastifyInstance): void {
     const tags = query.tags
       ? query.tags.split(',').map((t) => t.trim()).filter(Boolean)
       : [];
+    const serverIds = query.server_ids
+      ? query.server_ids.split(',').map((t) => t.trim()).filter(Boolean)
+      : [];
+    const modelNames = query.model_names
+      ? query.model_names.split(',').map((t) => t.trim()).filter(Boolean)
+      : [];
+    const scoreMin = query.score_min == null || query.score_min === '' ? undefined : Number(query.score_min);
+    const scoreMax = query.score_max == null || query.score_max === '' ? undefined : Number(query.score_max);
+
+    if ((scoreMin != null && (!Number.isFinite(scoreMin) || scoreMin < 0 || scoreMin > 100))
+      || (scoreMax != null && (!Number.isFinite(scoreMax) || scoreMax < 0 || scoreMax > 100))) {
+      reply.code(400).send({ error: 'score_min and score_max must be numbers between 0 and 100' });
+      return;
+    }
+
+    const sortBy = query.sort_by === 'latency' || query.sort_by === 'cost' || query.sort_by === 'pass_rate'
+      ? query.sort_by
+      : 'score';
+    const groupBy = query.group_by === 'server' || query.group_by === 'quantization'
+      ? query.group_by
+      : 'model';
 
     const result = getLeaderboard({
       date_from: query.date_from,
       date_to: query.date_to,
-      tags: tags.length > 0 ? tags : undefined
+      tags: tags.length > 0 ? tags : undefined,
+      server_ids: serverIds.length > 0 ? serverIds : undefined,
+      model_names: modelNames.length > 0 ? modelNames : undefined,
+      score_min: scoreMin,
+      score_max: scoreMax,
+      sort_by: sortBy,
+      group_by: groupBy
     });
 
     reply.code(200).send(result);

--- a/backend/src/api/routes/results-view.ts
+++ b/backend/src/api/routes/results-view.ts
@@ -1,0 +1,24 @@
+import { FastifyInstance } from 'fastify';
+
+import { getResultsRunDetail, queryResultsView } from '../../services/results-view-service.js';
+
+export function registerResultsViewRoutes(app: FastifyInstance): void {
+  app.post('/results-view/query', async (request, reply) => {
+    const response = queryResultsView((request.body as Record<string, unknown> | undefined) ?? {});
+    if (!response.ok) {
+      reply.code(400).send({ error: response.error, code: response.code });
+      return;
+    }
+    reply.send(response.value);
+  });
+
+  app.get('/results-view/runs/:runId', async (request, reply) => {
+    const { runId } = request.params as { runId: string };
+    const detail = getResultsRunDetail(runId);
+    if (!detail) {
+      reply.code(404).send({ error: 'Run not found' });
+      return;
+    }
+    reply.send(detail);
+  });
+}

--- a/backend/src/api/server.ts
+++ b/backend/src/api/server.ts
@@ -7,6 +7,7 @@ import { getDb, resolvedDbPath, runSchema } from '../models/db.js';
 import { reloadTests } from '../services/test-service.js';
 import { registerAuth } from './middleware/auth.js';
 import { registerResultsRoutes } from './routes/results.js';
+import { registerResultsViewRoutes } from './routes/results-view.js';
 import { registerRunsRoutes } from './routes/runs.js';
 import { registerRunGroupsRoutes } from './routes/run-groups.js';
 import { registerSuitesRoutes } from './routes/suites.js';
@@ -93,6 +94,7 @@ export function createServer() {
   registerProfilesRoutes(app);
   registerModelsRoutes(app);
   registerResultsRoutes(app);
+  registerResultsViewRoutes(app);
   registerTemplatesRoutes(app);
   registerDashboardResultsRoutes(app);
   registerEvalInferenceRoutes(app);

--- a/backend/src/services/leaderboard-service.ts
+++ b/backend/src/services/leaderboard-service.ts
@@ -4,6 +4,12 @@ export interface LeaderboardFilters {
   date_from?: string;
   date_to?: string;
   tags?: string[];
+  server_ids?: string[];
+  model_names?: string[];
+  score_min?: number;
+  score_max?: number;
+  sort_by?: 'score' | 'latency' | 'cost' | 'pass_rate';
+  group_by?: 'model' | 'server' | 'quantization';
 }
 
 export interface LeaderboardEntry {
@@ -19,6 +25,15 @@ export interface LeaderboardEntry {
   avg_latency_ms: number | null;
   avg_estimated_cost: number | null;
   evaluation_count: number;
+  score_percent: number;
+  pass_rate: number | null;
+  group_by: 'model' | 'server' | 'quantization';
+  group_key: string;
+  group_label: string;
+  server_id: string | null;
+  server_name: string | null;
+  quantization_level: string | null;
+  representative_evaluation_id: string | null;
 }
 
 export interface LeaderboardResult {
@@ -26,30 +41,210 @@ export interface LeaderboardResult {
     date_from: string | null;
     date_to: string | null;
     tags: string[];
+    server_ids: string[];
+    model_names: string[];
+    score_min: number | null;
+    score_max: number | null;
+    sort_by: string;
+    group_by: string;
   };
   entries: LeaderboardEntry[];
 }
 
 interface LeaderboardRow {
+  id: string;
   model_name: string;
-  avg_accuracy: number;
-  avg_relevance: number;
-  avg_coherence: number;
-  avg_completeness: number;
-  avg_helpfulness: number;
-  composite_score: number;
-  avg_total_tokens: number | null;
-  avg_latency_ms: number | null;
-  avg_estimated_cost: number | null;
-  evaluation_count: number;
+  server_id: string;
+  server_name: string | null;
+  inference_config: string;
+  accuracy_score: number;
+  relevance_score: number;
+  coherence_score: number;
+  completeness_score: number;
+  helpfulness_score: number;
+  total_tokens: number | null;
+  latency_ms: number | null;
+  estimated_cost: number | null;
+  created_at: string;
+}
+
+type GroupBy = NonNullable<LeaderboardFilters['group_by']>;
+type SortBy = NonNullable<LeaderboardFilters['sort_by']>;
+
+type GroupAccumulator = {
+  group_key: string;
+  group_label: string;
+  model_name: string;
+  server_id: string | null;
+  server_name: string | null;
+  quantization_level: string | null;
+  accuracy: number[];
+  relevance: number[];
+  coherence: number[];
+  completeness: number[];
+  helpfulness: number[];
+  tokens: number[];
+  latencies: number[];
+  costs: number[];
+  representative: { id: string; score: number; created_at: string } | null;
+};
+
+function average(values: number[]): number | null {
+  if (values.length === 0) {
+    return null;
+  }
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function round(value: number, places = 4): number {
+  const factor = 10 ** places;
+  return Math.round(value * factor) / factor;
+}
+
+function parseConfig(value: string): { quantization_level?: string | null } {
+  try {
+    return JSON.parse(value) as { quantization_level?: string | null };
+  } catch {
+    return {};
+  }
+}
+
+function rowScore(row: LeaderboardRow): number {
+  return (
+    row.accuracy_score +
+    row.relevance_score +
+    row.coherence_score +
+    row.completeness_score +
+    row.helpfulness_score
+  ) / 5;
+}
+
+function groupIdentity(row: LeaderboardRow, groupBy: GroupBy): Pick<
+  GroupAccumulator,
+  'group_key' | 'group_label' | 'model_name' | 'server_id' | 'server_name' | 'quantization_level'
+> {
+  const quantization = parseConfig(row.inference_config).quantization_level?.trim() || 'unknown';
+  if (groupBy === 'server') {
+    return {
+      group_key: row.server_id,
+      group_label: row.server_name ?? row.server_id,
+      model_name: row.model_name,
+      server_id: row.server_id,
+      server_name: row.server_name,
+      quantization_level: quantization
+    };
+  }
+  if (groupBy === 'quantization') {
+    return {
+      group_key: quantization,
+      group_label: quantization,
+      model_name: row.model_name,
+      server_id: row.server_id,
+      server_name: row.server_name,
+      quantization_level: quantization
+    };
+  }
+  return {
+    group_key: row.model_name,
+    group_label: row.model_name,
+    model_name: row.model_name,
+    server_id: row.server_id,
+    server_name: row.server_name,
+    quantization_level: quantization
+  };
+}
+
+function createGroup(identity: ReturnType<typeof groupIdentity>): GroupAccumulator {
+  return {
+    ...identity,
+    accuracy: [],
+    relevance: [],
+    coherence: [],
+    completeness: [],
+    helpfulness: [],
+    tokens: [],
+    latencies: [],
+    costs: [],
+    representative: null
+  };
+}
+
+function pushNumber(target: number[], value: number | null): void {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    target.push(value);
+  }
+}
+
+function groupToEntry(group: GroupAccumulator, groupBy: GroupBy): LeaderboardEntry {
+  const avgAccuracy = average(group.accuracy) ?? 0;
+  const avgRelevance = average(group.relevance) ?? 0;
+  const avgCoherence = average(group.coherence) ?? 0;
+  const avgCompleteness = average(group.completeness) ?? 0;
+  const avgHelpfulness = average(group.helpfulness) ?? 0;
+  const composite = (avgAccuracy + avgRelevance + avgCoherence + avgCompleteness + avgHelpfulness) / 5;
+  return {
+    rank: 0,
+    model_name: group.model_name,
+    composite_score: round(composite),
+    avg_accuracy: avgAccuracy,
+    avg_relevance: avgRelevance,
+    avg_coherence: avgCoherence,
+    avg_completeness: avgCompleteness,
+    avg_helpfulness: avgHelpfulness,
+    avg_total_tokens: average(group.tokens),
+    avg_latency_ms: average(group.latencies),
+    avg_estimated_cost: average(group.costs),
+    evaluation_count: group.accuracy.length,
+    score_percent: round(composite * 20, 2),
+    pass_rate: null,
+    group_by: groupBy,
+    group_key: group.group_key,
+    group_label: group.group_label,
+    server_id: group.server_id,
+    server_name: group.server_name,
+    quantization_level: group.quantization_level,
+    representative_evaluation_id: group.representative?.id ?? null
+  };
+}
+
+function compareEntries(sortBy: SortBy): (a: LeaderboardEntry, b: LeaderboardEntry) => number {
+  return (a, b) => {
+    const value = (entry: LeaderboardEntry): number => {
+      if (sortBy === 'latency') {
+        return entry.avg_latency_ms ?? Number.MAX_SAFE_INTEGER;
+      }
+      if (sortBy === 'cost') {
+        return entry.avg_estimated_cost ?? Number.MAX_SAFE_INTEGER;
+      }
+      if (sortBy === 'pass_rate') {
+        return entry.pass_rate ?? -1;
+      }
+      return entry.composite_score;
+    };
+    const left = value(a);
+    const right = value(b);
+    if (sortBy === 'latency' || sortBy === 'cost') {
+      return left - right || a.group_label.localeCompare(b.group_label);
+    }
+    return right - left || a.group_label.localeCompare(b.group_label);
+  };
 }
 
 export function getLeaderboard(filters: LeaderboardFilters): LeaderboardResult {
   const db = getDb();
-  const { date_from = null, date_to = null, tags = [] } = filters;
+  const {
+    date_from = null,
+    date_to = null,
+    tags = [],
+    server_ids = [],
+    model_names = [],
+    score_min = undefined,
+    score_max = undefined,
+    sort_by = 'score',
+    group_by = 'model'
+  } = filters;
 
   const params: unknown[] = [];
-
   let whereClause = 'WHERE 1=1';
 
   if (date_from) {
@@ -71,49 +266,85 @@ export function getLeaderboard(filters: LeaderboardFilters): LeaderboardResult {
     params.push(...tags);
   }
 
-  const sql = `
+  if (server_ids.length > 0) {
+    whereClause += ` AND e.server_id IN (${server_ids.map(() => '?').join(', ')})`;
+    params.push(...server_ids);
+  }
+
+  if (model_names.length > 0) {
+    whereClause += ` AND e.model_name IN (${model_names.map(() => '?').join(', ')})`;
+    params.push(...model_names);
+  }
+
+  const rows = db.prepare(`
     SELECT
+      e.id,
       e.model_name,
-      AVG(e.accuracy_score)     AS avg_accuracy,
-      AVG(e.relevance_score)    AS avg_relevance,
-      AVG(e.coherence_score)    AS avg_coherence,
-      AVG(e.completeness_score) AS avg_completeness,
-      AVG(e.helpfulness_score)  AS avg_helpfulness,
-      (AVG(e.accuracy_score) + AVG(e.relevance_score) + AVG(e.coherence_score)
-        + AVG(e.completeness_score) + AVG(e.helpfulness_score)) / 5.0 AS composite_score,
-      AVG(e.total_tokens)       AS avg_total_tokens,
-      AVG(e.latency_ms)         AS avg_latency_ms,
-      AVG(e.estimated_cost)     AS avg_estimated_cost,
-      COUNT(*)                  AS evaluation_count
+      e.server_id,
+      i.display_name AS server_name,
+      e.inference_config,
+      e.accuracy_score,
+      e.relevance_score,
+      e.coherence_score,
+      e.completeness_score,
+      e.helpfulness_score,
+      e.total_tokens,
+      e.latency_ms,
+      e.estimated_cost,
+      e.created_at
     FROM evaluations e
     JOIN eval_prompts ep ON ep.id = e.prompt_id
+    LEFT JOIN inference_servers i ON i.server_id = e.server_id
     ${whereClause}
-    GROUP BY e.model_name
-    ORDER BY composite_score DESC, e.model_name ASC
-  `;
+    ORDER BY e.created_at DESC
+  `).all(...params) as LeaderboardRow[];
 
-  const rows = db.prepare(sql).all(...params) as LeaderboardRow[];
+  const groups = new Map<string, GroupAccumulator>();
+  for (const row of rows) {
+    const scorePercent = rowScore(row) * 20;
+    if (score_min != null && scorePercent < score_min) {
+      continue;
+    }
+    if (score_max != null && scorePercent > score_max) {
+      continue;
+    }
+    const identity = groupIdentity(row, group_by);
+    const group = groups.get(identity.group_key) ?? createGroup(identity);
+    group.accuracy.push(row.accuracy_score);
+    group.relevance.push(row.relevance_score);
+    group.coherence.push(row.coherence_score);
+    group.completeness.push(row.completeness_score);
+    group.helpfulness.push(row.helpfulness_score);
+    pushNumber(group.tokens, row.total_tokens);
+    pushNumber(group.latencies, row.latency_ms);
+    pushNumber(group.costs, row.estimated_cost);
+    const representative = { id: row.id, score: rowScore(row), created_at: row.created_at };
+    if (
+      !group.representative ||
+      representative.score > group.representative.score ||
+      (representative.score === group.representative.score && representative.created_at > group.representative.created_at)
+    ) {
+      group.representative = representative;
+    }
+    groups.set(identity.group_key, group);
+  }
 
-  const entries: LeaderboardEntry[] = rows.map((row, index) => ({
-    rank: index + 1,
-    model_name: row.model_name,
-    composite_score: Math.round(row.composite_score * 10000) / 10000,
-    avg_accuracy: row.avg_accuracy,
-    avg_relevance: row.avg_relevance,
-    avg_coherence: row.avg_coherence,
-    avg_completeness: row.avg_completeness,
-    avg_helpfulness: row.avg_helpfulness,
-    avg_total_tokens: row.avg_total_tokens,
-    avg_latency_ms: row.avg_latency_ms,
-    avg_estimated_cost: row.avg_estimated_cost,
-    evaluation_count: row.evaluation_count
-  }));
+  const entries = Array.from(groups.values())
+    .map((group) => groupToEntry(group, group_by))
+    .sort(compareEntries(sort_by))
+    .map((entry, index) => ({ ...entry, rank: index + 1 }));
 
   return {
     filters_applied: {
-      date_from: date_from,
-      date_to: date_to,
-      tags
+      date_from,
+      date_to,
+      tags,
+      server_ids,
+      model_names,
+      score_min: score_min ?? null,
+      score_max: score_max ?? null,
+      sort_by,
+      group_by
     },
     entries
   };

--- a/backend/src/services/results-view-service.ts
+++ b/backend/src/services/results-view-service.ts
@@ -1,0 +1,667 @@
+import { getDb } from '../models/db.js';
+import { parseJson } from '../models/repositories.js';
+
+const DEFAULT_WINDOW_DAYS = 30;
+const DEFAULT_HISTORY_LIMIT = 50;
+const MAX_HISTORY_LIMIT = 200;
+const MAX_SOURCE_ROWS = 10000;
+
+type SortBy = 'started_at' | 'status' | 'model' | 'server' | 'template' | 'score' | 'latency' | 'cost';
+type SortDir = 'asc' | 'desc';
+
+type RuntimeSnapshot = {
+  server_software?: { version?: string | null };
+  api?: { api_version?: string | null; schema_family?: string[] };
+  version?: string | null;
+};
+
+type EnvironmentSnapshot = {
+  effective_config?: { model?: string | null };
+  model?: string | null;
+};
+
+type ResultDocument = {
+  test?: { tags?: string[]; type?: string | null };
+  steps?: Array<Record<string, unknown>>;
+  summary?: Record<string, unknown>;
+  selected_model?: { id?: string | null } | null;
+};
+
+type ResultsViewRow = {
+  run_id: string;
+  inference_server_id: string;
+  run_status: string;
+  run_started_at: string;
+  run_ended_at: string | null;
+  environment_snapshot: string | null;
+  server_display_name: string | null;
+  server_runtime: string | null;
+  result_id: string | null;
+  test_result_test_id: string | null;
+  run_test_id: string | null;
+  template_id: string | null;
+  test_definition_name: string | null;
+  runner_type: string | null;
+  verdict: string | null;
+  failure_reason: string | null;
+  metrics: string | null;
+  artefacts: string | null;
+  raw_events: string | null;
+  result_started_at: string | null;
+  result_ended_at: string | null;
+  document: string | null;
+};
+
+export interface ResultsFilterState {
+  date_from: string;
+  date_to: string;
+  server_ids: string[];
+  model_names: string[];
+  template_ids: string[];
+  statuses: string[];
+  tags: string[];
+  score_min: number | null;
+  score_max: number | null;
+  sort_by: SortBy;
+  sort_dir: SortDir;
+  page: number;
+  page_size: number;
+}
+
+export interface ResultsHistoryRow {
+  run_id: string;
+  status: 'pass' | 'fail' | 'partial' | 'streaming';
+  started_at: string;
+  ended_at: string | null;
+  duration_ms: number | null;
+  server_id: string;
+  server_name: string;
+  model_name: string;
+  template_id: string;
+  template_label: string;
+  score: number | null;
+  latency_ms: number | null;
+  cost: number | null;
+  tags: string[];
+  result_count: number;
+}
+
+export interface ResultsDashboardView {
+  scorecards: {
+    total_runs: number;
+    pass_rate: number | null;
+    median_latency_ms: number | null;
+    median_cost: number | null;
+  };
+  pass_rate_series: Array<{ label: string; points: Array<{ x: string; y: number | null }> }>;
+  latency_series: Array<{ label: string; points: Array<{ x: string; y: number | null }> }>;
+  recent_runs: ResultsHistoryRow[];
+}
+
+export interface ResultsRunDetail {
+  run: ResultsHistoryRow;
+  raw_run: Record<string, unknown>;
+  results: Array<Record<string, unknown>>;
+  documents: Array<Record<string, unknown>>;
+}
+
+export interface ResultsViewResponse {
+  filters_applied: ResultsFilterState;
+  filter_options: {
+    servers: Array<{ id: string; label: string; count: number }>;
+    models: Array<{ id: string; label: string; count: number }>;
+    templates: Array<{ id: string; label: string; kind: string; count: number }>;
+    statuses: Array<{ id: string; label: string; count: number }>;
+    tags: Array<{ id: string; label: string; count: number }>;
+    date_bounds: { min: string | null; max: string | null };
+  };
+  dashboard: ResultsDashboardView;
+  history: {
+    rows: ResultsHistoryRow[];
+    page: number;
+    page_size: number;
+    total: number;
+    total_pages: number;
+  };
+}
+
+type RunAccumulator = {
+  run_id: string;
+  inference_server_id: string;
+  run_status: string;
+  run_started_at: string;
+  run_ended_at: string | null;
+  environment_snapshot: EnvironmentSnapshot | null;
+  server_display_name: string | null;
+  server_runtime: RuntimeSnapshot | null;
+  results: Array<{
+    id: string;
+    test_id: string;
+    template_id: string;
+    template_label: string;
+    kind: string;
+    verdict: string | null;
+    failure_reason: string | null;
+    metrics: Record<string, unknown> | null;
+    artefacts: Record<string, unknown> | null;
+    raw_events: unknown;
+    started_at: string | null;
+    ended_at: string | null;
+    document: ResultDocument | null;
+  }>;
+};
+
+function defaultRange(now = new Date()): { date_from: string; date_to: string } {
+  const to = new Date(now);
+  const from = new Date(now);
+  from.setUTCDate(from.getUTCDate() - DEFAULT_WINDOW_DAYS);
+  return { date_from: from.toISOString(), date_to: to.toISOString() };
+}
+
+function normalizeStringArray(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return Array.from(new Set(value.filter((entry): entry is string => typeof entry === 'string').map((entry) => entry.trim()).filter(Boolean)));
+  }
+  if (typeof value === 'string' && value.trim()) {
+    return Array.from(new Set(value.split(',').map((entry) => entry.trim()).filter(Boolean)));
+  }
+  return [];
+}
+
+function normalizeNumber(value: unknown, fallback: number | null): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : fallback;
+  }
+  return fallback;
+}
+
+function normalizeInput(payload: Record<string, unknown> | undefined): { ok: true; value: ResultsFilterState } | { ok: false; error: string; code: string } {
+  const body = payload ?? {};
+  const range = defaultRange();
+  const date_from = typeof body.date_from === 'string' && body.date_from.trim() ? body.date_from : range.date_from;
+  const date_to = typeof body.date_to === 'string' && body.date_to.trim() ? body.date_to : range.date_to;
+  const fromMs = Date.parse(date_from);
+  const toMs = Date.parse(date_to);
+  if (!Number.isFinite(fromMs) || !Number.isFinite(toMs) || fromMs > toMs) {
+    return { ok: false, code: 'INVALID_DATE_RANGE', error: 'date_from and date_to must be valid ISO dates in ascending order' };
+  }
+
+  const score_min = normalizeNumber(body.score_min, null);
+  const score_max = normalizeNumber(body.score_max, null);
+  if ((score_min !== null && (score_min < 0 || score_min > 100)) || (score_max !== null && (score_max < 0 || score_max > 100))) {
+    return { ok: false, code: 'INVALID_SCORE_RANGE', error: 'score_min and score_max must be between 0 and 100' };
+  }
+
+  const sortBy = body.sort_by;
+  const sort_by: SortBy =
+    sortBy === 'status' || sortBy === 'model' || sortBy === 'server' || sortBy === 'template' || sortBy === 'score' || sortBy === 'latency' || sortBy === 'cost'
+      ? sortBy
+      : 'started_at';
+  const sort_dir: SortDir = body.sort_dir === 'asc' ? 'asc' : 'desc';
+  const page = Math.max(1, Math.trunc(normalizeNumber(body.page, 1) ?? 1));
+  const page_size = Math.min(MAX_HISTORY_LIMIT, Math.max(1, Math.trunc(normalizeNumber(body.page_size, DEFAULT_HISTORY_LIMIT) ?? DEFAULT_HISTORY_LIMIT)));
+
+  return {
+    ok: true,
+    value: {
+      date_from,
+      date_to,
+      server_ids: normalizeStringArray(body.server_ids),
+      model_names: normalizeStringArray(body.model_names),
+      template_ids: normalizeStringArray(body.template_ids),
+      statuses: normalizeStringArray(body.statuses),
+      tags: normalizeStringArray(body.tags),
+      score_min,
+      score_max,
+      sort_by,
+      sort_dir,
+      page,
+      page_size
+    }
+  };
+}
+
+function safeJson<T>(value: string | null): T | null {
+  try {
+    return parseJson<T>(value);
+  } catch {
+    return null;
+  }
+}
+
+function selectedModel(snapshot: EnvironmentSnapshot | null, document: ResultDocument | null): string {
+  return snapshot?.effective_config?.model?.trim() || snapshot?.model?.trim() || document?.selected_model?.id?.trim() || 'unknown';
+}
+
+function templateLabel(name: string | null, testId: string): string {
+  if (!name?.trim()) {
+    return testId;
+  }
+  return name.replace(/\s*\([^)]*\)\s*$/, '').trim() || name.trim();
+}
+
+function templateKey(row: ResultsViewRow): string {
+  return row.template_id?.trim() || templateLabel(row.test_definition_name, row.test_result_test_id ?? row.run_test_id ?? 'unknown');
+}
+
+function metricNumber(metrics: Record<string, unknown> | null, keys: string[]): number | null {
+  if (!metrics) {
+    return null;
+  }
+  for (const key of keys) {
+    const value = metrics[key];
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function latency(metrics: Record<string, unknown> | null): number | null {
+  const preferred = metricNumber(metrics, ['latency_ms', 'total_ms', 'duration_ms', 'ttfb_ms']);
+  if (preferred !== null) {
+    return preferred;
+  }
+  if (!metrics) {
+    return null;
+  }
+  const entry = Object.entries(metrics).find(([key, value]) => /latency|duration|total_ms|ttfb/i.test(key) && typeof value === 'number' && Number.isFinite(value));
+  return entry ? (entry[1] as number) : null;
+}
+
+function cost(metrics: Record<string, unknown> | null, artefacts: Record<string, unknown> | null): number | null {
+  return metricNumber(metrics, ['estimated_cost', 'cost', 'cost_usd']) ?? metricNumber(artefacts, ['estimated_cost', 'cost', 'cost_usd']);
+}
+
+function verdictScore(verdict: string | null): number | null {
+  if (verdict === 'pass') {
+    return 100;
+  }
+  if (verdict === 'fail' || verdict === 'error') {
+    return 0;
+  }
+  if (verdict === 'skip' || verdict === 'skipped') {
+    return 50;
+  }
+  return null;
+}
+
+function median(values: Array<number | null>): number | null {
+  const sorted = values.filter((value): value is number => typeof value === 'number' && Number.isFinite(value)).sort((a, b) => a - b);
+  if (sorted.length === 0) {
+    return null;
+  }
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 ? sorted[middle] : (sorted[middle - 1] + sorted[middle]) / 2;
+}
+
+function durationMs(startedAt: string, endedAt: string | null): number | null {
+  if (!endedAt) {
+    return null;
+  }
+  const start = Date.parse(startedAt);
+  const end = Date.parse(endedAt);
+  return Number.isFinite(start) && Number.isFinite(end) ? Math.max(0, end - start) : null;
+}
+
+function resultTags(result: RunAccumulator['results'][number]): string[] {
+  return Array.from(new Set((result.document?.test?.tags ?? []).filter((tag): tag is string => typeof tag === 'string' && tag.trim().length > 0)));
+}
+
+function rowStatus(run: RunAccumulator): ResultsHistoryRow['status'] {
+  if (run.run_status === 'running' || run.run_status === 'queued') {
+    return 'streaming';
+  }
+  const verdicts = run.results.map((result) => result.verdict).filter(Boolean);
+  if (verdicts.length === 0) {
+    return run.run_status === 'completed' ? 'partial' : 'fail';
+  }
+  const passes = verdicts.filter((verdict) => verdict === 'pass').length;
+  if (passes === verdicts.length) {
+    return 'pass';
+  }
+  if (passes > 0) {
+    return 'partial';
+  }
+  return 'fail';
+}
+
+function toHistoryRow(run: RunAccumulator): ResultsHistoryRow {
+  const firstResult = run.results[0];
+  const allLatencies = run.results.map((result) => latency(result.metrics));
+  const allCosts = run.results.map((result) => cost(result.metrics, result.artefacts));
+  const scores = run.results.map((result) => verdictScore(result.verdict));
+  const tags = Array.from(new Set(run.results.flatMap(resultTags)));
+  const document = firstResult?.document ?? null;
+  const model = selectedModel(run.environment_snapshot, document);
+  return {
+    run_id: run.run_id,
+    status: rowStatus(run),
+    started_at: run.run_started_at,
+    ended_at: run.run_ended_at,
+    duration_ms: durationMs(run.run_started_at, run.run_ended_at),
+    server_id: run.inference_server_id,
+    server_name: run.server_display_name ?? run.inference_server_id,
+    model_name: model,
+    template_id: firstResult?.template_id ?? run.results[0]?.test_id ?? run.run_id,
+    template_label: firstResult?.template_label ?? run.results[0]?.test_id ?? 'unknown',
+    score: median(scores),
+    latency_ms: median(allLatencies),
+    cost: allCosts.reduce((sum, value) => sum + (value ?? 0), 0) || null,
+    tags,
+    result_count: run.results.length
+  };
+}
+
+function fetchRows(filters: ResultsFilterState): ResultsViewRow[] {
+  const db = getDb();
+  return db.prepare(`
+    SELECT
+      r.id AS run_id,
+      r.inference_server_id,
+      r.status AS run_status,
+      r.started_at AS run_started_at,
+      r.ended_at AS run_ended_at,
+      r.environment_snapshot,
+      i.display_name AS server_display_name,
+      i.runtime AS server_runtime,
+      tr.id AS result_id,
+      tr.test_id AS test_result_test_id,
+      r.test_id AS run_test_id,
+      at.template_id,
+      td.name AS test_definition_name,
+      td.runner_type,
+      tr.verdict,
+      tr.failure_reason,
+      tr.metrics,
+      tr.artefacts,
+      tr.raw_events,
+      tr.started_at AS result_started_at,
+      tr.ended_at AS result_ended_at,
+      trd.document
+    FROM runs r
+    LEFT JOIN inference_servers i ON i.server_id = r.inference_server_id
+    LEFT JOIN test_results tr ON tr.run_id = r.id
+    LEFT JOIN active_tests at ON at.id = COALESCE(tr.test_id, r.test_id)
+    LEFT JOIN test_definitions td ON td.id = COALESCE(tr.test_id, r.test_id)
+    LEFT JOIN test_result_documents trd ON trd.test_result_id = tr.id
+    WHERE r.started_at >= ? AND r.started_at <= ?
+    ORDER BY r.started_at DESC
+    LIMIT ${MAX_SOURCE_ROWS}
+  `).all(filters.date_from, filters.date_to) as ResultsViewRow[];
+}
+
+function fetchRowsForRun(runId: string): ResultsViewRow[] {
+  const db = getDb();
+  return db.prepare(`
+    SELECT
+      r.id AS run_id,
+      r.inference_server_id,
+      r.status AS run_status,
+      r.started_at AS run_started_at,
+      r.ended_at AS run_ended_at,
+      r.environment_snapshot,
+      i.display_name AS server_display_name,
+      i.runtime AS server_runtime,
+      tr.id AS result_id,
+      tr.test_id AS test_result_test_id,
+      r.test_id AS run_test_id,
+      at.template_id,
+      td.name AS test_definition_name,
+      td.runner_type,
+      tr.verdict,
+      tr.failure_reason,
+      tr.metrics,
+      tr.artefacts,
+      tr.raw_events,
+      tr.started_at AS result_started_at,
+      tr.ended_at AS result_ended_at,
+      trd.document
+    FROM runs r
+    LEFT JOIN inference_servers i ON i.server_id = r.inference_server_id
+    LEFT JOIN test_results tr ON tr.run_id = r.id
+    LEFT JOIN active_tests at ON at.id = COALESCE(tr.test_id, r.test_id)
+    LEFT JOIN test_definitions td ON td.id = COALESCE(tr.test_id, r.test_id)
+    LEFT JOIN test_result_documents trd ON trd.test_result_id = tr.id
+    WHERE r.id = ?
+    ORDER BY tr.started_at ASC
+  `).all(runId) as ResultsViewRow[];
+}
+
+function materializeRuns(rows: ResultsViewRow[]): RunAccumulator[] {
+  const byRun = new Map<string, RunAccumulator>();
+  for (const row of rows) {
+    const run = byRun.get(row.run_id) ?? {
+      run_id: row.run_id,
+      inference_server_id: row.inference_server_id,
+      run_status: row.run_status,
+      run_started_at: row.run_started_at,
+      run_ended_at: row.run_ended_at,
+      environment_snapshot: safeJson<EnvironmentSnapshot>(row.environment_snapshot),
+      server_display_name: row.server_display_name,
+      server_runtime: safeJson<RuntimeSnapshot>(row.server_runtime),
+      results: []
+    };
+    if (row.result_id) {
+      const testId = row.test_result_test_id ?? row.run_test_id ?? row.result_id;
+      const document = safeJson<ResultDocument>(row.document);
+      run.results.push({
+        id: row.result_id,
+        test_id: testId,
+        template_id: templateKey(row),
+        template_label: templateLabel(row.test_definition_name, testId),
+        kind: row.runner_type === 'python' || document?.test?.type?.includes('python') ? 'PY' : 'JSON',
+        verdict: row.verdict,
+        failure_reason: row.failure_reason,
+        metrics: safeJson<Record<string, unknown>>(row.metrics),
+        artefacts: safeJson<Record<string, unknown>>(row.artefacts),
+        raw_events: safeJson<unknown>(row.raw_events),
+        started_at: row.result_started_at,
+        ended_at: row.result_ended_at,
+        document
+      });
+    }
+    byRun.set(row.run_id, run);
+  }
+  return Array.from(byRun.values());
+}
+
+function matchesFilters(row: ResultsHistoryRow, filters: ResultsFilterState): boolean {
+  if (filters.server_ids.length > 0 && !filters.server_ids.includes(row.server_id)) {
+    return false;
+  }
+  if (filters.model_names.length > 0 && !filters.model_names.includes(row.model_name)) {
+    return false;
+  }
+  if (filters.template_ids.length > 0 && !filters.template_ids.includes(row.template_id)) {
+    return false;
+  }
+  if (filters.statuses.length > 0 && !filters.statuses.includes(row.status)) {
+    return false;
+  }
+  if (filters.score_min !== null && (row.score === null || row.score < filters.score_min)) {
+    return false;
+  }
+  if (filters.score_max !== null && (row.score === null || row.score > filters.score_max)) {
+    return false;
+  }
+  if (filters.tags.length > 0) {
+    const lowerTags = row.tags.map((tag) => tag.toLowerCase());
+    const matches = filters.tags.some((tag) => lowerTags.some((candidate) => candidate.includes(tag.toLowerCase())));
+    if (!matches) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function sortRows(rows: ResultsHistoryRow[], filters: ResultsFilterState): ResultsHistoryRow[] {
+  const multiplier = filters.sort_dir === 'asc' ? 1 : -1;
+  const value = (row: ResultsHistoryRow): string | number => {
+    switch (filters.sort_by) {
+      case 'status':
+        return row.status;
+      case 'model':
+        return row.model_name;
+      case 'server':
+        return row.server_name;
+      case 'template':
+        return row.template_label;
+      case 'score':
+        return row.score ?? -1;
+      case 'latency':
+        return row.latency_ms ?? Number.MAX_SAFE_INTEGER;
+      case 'cost':
+        return row.cost ?? Number.MAX_SAFE_INTEGER;
+      case 'started_at':
+      default:
+        return Date.parse(row.started_at) || 0;
+    }
+  };
+  return rows.slice().sort((a, b) => {
+    const left = value(a);
+    const right = value(b);
+    if (typeof left === 'number' && typeof right === 'number') {
+      return (left - right) * multiplier;
+    }
+    return String(left).localeCompare(String(right)) * multiplier;
+  });
+}
+
+function countOptions(rows: ResultsHistoryRow[]) {
+  const count = <T extends string>(values: T[]) => {
+    const map = new Map<T, number>();
+    for (const value of values) {
+      map.set(value, (map.get(value) ?? 0) + 1);
+    }
+    return map;
+  };
+  const servers = new Map<string, { label: string; count: number }>();
+  const templates = new Map<string, { label: string; kind: string; count: number }>();
+  for (const row of rows) {
+    const server = servers.get(row.server_id) ?? { label: row.server_name, count: 0 };
+    server.count += 1;
+    servers.set(row.server_id, server);
+    const template = templates.get(row.template_id) ?? { label: row.template_label, kind: 'JSON', count: 0 };
+    template.count += 1;
+    templates.set(row.template_id, template);
+  }
+  return {
+    servers: Array.from(servers.entries()).map(([id, entry]) => ({ id, label: entry.label, count: entry.count })),
+    models: Array.from(count(rows.map((row) => row.model_name)).entries()).map(([id, total]) => ({ id, label: id, count: total })),
+    templates: Array.from(templates.entries()).map(([id, entry]) => ({ id, label: entry.label, kind: entry.kind, count: entry.count })),
+    statuses: Array.from(count(rows.map((row) => row.status)).entries()).map(([id, total]) => ({ id, label: id, count: total })),
+    tags: Array.from(count(rows.flatMap((row) => row.tags)).entries()).map(([id, total]) => ({ id, label: id, count: total }))
+  };
+}
+
+function dayBucket(iso: string): string {
+  return iso.slice(0, 10);
+}
+
+function dashboard(rows: ResultsHistoryRow[]): ResultsDashboardView {
+  const total = rows.length;
+  const passRate = total > 0 ? (rows.filter((row) => row.status === 'pass').length / total) * 100 : null;
+  const byModelDay = new Map<string, { pass: number; total: number; latency: Array<{ x: string; y: number | null }> }>();
+  for (const row of rows) {
+    const key = `${row.model_name}|${dayBucket(row.started_at)}`;
+    const bucket = byModelDay.get(key) ?? { pass: 0, total: 0, latency: [] };
+    bucket.total += 1;
+    if (row.status === 'pass') {
+      bucket.pass += 1;
+    }
+    bucket.latency.push({ x: row.started_at, y: row.latency_ms });
+    byModelDay.set(key, bucket);
+  }
+  const passSeries = new Map<string, Array<{ x: string; y: number | null }>>();
+  const latencySeries = new Map<string, Array<{ x: string; y: number | null }>>();
+  for (const [key, bucket] of byModelDay.entries()) {
+    const [model, day] = key.split('|');
+    const passPoints = passSeries.get(model) ?? [];
+    passPoints.push({ x: day, y: bucket.total > 0 ? (bucket.pass / bucket.total) * 100 : null });
+    passSeries.set(model, passPoints);
+  }
+  for (const row of rows) {
+    const points = latencySeries.get(row.model_name) ?? [];
+    points.push({ x: row.started_at, y: row.latency_ms });
+    latencySeries.set(row.model_name, points);
+  }
+  return {
+    scorecards: {
+      total_runs: total,
+      pass_rate: passRate,
+      median_latency_ms: median(rows.map((row) => row.latency_ms)),
+      median_cost: median(rows.map((row) => row.cost))
+    },
+    pass_rate_series: Array.from(passSeries.entries()).map(([label, points]) => ({ label, points: points.sort((a, b) => a.x.localeCompare(b.x)) })),
+    latency_series: Array.from(latencySeries.entries()).map(([label, points]) => ({ label, points: points.sort((a, b) => a.x.localeCompare(b.x)) })),
+    recent_runs: rows.slice().sort((a, b) => b.started_at.localeCompare(a.started_at)).slice(0, 8)
+  };
+}
+
+export function queryResultsView(payload: Record<string, unknown> | undefined): { ok: true; value: ResultsViewResponse } | { ok: false; code: string; error: string } {
+  const normalized = normalizeInput(payload);
+  if (!normalized.ok) {
+    return normalized;
+  }
+  const runs = materializeRuns(fetchRows(normalized.value));
+  const allRows = runs.map(toHistoryRow);
+  const options = countOptions(allRows);
+  const filteredRows = allRows.filter((row) => matchesFilters(row, normalized.value));
+  const sortedRows = sortRows(filteredRows, normalized.value);
+  const start = (normalized.value.page - 1) * normalized.value.page_size;
+  const pageRows = sortedRows.slice(start, start + normalized.value.page_size);
+  const dates = allRows.map((row) => row.started_at).sort();
+
+  return {
+    ok: true,
+    value: {
+      filters_applied: normalized.value,
+      filter_options: {
+        ...options,
+        date_bounds: { min: dates[0] ?? null, max: dates[dates.length - 1] ?? null }
+      },
+      dashboard: dashboard(filteredRows),
+      history: {
+        rows: pageRows,
+        page: normalized.value.page,
+        page_size: normalized.value.page_size,
+        total: filteredRows.length,
+        total_pages: Math.max(1, Math.ceil(filteredRows.length / normalized.value.page_size))
+      }
+    }
+  };
+}
+
+export function getResultsRunDetail(runId: string): ResultsRunDetail | null {
+  const rows = materializeRuns(fetchRowsForRun(runId));
+  const run = rows[0];
+  if (!run) {
+    return null;
+  }
+  const db = getDb();
+  const rawRun = db.prepare('SELECT * FROM runs WHERE id = ?').get(runId) as Record<string, unknown>;
+  return {
+    run: toHistoryRow(run),
+    raw_run: { ...rawRun, environment_snapshot: safeJson<Record<string, unknown>>((rawRun.environment_snapshot as string | null) ?? null) },
+    results: run.results.map((result) => ({
+      id: result.id,
+      test_id: result.test_id,
+      template_id: result.template_id,
+      template_label: result.template_label,
+      kind: result.kind,
+      verdict: result.verdict,
+      failure_reason: result.failure_reason,
+      metrics: result.metrics,
+      artefacts: result.artefacts,
+      raw_events: result.raw_events,
+      started_at: result.started_at,
+      ended_at: result.ended_at
+    })),
+    documents: run.results.map((result) => result.document ?? {})
+  };
+}

--- a/backend/tests/integration/leaderboard.test.ts
+++ b/backend/tests/integration/leaderboard.test.ts
@@ -34,9 +34,21 @@ function seedEvaluation(opts: {
   scores?: number;
   tags?: string[];
   createdAt?: string;
+  latencyMs?: number;
+  estimatedCost?: number;
+  quantization?: string | null;
 }) {
   const db = getDb();
-  const { modelName, serverId = 'srv-lb-int', scores = 3, tags = [], createdAt = new Date().toISOString() } = opts;
+  const {
+    modelName,
+    serverId = 'srv-lb-int',
+    scores = 3,
+    tags = [],
+    createdAt = new Date().toISOString(),
+    latencyMs = null,
+    estimatedCost = null,
+    quantization = null
+  } = opts;
   const promptId = crypto.randomUUID();
   db.prepare('INSERT INTO eval_prompts (id, text, tags, created_at) VALUES (?, ?, ?, ?)').run(
     promptId,
@@ -48,16 +60,20 @@ function seedEvaluation(opts: {
   db.prepare(`
     INSERT INTO evaluations (
       id, prompt_id, model_name, server_id, inference_config, answer_text,
+      latency_ms, estimated_cost,
       accuracy_score, relevance_score, coherence_score, completeness_score, helpfulness_score,
       created_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
     evalId, promptId, modelName, serverId,
-    JSON.stringify({ temperature: null, top_p: null, max_tokens: null, quantization_level: null }),
+    JSON.stringify({ temperature: null, top_p: null, max_tokens: null, quantization_level: quantization }),
     'Answer',
+    latencyMs,
+    estimatedCost,
     scores, scores, scores, scores, scores,
     createdAt
   );
+  return evalId;
 }
 
 describe('GET /leaderboard', () => {
@@ -226,5 +242,43 @@ describe('GET /leaderboard', () => {
     const db = getDb();
     expect(db.prepare('SELECT COUNT(*) AS count FROM evaluations').get()).toEqual({ count: 0 });
     expect(db.prepare('SELECT COUNT(*) AS count FROM eval_prompts').get()).toEqual({ count: 0 });
+  });
+
+  it('applies server, model, score, sort and group filters without changing evaluation backing', async () => {
+    const app = createServer();
+    seedServer('srv-alt');
+    seedEvaluation({ modelName: 'model-a', serverId: 'srv-lb-int', scores: 5, latencyMs: 200, quantization: 'Q4' });
+    seedEvaluation({ modelName: 'model-b', serverId: 'srv-alt', scores: 2, latencyMs: 50, quantization: 'Q8' });
+
+    const filtered = await app.inject({
+      method: 'GET',
+      url: '/leaderboard?server_ids=srv-lb-int&model_names=model-a&score_min=90&sort_by=latency&group_by=server',
+      headers: AUTH_HEADERS
+    });
+
+    expect(filtered.statusCode).toBe(200);
+    const body = filtered.json();
+    expect(body.entries).toHaveLength(1);
+    expect(body.entries[0].group_by).toBe('server');
+    expect(body.entries[0].server_id).toBe('srv-lb-int');
+    expect(body.entries[0].representative_evaluation_id).toBeTruthy();
+  });
+
+  it('groups leaderboard entries by quantization level', async () => {
+    const app = createServer();
+    seedEvaluation({ modelName: 'model-a', scores: 5, quantization: 'Q4' });
+    seedEvaluation({ modelName: 'model-b', scores: 4, quantization: 'Q4' });
+    seedEvaluation({ modelName: 'model-c', scores: 3, quantization: 'Q8' });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/leaderboard?group_by=quantization',
+      headers: AUTH_HEADERS
+    });
+
+    expect(response.statusCode).toBe(200);
+    const labels = response.json().entries.map((entry: { group_label: string }) => entry.group_label);
+    expect(labels).toContain('Q4');
+    expect(labels).toContain('Q8');
   });
 });

--- a/backend/tests/integration/results-view.integration.test.ts
+++ b/backend/tests/integration/results-view.integration.test.ts
@@ -1,0 +1,167 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createServer } from '../../src/api/server.js';
+import { getDb, resetDbInstance, runSchema } from '../../src/models/db.js';
+
+const AUTH_HEADERS = { 'x-api-token': 'test-token' };
+
+const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+const SCHEMA_PATH = path.resolve(moduleDir, '../../src/models/schema.sql');
+
+function seedServer(serverId = 'srv-results') {
+  const db = getDb();
+  const now = '2026-05-01T00:00:00.000Z';
+  db.prepare(`
+    INSERT INTO inference_servers (
+      server_id, display_name, active, archived, created_at, updated_at, runtime,
+      endpoints, auth, capabilities, discovery, raw
+    ) VALUES (?, ?, 1, 0, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    serverId,
+    'Results Server',
+    now,
+    now,
+    JSON.stringify({ api: { api_version: '1.0.0' } }),
+    JSON.stringify({ base_url: 'http://localhost:8080' }),
+    JSON.stringify({}),
+    JSON.stringify({}),
+    JSON.stringify({ model_list: { normalised: [] } }),
+    JSON.stringify({})
+  );
+  return serverId;
+}
+
+function seedRun(input: {
+  runId: string;
+  model: string;
+  verdict: 'pass' | 'fail';
+  startedAt: string;
+  latency: number;
+  templateId?: string;
+}) {
+  const db = getDb();
+  const templateId = input.templateId ?? 'cold-start';
+  db.prepare(`
+    INSERT INTO active_tests (
+      id, template_id, template_version, inference_server_id, model_name,
+      status, created_at, deleted_at, version, command_preview, python_ready
+    ) VALUES (?, ?, '1.0.0', 'srv-results', ?, 'active', ?, null, '1.0.0', null, 1)
+  `).run(`${templateId}-${input.runId}`, templateId, input.model, input.startedAt);
+
+  db.prepare(`
+    INSERT INTO runs (
+      id, inference_server_id, suite_id, test_id, profile_id, profile_version,
+      status, started_at, ended_at, environment_snapshot, retention_days
+    ) VALUES (?, 'srv-results', null, ?, null, null, 'completed', ?, ?, ?, 30)
+  `).run(
+    input.runId,
+    `${templateId}-${input.runId}`,
+    input.startedAt,
+    input.startedAt,
+    JSON.stringify({ effective_config: { model: input.model } })
+  );
+
+  const resultId = `result-${input.runId}`;
+  db.prepare(`
+    INSERT INTO test_results (
+      id, run_id, test_id, verdict, failure_reason, metrics, artefacts, raw_events,
+      repetition_stats, started_at, ended_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, '[]', ?, ?, ?)
+  `).run(
+    resultId,
+    input.runId,
+    `${templateId}-${input.runId}`,
+    input.verdict,
+    input.verdict === 'fail' ? 'assertion failed' : null,
+    JSON.stringify({ latency_ms: input.latency, estimated_cost: 0.001 }),
+    JSON.stringify({}),
+    JSON.stringify({ repetitions: 1 }),
+    input.startedAt,
+    input.startedAt
+  );
+
+  db.prepare(`
+    INSERT INTO test_result_documents (test_result_id, run_id, test_id, schema_version, document, created_at)
+    VALUES (?, ?, ?, '1.0.0', ?, ?)
+  `).run(
+    resultId,
+    input.runId,
+    `${templateId}-${input.runId}`,
+    JSON.stringify({ test: { tags: ['nightly'], type: 'scenario-json' }, selected_model: { id: input.model }, steps: [] }),
+    input.startedAt
+  );
+}
+
+describe('results-view routes', () => {
+  process.env.AITESTBENCH_API_TOKEN = 'test-token';
+
+  beforeEach(() => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aitb-results-view-'));
+    process.env.AITESTBENCH_DB_PATH = path.join(tmpDir, 'test.sqlite');
+    resetDbInstance();
+    runSchema(fs.readFileSync(SCHEMA_PATH, 'utf8'));
+    seedServer();
+  });
+
+  afterEach(() => {
+    resetDbInstance();
+  });
+
+  it('returns empty dashboard/history structures for an empty database window', async () => {
+    const app = createServer();
+    const response = await app.inject({
+      method: 'POST',
+      url: '/results-view/query',
+      headers: AUTH_HEADERS,
+      payload: { date_from: '2026-05-01T00:00:00.000Z', date_to: '2026-05-02T00:00:00.000Z' }
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().dashboard.scorecards.total_runs).toBe(0);
+    expect(response.json().history.rows).toEqual([]);
+  });
+
+  it('filters run-backed history by status, model, score and tag', async () => {
+    const app = createServer();
+    seedRun({ runId: 'run-pass', model: 'model-a', verdict: 'pass', startedAt: '2026-05-01T10:00:00.000Z', latency: 100 });
+    seedRun({ runId: 'run-fail', model: 'model-b', verdict: 'fail', startedAt: '2026-05-01T11:00:00.000Z', latency: 200 });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/results-view/query',
+      headers: AUTH_HEADERS,
+      payload: {
+        date_from: '2026-05-01T00:00:00.000Z',
+        date_to: '2026-05-02T00:00:00.000Z',
+        statuses: ['pass'],
+        model_names: ['model-a'],
+        score_min: 90,
+        tags: ['nightly']
+      }
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().history.rows).toHaveLength(1);
+    expect(response.json().history.rows[0].run_id).toBe('run-pass');
+  });
+
+  it('opens run drawer detail for a history row', async () => {
+    const app = createServer();
+    seedRun({ runId: 'run-detail', model: 'model-a', verdict: 'pass', startedAt: '2026-05-01T10:00:00.000Z', latency: 100 });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/results-view/runs/run-detail',
+      headers: AUTH_HEADERS
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().run.run_id).toBe('run-detail');
+    expect(response.json().results[0].metrics.latency_ms).toBe(100);
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,14 +1,11 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Navigate, Route, Routes, useLocation, useNavigate, useSearchParams } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation, useSearchParams } from 'react-router-dom';
 
 import packageInfo from '../package.json';
-import { MergedPageHeader } from './components/MergedPageHeader.js';
 import { Sidebar } from './components/Sidebar.js';
 import { Catalog } from './pages/Catalog.js';
 import { Evaluate } from './pages/Evaluate.js';
-import { Leaderboard } from './pages/Leaderboard.js';
-import { ResultsDashboard } from './pages/ResultsDashboard.js';
-import { RunHistory } from './pages/RunHistory.js';
+import { ResultsUnified } from './pages/ResultsUnified.js';
 import { RunUnified } from './pages/RunUnified.js';
 import { Templates } from './pages/Templates.js';
 import { legacyRedirectSearch, normalizeResultsTab, resultsSearch } from './navigation.js';
@@ -35,7 +32,6 @@ function CatalogRoute({ servers, connectivity }: { servers: InferenceServerRecor
 
 function ResultsRoute({ runCount }: { runCount: number | null }) {
   const [searchParams, setSearchParams] = useSearchParams();
-  const navigate = useNavigate();
   const activeTab = normalizeResultsTab(searchParams.get('tab'));
 
   useEffect(() => {
@@ -47,34 +43,7 @@ function ResultsRoute({ runCount }: { runCount: number | null }) {
     setSearchParams(next, { replace: true });
   }, [activeTab, searchParams, setSearchParams]);
 
-  return (
-    <>
-      <MergedPageHeader
-        title="Results"
-        subtitle={`${runCount ?? 0} recorded runs`}
-        tabs={[
-          { id: 'dashboard', label: 'Dashboard' },
-          { id: 'leaderboard', label: 'Leaderboard' },
-          { id: 'history', label: 'History', sub: `${runCount ?? 0} runs` }
-        ]}
-        activeTab={activeTab}
-        onTabChange={(tab) => setSearchParams({ tab })}
-      />
-      {activeTab === 'leaderboard' ? (
-        <Leaderboard
-          setView={(view) => {
-            if (view === 'evaluate') {
-              navigate('/evaluate');
-            }
-          }}
-        />
-      ) : activeTab === 'history' ? (
-        <RunHistory />
-      ) : (
-        <ResultsDashboard />
-      )}
-    </>
-  );
+  return <ResultsUnified runCount={runCount} />;
 }
 
 function RunRoute() {

--- a/frontend/src/pages/ResultsUnified.tsx
+++ b/frontend/src/pages/ResultsUnified.tsx
@@ -1,0 +1,815 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+import { MergedPageHeader } from '../components/MergedPageHeader.js';
+import { ResultsGraphPanel } from '../components/results-graph-panel.js';
+import { normalizeResultsTab } from '../navigation.js';
+import { getLeaderboard, type LeaderboardEntry } from '../services/leaderboard-api.js';
+import {
+  getResultsEvaluationDetail,
+  getResultsRunDetail,
+  queryResultsView,
+  type ResultsEvaluationDetail,
+  type ResultsFilterOptions,
+  type ResultsFilterState,
+  type ResultsHistoryRow,
+  type ResultsRunDetail,
+  type ResultsStatus,
+  type ResultsTab
+} from '../services/results-view-api.js';
+import type { DashboardPanel } from '../services/dashboard-results-api.js';
+import { toLocalInputValue } from './ResultsDashboard.js';
+import '../styles/dashboard-results.css';
+
+type LeaderboardSort = 'score' | 'latency' | 'cost' | 'pass_rate';
+type LeaderboardGroup = 'model' | 'server' | 'quantization';
+
+const STATUS_OPTIONS: ResultsStatus[] = ['pass', 'fail', 'partial', 'streaming'];
+
+function defaultRange(): { date_from: string; date_to: string } {
+  const to = new Date();
+  const from = new Date(to);
+  from.setDate(from.getDate() - 30);
+  return { date_from: from.toISOString(), date_to: to.toISOString() };
+}
+
+function toIsoFromLocal(value: string): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
+}
+
+function csvList(params: URLSearchParams, key: string): string[] {
+  const value = params.get(key);
+  return value ? value.split(',').map((entry) => entry.trim()).filter(Boolean) : [];
+}
+
+function numberParam(params: URLSearchParams, key: string): number | null {
+  const value = params.get(key);
+  if (!value) {
+    return null;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function decodeFilters(params: URLSearchParams): ResultsFilterState {
+  const range = defaultRange();
+  const statuses = csvList(params, 'status').filter((status): status is ResultsStatus =>
+    STATUS_OPTIONS.includes(status as ResultsStatus)
+  );
+  const sortBy = params.get('sort_by');
+  const sortDir = params.get('sort_dir');
+  return {
+    date_from: params.get('date_from') ?? range.date_from,
+    date_to: params.get('date_to') ?? range.date_to,
+    server_ids: csvList(params, 'server'),
+    model_names: csvList(params, 'model'),
+    template_ids: csvList(params, 'template'),
+    statuses,
+    tags: csvList(params, 'tag'),
+    score_min: numberParam(params, 'score_min'),
+    score_max: numberParam(params, 'score_max'),
+    sort_by:
+      sortBy === 'status' || sortBy === 'model' || sortBy === 'server' || sortBy === 'template' || sortBy === 'score' || sortBy === 'latency' || sortBy === 'cost'
+        ? sortBy
+        : 'started_at',
+    sort_dir: sortDir === 'asc' ? 'asc' : 'desc',
+    page: Math.max(1, Number(params.get('page') ?? '1') || 1),
+    page_size: 50
+  };
+}
+
+function writeFilters(params: URLSearchParams, filters: ResultsFilterState): URLSearchParams {
+  const next = new URLSearchParams(params);
+  const setCsv = (key: string, values: string[]) => {
+    if (values.length > 0) {
+      next.set(key, values.join(','));
+    } else {
+      next.delete(key);
+    }
+  };
+  if (filters.date_from) next.set('date_from', filters.date_from);
+  if (filters.date_to) next.set('date_to', filters.date_to);
+  setCsv('server', filters.server_ids);
+  setCsv('model', filters.model_names);
+  setCsv('template', filters.template_ids);
+  setCsv('status', filters.statuses);
+  setCsv('tag', filters.tags);
+  if (filters.score_min != null) next.set('score_min', String(filters.score_min)); else next.delete('score_min');
+  if (filters.score_max != null) next.set('score_max', String(filters.score_max)); else next.delete('score_max');
+  next.set('sort_by', filters.sort_by);
+  next.set('sort_dir', filters.sort_dir);
+  next.set('page', String(filters.page));
+  return next;
+}
+
+function formatNumber(value: number | null, suffix = ''): string {
+  if (value == null || !Number.isFinite(value)) {
+    return 'N/A';
+  }
+  return `${Number(value.toFixed(value >= 100 ? 0 : 2)).toLocaleString()}${suffix}`;
+}
+
+function formatDate(value: string): string {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
+}
+
+function toggleValue(values: string[], value: string): string[] {
+  return values.includes(value) ? values.filter((entry) => entry !== value) : [...values, value];
+}
+
+function seriesPanel(title: string, metric: string, series: Array<{ label: string; points: Array<{ x: string; y: number | null }> }>): DashboardPanel {
+  return {
+    panel_id: `results:${metric}`,
+    presentation_type: 'performance_graph',
+    title,
+    runtime_key: 'selected',
+    server_version: null,
+    model_id: 'selected',
+    test_ids: [],
+    metric_keys: [metric],
+    unit_keys: metric === 'pass_rate' ? ['%'] : ['ms'],
+    grouped: true,
+    series,
+    missing_fields: []
+  };
+}
+
+function ResultsFilterRail({
+  filters,
+  options,
+  loading,
+  onChange,
+  onReset
+}: {
+  filters: ResultsFilterState;
+  options: ResultsFilterOptions | null;
+  loading: boolean;
+  onChange: (next: ResultsFilterState) => void;
+  onReset: () => void;
+}) {
+  const dateFrom = filters.date_from ? toLocalInputValue(filters.date_from) : '';
+  const dateTo = filters.date_to ? toLocalInputValue(filters.date_to, 'to') : '';
+  const disabled = loading && !options;
+  return (
+    <aside className="results-rail" aria-label="Results filters">
+      <div className="results-rail__group">
+        <h3>Time range</h3>
+        <div className="results-range-buttons">
+          {[1, 7, 30].map((days) => (
+            <button
+              key={days}
+              type="button"
+              className="ghost-button"
+              onClick={() => {
+                const to = new Date();
+                const from = new Date(to);
+                from.setDate(from.getDate() - days);
+                onChange({ ...filters, date_from: from.toISOString(), date_to: to.toISOString(), page: 1 });
+              }}
+            >
+              {days === 1 ? '24h' : `${days}d`}
+            </button>
+          ))}
+        </div>
+        <label>
+          From
+          <input
+            type="datetime-local"
+            value={dateFrom}
+            disabled={disabled}
+            onChange={(event) => onChange({ ...filters, date_from: toIsoFromLocal(event.target.value), page: 1 })}
+          />
+        </label>
+        <label>
+          To
+          <input
+            type="datetime-local"
+            value={dateTo}
+            disabled={disabled}
+            onChange={(event) => onChange({ ...filters, date_to: toIsoFromLocal(event.target.value), page: 1 })}
+          />
+        </label>
+      </div>
+
+      <FilterCheckGroup
+        title="Servers"
+        options={options?.servers ?? []}
+        selected={filters.server_ids}
+        onToggle={(id) => onChange({ ...filters, server_ids: toggleValue(filters.server_ids, id), page: 1 })}
+      />
+      <FilterCheckGroup
+        title="Models"
+        options={options?.models ?? []}
+        selected={filters.model_names}
+        onToggle={(id) => onChange({ ...filters, model_names: toggleValue(filters.model_names, id), page: 1 })}
+      />
+      <FilterCheckGroup
+        title="Templates"
+        options={options?.templates ?? []}
+        selected={filters.template_ids}
+        onToggle={(id) => onChange({ ...filters, template_ids: toggleValue(filters.template_ids, id), page: 1 })}
+      />
+      <FilterCheckGroup
+        title="Status"
+        options={(options?.statuses ?? STATUS_OPTIONS.map((id) => ({ id, label: id, count: 0 })))}
+        selected={filters.statuses}
+        onToggle={(id) => onChange({ ...filters, statuses: toggleValue(filters.statuses, id) as ResultsStatus[], page: 1 })}
+      />
+
+      <div className="results-rail__group">
+        <h3>Score range</h3>
+        <label>
+          Min
+          <input
+            type="number"
+            min="0"
+            max="100"
+            value={filters.score_min ?? ''}
+            onChange={(event) => onChange({ ...filters, score_min: event.target.value ? Number(event.target.value) : null, page: 1 })}
+          />
+        </label>
+        <label>
+          Max
+          <input
+            type="number"
+            min="0"
+            max="100"
+            value={filters.score_max ?? ''}
+            onChange={(event) => onChange({ ...filters, score_max: event.target.value ? Number(event.target.value) : null, page: 1 })}
+          />
+        </label>
+      </div>
+
+      <div className="results-rail__group">
+        <h3>Iteration tag</h3>
+        <input
+          value={filters.tags.join(', ')}
+          placeholder="perf-bench-q3"
+          onChange={(event) => onChange({ ...filters, tags: event.target.value.split(',').map((tag) => tag.trim()).filter(Boolean), page: 1 })}
+        />
+        {options?.tags.length ? (
+          <div className="results-tag-list">
+            {options.tags.slice(0, 8).map((tag) => (
+              <button key={tag.id} type="button" className="ghost-button" onClick={() => onChange({ ...filters, tags: toggleValue(filters.tags, tag.id), page: 1 })}>
+                {tag.label}
+              </button>
+            ))}
+          </div>
+        ) : null}
+      </div>
+
+      <button type="button" className="ghost-button results-reset" onClick={onReset}>
+        Reset filters
+      </button>
+    </aside>
+  );
+}
+
+function FilterCheckGroup({
+  title,
+  options,
+  selected,
+  onToggle
+}: {
+  title: string;
+  options: Array<{ id: string; label: string; count: number; kind?: string }>;
+  selected: string[];
+  onToggle: (id: string) => void;
+}) {
+  return (
+    <div className="results-rail__group">
+      <h3>{title}</h3>
+      <div className="results-check-list">
+        {options.length === 0 ? <p className="muted">No options</p> : null}
+        {options.slice(0, 12).map((option) => (
+          <label key={option.id} className="results-check">
+            <input type="checkbox" checked={selected.includes(option.id)} onChange={() => onToggle(option.id)} />
+            <span>{option.label}</span>
+            <small>{option.kind ? `${option.kind} · ` : ''}{option.count}</small>
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function DashboardTab({ rows, dashboard, onOpenRun }: { rows: ResultsHistoryRow[]; dashboard: Awaited<ReturnType<typeof queryResultsView>>['dashboard']; onOpenRun: (id: string) => void }) {
+  const cards = dashboard.scorecards;
+  return (
+    <div className="results-main-stack">
+      <div className="results-scorecards">
+        <div className="results-scorecard"><span>Total runs</span><strong>{cards.total_runs}</strong></div>
+        <div className="results-scorecard"><span>Pass rate</span><strong>{formatNumber(cards.pass_rate, '%')}</strong></div>
+        <div className="results-scorecard"><span>Median latency</span><strong>{formatNumber(cards.median_latency_ms, ' ms')}</strong></div>
+        <div className="results-scorecard"><span>Median cost</span><strong>{cards.median_cost == null ? 'N/A' : `$${cards.median_cost.toFixed(6)}`}</strong></div>
+      </div>
+      <ResultsGraphPanel panel={seriesPanel('Pass-rate over time', 'pass_rate', dashboard.pass_rate_series)} />
+      <ResultsGraphPanel panel={seriesPanel('Latency distribution', 'latency_ms', dashboard.latency_series)} />
+      <section className="results-panel">
+        <header className="results-panel__header">
+          <h2>Recent runs</h2>
+          <span>{rows.length} visible</span>
+        </header>
+        <div className="results-mini-list">
+          {dashboard.recent_runs.length === 0 ? <p className="muted">No runs match the current filters.</p> : null}
+          {dashboard.recent_runs.map((run) => (
+            <button key={run.run_id} type="button" className="results-run-row" onClick={() => onOpenRun(run.run_id)}>
+              <StatusPill status={run.status} />
+              <span>{run.template_label}</span>
+              <strong>{run.model_name}</strong>
+              <small>{formatDate(run.started_at)}</small>
+            </button>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function LeaderboardTab({
+  entries,
+  loading,
+  sort,
+  group,
+  onSort,
+  onGroup,
+  onOpenEvaluation
+}: {
+  entries: LeaderboardEntry[];
+  loading: boolean;
+  sort: LeaderboardSort;
+  group: LeaderboardGroup;
+  onSort: (sort: LeaderboardSort) => void;
+  onGroup: (group: LeaderboardGroup) => void;
+  onOpenEvaluation: (id: string) => void;
+}) {
+  return (
+    <div className="results-main-stack">
+      <div className="results-toolbar">
+        <label>
+          Sort by
+          <select value={sort} onChange={(event) => onSort(event.target.value as LeaderboardSort)}>
+            <option value="score">Score</option>
+            <option value="latency">Latency p50</option>
+            <option value="cost">Cost</option>
+            <option value="pass_rate">Pass rate</option>
+          </select>
+        </label>
+        <label>
+          Group by
+          <select value={group} onChange={(event) => onGroup(event.target.value as LeaderboardGroup)}>
+            <option value="model">Model</option>
+            <option value="server">Server</option>
+            <option value="quantization">Quantization</option>
+          </select>
+        </label>
+      </div>
+      <div className="results-leader-list">
+        {loading ? <p className="muted">Loading leaderboard...</p> : null}
+        {!loading && entries.length === 0 ? <p className="muted">No evaluations match the selected filters.</p> : null}
+        {entries.map((entry) => (
+          <button
+            key={`${entry.group_by}:${entry.group_key}`}
+            type="button"
+            className="results-leader-row"
+            onClick={() => entry.representative_evaluation_id && onOpenEvaluation(entry.representative_evaluation_id)}
+          >
+            <span className="results-rank">{entry.rank}</span>
+            <span className="results-leader-row__main">
+              <strong>{entry.group_label}</strong>
+              <small>{entry.server_name ?? entry.server_id ?? 'server'} · {entry.quantization_level ?? 'quant unknown'} · {entry.evaluation_count} evals</small>
+            </span>
+            <MetricStrip label="Score" value={entry.score_percent} suffix="%" />
+            <MetricStrip label="Latency" value={entry.avg_latency_ms} suffix=" ms" inverse />
+            <MetricStrip label="Cost" value={entry.avg_estimated_cost} prefix="$" inverse />
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function MetricStrip({ label, value, suffix = '', prefix = '', inverse = false }: { label: string; value: number | null; suffix?: string; prefix?: string; inverse?: boolean }) {
+  const normalized = value == null ? 0 : inverse ? Math.max(0, 100 - Math.min(100, value)) : Math.min(100, value);
+  return (
+    <span className="results-metric-strip">
+      <small>{label}</small>
+      <strong>{value == null ? 'N/A' : `${prefix}${Number(value.toFixed(value >= 100 ? 0 : 2))}${suffix}`}</strong>
+      <i style={{ width: `${normalized}%` }} />
+    </span>
+  );
+}
+
+function HistoryTab({
+  rows,
+  page,
+  totalPages,
+  sortBy,
+  sortDir,
+  onSort,
+  onPage,
+  onOpenRun
+}: {
+  rows: ResultsHistoryRow[];
+  page: number;
+  totalPages: number;
+  sortBy: ResultsFilterState['sort_by'];
+  sortDir: ResultsFilterState['sort_dir'];
+  onSort: (sort: ResultsFilterState['sort_by']) => void;
+  onPage: (page: number) => void;
+  onOpenRun: (id: string) => void;
+}) {
+  const heading = (label: string, key: ResultsFilterState['sort_by']) => (
+    <button type="button" className="table-sort-button" onClick={() => onSort(key)}>
+      {label}{sortBy === key ? (sortDir === 'asc' ? ' ↑' : ' ↓') : ''}
+    </button>
+  );
+  return (
+    <section className="results-panel">
+      <div className="results-history-table-wrap">
+        <table className="results-history-table">
+          <thead>
+            <tr>
+              <th>{heading('Status', 'status')}</th>
+              <th>{heading('Started', 'started_at')}</th>
+              <th>{heading('Model · server', 'model')}</th>
+              <th>{heading('Template', 'template')}</th>
+              <th>{heading('Score', 'score')}</th>
+              <th>{heading('Latency', 'latency')}</th>
+              <th>{heading('Cost', 'cost')}</th>
+              <th>Tags</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.length === 0 ? (
+              <tr><td colSpan={8} className="empty-state-cell">No runs match the current filters.</td></tr>
+            ) : (
+              rows.map((row) => (
+                <tr key={row.run_id} onClick={() => onOpenRun(row.run_id)}>
+                  <td><StatusPill status={row.status} /></td>
+                  <td>{formatDate(row.started_at)}</td>
+                  <td><strong>{row.model_name}</strong><br /><small>{row.server_name}</small></td>
+                  <td>{row.template_label}</td>
+                  <td>{formatNumber(row.score, '%')}</td>
+                  <td>{formatNumber(row.latency_ms, ' ms')}</td>
+                  <td>{row.cost == null ? 'N/A' : `$${row.cost.toFixed(6)}`}</td>
+                  <td>{row.tags.join(', ') || 'N/A'}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+      <div className="results-pagination">
+        <button type="button" className="ghost-button" disabled={page <= 1} onClick={() => onPage(page - 1)}>Previous</button>
+        <span>Page {page} / {totalPages}</span>
+        <button type="button" className="ghost-button" disabled={page >= totalPages} onClick={() => onPage(page + 1)}>Next</button>
+      </div>
+    </section>
+  );
+}
+
+function StatusPill({ status }: { status: ResultsStatus }) {
+  return <span className={`results-status results-status--${status}`}>{status}</span>;
+}
+
+function DetailDrawer({
+  runDetail,
+  evaluationDetail,
+  loading,
+  onClose
+}: {
+  runDetail: ResultsRunDetail | null;
+  evaluationDetail: ResultsEvaluationDetail | null;
+  loading: boolean;
+  onClose: () => void;
+}) {
+  return (
+    <div className="results-drawer-backdrop" role="presentation" onClick={onClose}>
+      <aside className="results-drawer" role="dialog" aria-modal="true" onClick={(event) => event.stopPropagation()}>
+        <header className="results-drawer__header">
+          <button type="button" className="ghost-button" onClick={onClose}>Close</button>
+          <div>
+            <h2>{runDetail ? runDetail.run.run_id : evaluationDetail ? evaluationDetail.evaluation.id : 'Detail'}</h2>
+            <p>{runDetail ? 'Run detail' : 'Evaluation detail'}</p>
+          </div>
+        </header>
+        {loading ? <p className="muted">Loading detail...</p> : null}
+        {runDetail ? <RunDetailBody detail={runDetail} /> : null}
+        {evaluationDetail ? <EvaluationDetailBody detail={evaluationDetail} /> : null}
+      </aside>
+    </div>
+  );
+}
+
+function RunDetailBody({ detail }: { detail: ResultsRunDetail }) {
+  return (
+    <div className="results-drawer__body">
+      <section className="results-kv">
+        <div><span>Status</span><strong>{detail.run.status}</strong></div>
+        <div><span>Server</span><strong>{detail.run.server_name}</strong></div>
+        <div><span>Model</span><strong>{detail.run.model_name}</strong></div>
+        <div><span>Template</span><strong>{detail.run.template_label}</strong></div>
+        <div><span>Started</span><strong>{formatDate(detail.run.started_at)}</strong></div>
+        <div><span>Duration</span><strong>{formatNumber(detail.run.duration_ms, ' ms')}</strong></div>
+      </section>
+      <section>
+        <h3>Results</h3>
+        {detail.results.map((result) => (
+          <div key={String(result.id)} className="results-detail-block">
+            <strong>{String(result.template_label ?? result.test_id)}</strong>
+            <pre>{JSON.stringify(result, null, 2)}</pre>
+          </div>
+        ))}
+      </section>
+      <section>
+        <h3>Raw envelope</h3>
+        <pre>{JSON.stringify(detail.documents, null, 2)}</pre>
+      </section>
+    </div>
+  );
+}
+
+function EvaluationDetailBody({ detail }: { detail: ResultsEvaluationDetail }) {
+  return (
+    <div className="results-drawer__body">
+      <section className="results-kv">
+        <div><span>Model</span><strong>{detail.evaluation.model_name}</strong></div>
+        <div><span>Server</span><strong>{detail.server?.display_name ?? detail.evaluation.server_id}</strong></div>
+        <div><span>Score</span><strong>{formatNumber(detail.composite_score * 20, '%')}</strong></div>
+        <div><span>Latency</span><strong>{formatNumber(detail.evaluation.latency_ms, ' ms')}</strong></div>
+        <div><span>Tokens</span><strong>{formatNumber(detail.evaluation.total_tokens)}</strong></div>
+        <div><span>Cost</span><strong>{detail.evaluation.estimated_cost == null ? 'N/A' : `$${detail.evaluation.estimated_cost.toFixed(6)}`}</strong></div>
+      </section>
+      <section>
+        <h3>Prompt</h3>
+        <p>{detail.prompt?.text ?? 'N/A'}</p>
+      </section>
+      <section>
+        <h3>Answer</h3>
+        <pre>{detail.evaluation.answer_text}</pre>
+      </section>
+      <section>
+        <h3>Scores</h3>
+        <pre>{JSON.stringify({
+          accuracy: detail.evaluation.accuracy_score,
+          relevance: detail.evaluation.relevance_score,
+          coherence: detail.evaluation.coherence_score,
+          completeness: detail.evaluation.completeness_score,
+          helpfulness: detail.evaluation.helpfulness_score,
+          note: detail.evaluation.note
+        }, null, 2)}</pre>
+      </section>
+    </div>
+  );
+}
+
+export function ResultsUnified({ runCount }: { runCount: number | null }) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const activeTab = normalizeResultsTab(searchParams.get('tab')) as ResultsTab;
+  const filters = useMemo(() => decodeFilters(searchParams), [searchParams]);
+  const [data, setData] = useState<Awaited<ReturnType<typeof queryResultsView>> | null>(null);
+  const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [leaderboardLoading, setLeaderboardLoading] = useState(false);
+  const [leaderboardRefreshToken, setLeaderboardRefreshToken] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [leaderSort, setLeaderSort] = useState<LeaderboardSort>((searchParams.get('leader_sort') as LeaderboardSort) || 'score');
+  const [leaderGroup, setLeaderGroup] = useState<LeaderboardGroup>((searchParams.get('group_by') as LeaderboardGroup) || 'model');
+  const [runDetail, setRunDetail] = useState<ResultsRunDetail | null>(null);
+  const [evaluationDetail, setEvaluationDetail] = useState<ResultsEvaluationDetail | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const hasExplicitDateTo = searchParams.has('date_to');
+
+  useEffect(() => {
+    const next = new URLSearchParams(searchParams);
+    if (next.get('tab') !== activeTab) {
+      next.set('tab', activeTab);
+      setSearchParams(next, { replace: true });
+    }
+  }, [activeTab, searchParams, setSearchParams]);
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    setError(null);
+    queryResultsView(filters)
+      .then((response) => {
+        if (active) setData(response);
+      })
+      .catch((err) => {
+        if (active) setError(err instanceof Error ? err.message : 'Unable to load results');
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [filters]);
+
+  useEffect(() => {
+    if (activeTab !== 'leaderboard') {
+      return;
+    }
+    let active = true;
+    setLeaderboardLoading(true);
+    getLeaderboard({
+      date_from: filters.date_from,
+      date_to: hasExplicitDateTo ? filters.date_to : new Date().toISOString(),
+      tags: filters.tags,
+      server_ids: filters.server_ids,
+      model_names: filters.model_names,
+      score_min: filters.score_min,
+      score_max: filters.score_max,
+      sort_by: leaderSort,
+      group_by: leaderGroup
+    })
+      .then((response) => {
+        if (active) setLeaderboard(response.entries);
+      })
+      .catch(() => {
+        if (active) setLeaderboard([]);
+      })
+      .finally(() => {
+        if (active) setLeaderboardLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [activeTab, filters, hasExplicitDateTo, leaderGroup, leaderSort, leaderboardRefreshToken]);
+
+  useEffect(() => {
+    const refreshLeaderboard = () => setLeaderboardRefreshToken((current) => current + 1);
+    const clearLeaderboard = () => {
+      setLeaderboard([]);
+      refreshLeaderboard();
+    };
+    window.addEventListener('evaluations:saved', refreshLeaderboard);
+    window.addEventListener('database:cleared', clearLeaderboard);
+    return () => {
+      window.removeEventListener('evaluations:saved', refreshLeaderboard);
+      window.removeEventListener('database:cleared', clearLeaderboard);
+    };
+  }, []);
+
+  useEffect(() => {
+    const runId = searchParams.get('run');
+    const evaluationId = searchParams.get('evaluation');
+    if (!runId && !evaluationId) {
+      setRunDetail(null);
+      setEvaluationDetail(null);
+      return;
+    }
+    let active = true;
+    setDetailLoading(true);
+    setRunDetail(null);
+    setEvaluationDetail(null);
+    const request = runId ? getResultsRunDetail(runId).then((detail) => ({ run: detail })) : getResultsEvaluationDetail(evaluationId as string).then((detail) => ({ evaluation: detail }));
+    request
+      .then((detail) => {
+        if (!active) return;
+        if ('run' in detail) setRunDetail(detail.run);
+        if ('evaluation' in detail) setEvaluationDetail(detail.evaluation);
+      })
+      .finally(() => {
+        if (active) setDetailLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [searchParams]);
+
+  function updateFilters(nextFilters: ResultsFilterState) {
+    setSearchParams(writeFilters(searchParams, nextFilters));
+  }
+
+  function updateTab(tab: string) {
+    const next = new URLSearchParams(searchParams);
+    next.set('tab', tab);
+    next.delete('run');
+    next.delete('evaluation');
+    setSearchParams(next);
+  }
+
+  function resetFilters() {
+    const next = new URLSearchParams();
+    next.set('tab', activeTab);
+    setSearchParams(writeFilters(next, { ...decodeFilters(next), page: 1 }));
+  }
+
+  function openRun(id: string) {
+    const next = new URLSearchParams(searchParams);
+    next.set('run', id);
+    next.delete('evaluation');
+    setSearchParams(next);
+  }
+
+  function openEvaluation(id: string) {
+    const next = new URLSearchParams(searchParams);
+    next.set('evaluation', id);
+    next.delete('run');
+    setSearchParams(next);
+  }
+
+  function closeDrawer() {
+    const next = new URLSearchParams(searchParams);
+    next.delete('run');
+    next.delete('evaluation');
+    setSearchParams(next);
+  }
+
+  function exportView() {
+    const payload = JSON.stringify({ filters, data, leaderboard }, null, 2);
+    const url = URL.createObjectURL(new Blob([payload], { type: 'application/json' }));
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `aitestbench-results-${activeTab}.json`;
+    link.click();
+    URL.revokeObjectURL(url);
+  }
+
+  function shareView() {
+    void navigator.clipboard?.writeText(window.location.href);
+  }
+
+  const subtitle = `${data?.history.total ?? runCount ?? 0} runs · ${data?.filter_options.models.length ?? 0} models · selected range`;
+  return (
+    <>
+      <MergedPageHeader
+        title="Results"
+        subtitle={subtitle}
+        tabs={[
+          { id: 'dashboard', label: 'Dashboard', sub: String(data?.dashboard.scorecards.total_runs ?? runCount ?? 0) },
+          { id: 'leaderboard', label: 'Leaderboard' },
+          { id: 'history', label: 'History' }
+        ]}
+        activeTab={activeTab}
+        onTabChange={updateTab}
+        action={
+          <div className="results-header-actions">
+            <button type="button" className="ghost-button" onClick={exportView}>Export</button>
+            <button type="button" className="ghost-button" onClick={shareView}>Share view</button>
+          </div>
+        }
+      />
+      <section className="results-page">
+        <ResultsFilterRail
+          filters={filters}
+          options={data?.filter_options ?? null}
+          loading={loading}
+          onChange={updateFilters}
+          onReset={resetFilters}
+        />
+        <main className="results-main">
+          {error ? <div className="error">{error}</div> : null}
+          {loading && !data ? <p className="muted">Loading results...</p> : null}
+          {data && activeTab === 'dashboard' ? (
+            <DashboardTab rows={data.history.rows} dashboard={data.dashboard} onOpenRun={openRun} />
+          ) : null}
+          {data && activeTab === 'leaderboard' ? (
+            <LeaderboardTab
+              entries={leaderboard}
+              loading={leaderboardLoading}
+              sort={leaderSort}
+              group={leaderGroup}
+              onSort={(sort) => {
+                setLeaderSort(sort);
+                const next = new URLSearchParams(searchParams);
+                next.set('leader_sort', sort);
+                setSearchParams(next);
+              }}
+              onGroup={(group) => {
+                setLeaderGroup(group);
+                const next = new URLSearchParams(searchParams);
+                next.set('group_by', group);
+                setSearchParams(next);
+              }}
+              onOpenEvaluation={openEvaluation}
+            />
+          ) : null}
+          {data && activeTab === 'history' ? (
+            <HistoryTab
+              rows={data.history.rows}
+              page={data.history.page}
+              totalPages={data.history.total_pages}
+              sortBy={filters.sort_by}
+              sortDir={filters.sort_dir}
+              onSort={(sort) => updateFilters({ ...filters, sort_by: sort, sort_dir: filters.sort_by === sort && filters.sort_dir === 'asc' ? 'desc' : 'asc', page: 1 })}
+              onPage={(page) => updateFilters({ ...filters, page })}
+              onOpenRun={openRun}
+            />
+          ) : null}
+        </main>
+      </section>
+      {runDetail || evaluationDetail || detailLoading ? (
+        <DetailDrawer runDetail={runDetail} evaluationDetail={evaluationDetail} loading={detailLoading} onClose={closeDrawer} />
+      ) : null}
+    </>
+  );
+}

--- a/frontend/src/services/leaderboard-api.ts
+++ b/frontend/src/services/leaderboard-api.ts
@@ -13,6 +13,15 @@ export interface LeaderboardEntry {
   avg_latency_ms: number | null;
   avg_estimated_cost: number | null;
   evaluation_count: number;
+  score_percent: number;
+  pass_rate: number | null;
+  group_by: 'model' | 'server' | 'quantization';
+  group_key: string;
+  group_label: string;
+  server_id: string | null;
+  server_name: string | null;
+  quantization_level: string | null;
+  representative_evaluation_id: string | null;
 }
 
 export interface LeaderboardResponse {
@@ -20,6 +29,12 @@ export interface LeaderboardResponse {
     date_from: string | null;
     date_to: string | null;
     tags: string[];
+    server_ids: string[];
+    model_names: string[];
+    score_min: number | null;
+    score_max: number | null;
+    sort_by: string;
+    group_by: string;
   };
   entries: LeaderboardEntry[];
 }
@@ -28,6 +43,12 @@ export interface LeaderboardFilters {
   date_from?: string;
   date_to?: string;
   tags?: string[];
+  server_ids?: string[];
+  model_names?: string[];
+  score_min?: number | null;
+  score_max?: number | null;
+  sort_by?: 'score' | 'latency' | 'cost' | 'pass_rate';
+  group_by?: 'model' | 'server' | 'quantization';
 }
 
 export function getLeaderboard(filters: LeaderboardFilters = {}): Promise<LeaderboardResponse> {
@@ -35,6 +56,12 @@ export function getLeaderboard(filters: LeaderboardFilters = {}): Promise<Leader
   if (filters.date_from) params.set('date_from', filters.date_from);
   if (filters.date_to) params.set('date_to', filters.date_to);
   if (filters.tags && filters.tags.length > 0) params.set('tags', filters.tags.join(','));
+  if (filters.server_ids && filters.server_ids.length > 0) params.set('server_ids', filters.server_ids.join(','));
+  if (filters.model_names && filters.model_names.length > 0) params.set('model_names', filters.model_names.join(','));
+  if (filters.score_min != null) params.set('score_min', String(filters.score_min));
+  if (filters.score_max != null) params.set('score_max', String(filters.score_max));
+  if (filters.sort_by) params.set('sort_by', filters.sort_by);
+  if (filters.group_by) params.set('group_by', filters.group_by);
   const query = params.toString();
   return apiGet<LeaderboardResponse>(`/leaderboard${query ? `?${query}` : ''}`);
 }

--- a/frontend/src/services/results-view-api.ts
+++ b/frontend/src/services/results-view-api.ts
@@ -1,0 +1,120 @@
+import { apiGet, apiPost } from './api.js';
+
+export type ResultsTab = 'dashboard' | 'leaderboard' | 'history';
+export type ResultsStatus = 'pass' | 'fail' | 'partial' | 'streaming';
+export type ResultsSortBy = 'started_at' | 'status' | 'model' | 'server' | 'template' | 'score' | 'latency' | 'cost';
+export type ResultsSortDir = 'asc' | 'desc';
+
+export interface ResultsFilterState {
+  date_from?: string;
+  date_to?: string;
+  server_ids: string[];
+  model_names: string[];
+  template_ids: string[];
+  statuses: ResultsStatus[];
+  tags: string[];
+  score_min: number | null;
+  score_max: number | null;
+  sort_by: ResultsSortBy;
+  sort_dir: ResultsSortDir;
+  page: number;
+  page_size: number;
+}
+
+export interface ResultsHistoryRow {
+  run_id: string;
+  status: ResultsStatus;
+  started_at: string;
+  ended_at: string | null;
+  duration_ms: number | null;
+  server_id: string;
+  server_name: string;
+  model_name: string;
+  template_id: string;
+  template_label: string;
+  score: number | null;
+  latency_ms: number | null;
+  cost: number | null;
+  tags: string[];
+  result_count: number;
+}
+
+export interface ResultsDashboardView {
+  scorecards: {
+    total_runs: number;
+    pass_rate: number | null;
+    median_latency_ms: number | null;
+    median_cost: number | null;
+  };
+  pass_rate_series: Array<{ label: string; points: Array<{ x: string; y: number | null }> }>;
+  latency_series: Array<{ label: string; points: Array<{ x: string; y: number | null }> }>;
+  recent_runs: ResultsHistoryRow[];
+}
+
+export interface ResultsFilterOptions {
+  servers: Array<{ id: string; label: string; count: number }>;
+  models: Array<{ id: string; label: string; count: number }>;
+  templates: Array<{ id: string; label: string; kind: string; count: number }>;
+  statuses: Array<{ id: ResultsStatus; label: string; count: number }>;
+  tags: Array<{ id: string; label: string; count: number }>;
+  date_bounds: { min: string | null; max: string | null };
+}
+
+export interface ResultsViewResponse {
+  filters_applied: ResultsFilterState;
+  filter_options: ResultsFilterOptions;
+  dashboard: ResultsDashboardView;
+  history: {
+    rows: ResultsHistoryRow[];
+    page: number;
+    page_size: number;
+    total: number;
+    total_pages: number;
+  };
+}
+
+export interface ResultsRunDetail {
+  run: ResultsHistoryRow;
+  raw_run: Record<string, unknown>;
+  results: Array<Record<string, unknown>>;
+  documents: Array<Record<string, unknown>>;
+}
+
+export interface ResultsEvaluationDetail {
+  evaluation: {
+    id: string;
+    prompt_id: string;
+    model_name: string;
+    server_id: string;
+    inference_config: Record<string, unknown>;
+    answer_text: string;
+    input_tokens: number | null;
+    output_tokens: number | null;
+    total_tokens: number | null;
+    latency_ms: number | null;
+    word_count: number | null;
+    estimated_cost: number | null;
+    accuracy_score: number;
+    relevance_score: number;
+    coherence_score: number;
+    completeness_score: number;
+    helpfulness_score: number;
+    note: string | null;
+    created_at: string;
+  };
+  prompt: { id: string; text: string; tags: string[]; created_at: string } | null;
+  server: { server_id: string; display_name: string } | null;
+  composite_score: number;
+}
+
+export function queryResultsView(filters: Partial<ResultsFilterState>): Promise<ResultsViewResponse> {
+  return apiPost<ResultsViewResponse>('/results-view/query', filters);
+}
+
+export function getResultsRunDetail(runId: string): Promise<ResultsRunDetail> {
+  return apiGet<ResultsRunDetail>(`/results-view/runs/${encodeURIComponent(runId)}`);
+}
+
+export function getResultsEvaluationDetail(evaluationId: string): Promise<ResultsEvaluationDetail> {
+  return apiGet<ResultsEvaluationDetail>(`/evaluations/${encodeURIComponent(evaluationId)}`);
+}

--- a/frontend/src/styles/dashboard-results.css
+++ b/frontend/src/styles/dashboard-results.css
@@ -74,3 +74,404 @@
     grid-template-columns: 1fr;
   }
 }
+
+.results-page {
+  max-width: 1440px;
+  margin: 0 auto;
+  padding: 20px 24px 64px;
+  display: grid;
+  grid-template-columns: 240px minmax(0, 1fr);
+  gap: 20px;
+}
+
+.results-header-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.ghost-button {
+  border: 1px solid var(--paper-7);
+  background: var(--paper-1);
+  color: var(--ink-8);
+  border-radius: 8px;
+  padding: 8px 12px;
+  font-size: 12px;
+}
+
+.ghost-button:hover {
+  background: var(--paper-3);
+}
+
+.results-rail {
+  position: sticky;
+  top: 20px;
+  align-self: start;
+  display: grid;
+  gap: 14px;
+  padding: 14px;
+  background: var(--paper-1);
+  border: 1px solid var(--paper-7);
+  border-radius: 8px;
+}
+
+.results-rail__group {
+  display: grid;
+  gap: 8px;
+}
+
+.results-rail__group h3 {
+  margin: 0;
+  color: var(--ink-5);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.results-range-buttons,
+.results-tag-list,
+.results-toolbar,
+.results-pagination {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.results-check-list {
+  display: grid;
+  gap: 6px;
+  max-height: 190px;
+  overflow: auto;
+}
+
+.results-check {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  color: var(--ink-7);
+  font-size: 12px;
+}
+
+.results-check span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.results-check small {
+  color: var(--ink-3);
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+
+.results-reset {
+  width: 100%;
+  justify-content: center;
+}
+
+.results-main,
+.results-main-stack {
+  min-width: 0;
+  display: grid;
+  gap: 16px;
+}
+
+.results-scorecards {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.results-scorecard,
+.results-panel,
+.results-leader-row {
+  background: var(--paper-1);
+  border: 1px solid var(--paper-7);
+  border-radius: 8px;
+}
+
+.results-scorecard {
+  padding: 14px;
+  display: grid;
+  gap: 8px;
+}
+
+.results-scorecard span,
+.results-panel__header span,
+.results-metric-strip small {
+  color: var(--ink-3);
+  font-size: 11px;
+}
+
+.results-scorecard strong {
+  font-size: 24px;
+  font-weight: 600;
+}
+
+.results-panel {
+  padding: 14px;
+}
+
+.results-panel__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.results-panel__header h2 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.results-mini-list,
+.results-leader-list {
+  display: grid;
+  gap: 8px;
+}
+
+.results-run-row {
+  width: 100%;
+  display: grid;
+  grid-template-columns: auto minmax(140px, 1fr) minmax(120px, 0.8fr) auto;
+  gap: 10px;
+  align-items: center;
+  border: 1px solid var(--paper-7);
+  border-radius: 8px;
+  background: var(--paper-2);
+  color: var(--ink-8);
+  text-align: left;
+}
+
+.results-run-row small {
+  color: var(--ink-3);
+}
+
+.results-status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 64px;
+  border-radius: 999px;
+  padding: 3px 8px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.results-status--pass {
+  background: #ddf2e4;
+  color: #246b3d;
+}
+
+.results-status--fail {
+  background: #f7dedb;
+  color: #93403d;
+}
+
+.results-status--partial {
+  background: #f8edc7;
+  color: #7a5b11;
+}
+
+.results-status--streaming {
+  background: #dfeaf7;
+  color: #315f8c;
+}
+
+.results-toolbar {
+  justify-content: flex-end;
+}
+
+.results-toolbar label {
+  min-width: 180px;
+}
+
+.results-leader-row {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 54px minmax(220px, 1fr) repeat(3, minmax(110px, 0.36fr));
+  gap: 12px;
+  align-items: center;
+  padding: 12px;
+  color: var(--ink-9);
+  text-align: left;
+}
+
+.results-rank {
+  font-family: var(--font-mono);
+  font-size: 22px;
+  font-weight: 700;
+}
+
+.results-leader-row__main {
+  display: grid;
+  gap: 4px;
+}
+
+.results-leader-row__main small {
+  color: var(--ink-3);
+  font-size: 11px;
+}
+
+.results-metric-strip {
+  display: grid;
+  gap: 5px;
+}
+
+.results-metric-strip strong {
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.results-metric-strip i {
+  display: block;
+  height: 4px;
+  border-radius: 999px;
+  background: var(--gold-3);
+}
+
+.results-history-table-wrap {
+  overflow-x: auto;
+}
+
+.results-history-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.results-history-table th,
+.results-history-table td {
+  border-bottom: 1px solid var(--paper-7);
+  padding: 9px 8px;
+  text-align: left;
+  vertical-align: middle;
+  font-size: 12px;
+}
+
+.results-history-table th {
+  position: sticky;
+  top: 0;
+  background: var(--paper-1);
+  z-index: 1;
+}
+
+.results-history-table tbody tr {
+  cursor: pointer;
+}
+
+.results-history-table tbody tr:hover {
+  background: var(--paper-2);
+}
+
+.table-sort-button {
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: var(--ink-5);
+  font-size: 11px;
+}
+
+.results-pagination {
+  justify-content: flex-end;
+  margin-top: 12px;
+}
+
+.results-drawer-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 20;
+  display: flex;
+  justify-content: flex-end;
+  background: rgba(0, 0, 0, 0.38);
+}
+
+.results-drawer {
+  width: min(640px, 100vw);
+  height: 100vh;
+  overflow: auto;
+  background: var(--paper-1);
+  box-shadow: -12px 0 30px rgba(0, 0, 0, 0.18);
+}
+
+.results-drawer__header {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--paper-7);
+  background: var(--paper-1);
+}
+
+.results-drawer__header h2 {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 16px;
+}
+
+.results-drawer__header p {
+  margin: 2px 0 0;
+  color: var(--ink-3);
+  font-size: 12px;
+}
+
+.results-drawer__body {
+  display: grid;
+  gap: 14px;
+  padding: 18px;
+}
+
+.results-kv {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.results-kv div,
+.results-detail-block {
+  padding: 10px;
+  border: 1px solid var(--paper-7);
+  border-radius: 8px;
+  background: var(--paper-2);
+}
+
+.results-kv span {
+  display: block;
+  color: var(--ink-3);
+  font-size: 11px;
+  margin-bottom: 4px;
+}
+
+.results-drawer pre {
+  max-height: 320px;
+  overflow: auto;
+  padding: 12px;
+  border-radius: 8px;
+  background: var(--ink-9);
+  color: var(--paper-1);
+  font-size: 11px;
+}
+
+@media (max-width: 1100px) {
+  .results-page {
+    grid-template-columns: 1fr;
+  }
+
+  .results-rail {
+    position: static;
+  }
+
+  .results-scorecards,
+  .results-leader-row,
+  .results-run-row {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/tests/e2e/leaderboard.spec.ts
+++ b/frontend/tests/e2e/leaderboard.spec.ts
@@ -64,37 +64,34 @@ async function getOrCreateServer(request: APIRequestContext): Promise<string> {
 }
 
 test.describe('Leaderboard page — empty state', () => {
-  test('shows informative empty state message and CTA when no evaluations', async ({ page }) => {
+  test('renders the merged Results leaderboard tab and shared filter rail when no evaluations match', async ({ page }) => {
     await page.goto('/results?tab=leaderboard');
-    await expect(page.getByRole('heading', { name: 'Leaderboard' })).toBeVisible();
-    await expect(page.getByText('No evaluations yet.')).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Create your first evaluation' })).toBeVisible();
-  });
-
-  test('CTA navigates to Evaluate page', async ({ page }) => {
-    await page.goto('/results?tab=leaderboard');
-    const cta = page.getByRole('button', { name: 'Create your first evaluation' });
-    if (await cta.isVisible()) {
-      await cta.click();
-      await expect(page.getByRole('heading', { name: 'Evaluate' })).toBeVisible();
-    }
+    await expect(page.getByRole('heading', { name: 'Results' })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Leaderboard' })).toHaveAttribute('aria-selected', 'true');
+    await expect(page.locator('[aria-label="Results filters"]')).toBeVisible();
+    await expect(page.getByLabel('Sort by')).toBeVisible();
+    await expect(page.getByLabel('Group by')).toBeVisible();
+    await expect(page.getByText('No evaluations match the selected filters.')).toBeVisible();
   });
 });
 
 // T035 [US2] — populated state
 test.describe('Leaderboard page — populated state', () => {
-  test('shows model entry after evaluation is saved', async ({ page, request }) => {
+  test('shows a ranked model row after evaluation is saved and opens the evaluation drawer', async ({ page, request }) => {
     const serverId = await getOrCreateServer(request);
     await seedEvaluation(request, { serverId, modelName: 'e2e-model-leaderboard' });
 
     await page.goto('/results?tab=leaderboard');
 
-    await expect(
-      page.locator('.leaderboard-table tbody').getByText('e2e-model-leaderboard')
-    ).toBeVisible({ timeout: 5000 });
+    const row = page.locator('.results-leader-row').filter({ hasText: 'e2e-model-leaderboard' });
+    await expect(row).toBeVisible({ timeout: 5000 });
+    await expect(row.getByText('Score')).toBeVisible();
+    await row.click();
+    await expect(page.getByText('Evaluation detail')).toBeVisible();
+    await expect(page.getByText('Test answer')).toBeVisible();
   });
 
-  test('SC-003: leaderboard updates within 3s after evaluations:saved event', async ({ page, request }) => {
+  test('leaderboard updates within 3s after evaluations:saved event', async ({ page, request }) => {
     const serverId = await getOrCreateServer(request);
 
     await page.goto('/results?tab=leaderboard');
@@ -106,7 +103,7 @@ test.describe('Leaderboard page — populated state', () => {
 
     await page.evaluate(() => window.dispatchEvent(new CustomEvent('evaluations:saved')));
     await expect(
-      page.locator('.leaderboard-table tbody').getByText(modelName)
+      page.locator('.results-leader-row').filter({ hasText: modelName })
     ).toBeVisible({ timeout: 3000 });
 
     const elapsed = Date.now() - t0;
@@ -116,42 +113,41 @@ test.describe('Leaderboard page — populated state', () => {
 
 // T039 [US3] — filter test cases
 test.describe('Leaderboard filters', () => {
-  test('apply date range — only in-range evaluations reflected', async ({ page, request }) => {
+  test('shared date range rail filters evaluation-backed leaderboard entries', async ({ page, request }) => {
     const serverId = await getOrCreateServer(request);
+    const modelName = `e2e-filter-rail-${Date.now()}`;
+    await seedEvaluation(request, { serverId, modelName });
 
     await page.goto('/results?tab=leaderboard');
+    await expect(page.locator('.results-leader-row').filter({ hasText: modelName })).toBeVisible();
 
-    await page.locator('input[type="date"]').first().fill('2030-01-01');
-    await page.locator('input[type="date"]').last().fill('2030-12-31');
-    await page.getByRole('button', { name: 'Apply' }).click();
-
+    await page.getByLabel('From').fill('2030-01-01T00:00');
+    await page.getByLabel('To').fill('2030-12-31T23:59');
     await expect(page.getByText('No evaluations match the selected filters.')).toBeVisible({ timeout: 3000 });
   });
 
-  test('clear filters — restores full unfiltered results within 1s (SC-005)', async ({ page, request }) => {
+  test('Reset filters restores the leaderboard view within 1s', async ({ page, request }) => {
     const serverId = await getOrCreateServer(request);
     const modelName = `e2e-filter-clear-${Date.now()}`;
     await seedEvaluation(request, { serverId, modelName });
 
     await page.goto('/results?tab=leaderboard');
 
-    await page.locator('input[type="date"]').first().fill('2030-01-01');
-    await page.getByRole('button', { name: 'Apply' }).click();
+    await page.getByLabel('From').fill('2030-01-01T00:00');
+    await page.getByLabel('To').fill('2030-12-31T23:59');
     await expect(page.getByText('No evaluations match the selected filters.')).toBeVisible();
 
     const t0 = Date.now();
-    await page.getByRole('button', { name: 'Clear' }).click();
-    await expect(page.locator('.leaderboard-table')).toBeVisible({ timeout: 1000 });
+    await page.getByRole('button', { name: 'Reset filters' }).click();
+    await expect(page.locator('.results-leader-row').filter({ hasText: modelName })).toBeVisible({ timeout: 1000 });
     expect(Date.now() - t0).toBeLessThan(1000);
   });
 
-  test('filter-specific empty state is distinct from generic empty state', async ({ page }) => {
+  test('sort and group controls are URL-backed on the merged leaderboard tab', async ({ page }) => {
     await page.goto('/results?tab=leaderboard');
-
-    await page.locator('input[type="date"]').first().fill('2030-01-01');
-    await page.getByRole('button', { name: 'Apply' }).click();
-
-    await expect(page.getByText('No evaluations match the selected filters.')).toBeVisible();
-    await expect(page.getByText('No evaluations yet.')).not.toBeVisible();
+    await page.getByLabel('Sort by').selectOption('latency');
+    await expect(page).toHaveURL(/leader_sort=latency/);
+    await page.getByLabel('Group by').selectOption('quantization');
+    await expect(page).toHaveURL(/group_by=quantization/);
   });
 });

--- a/frontend/tests/e2e/results-dashboard.spec.ts
+++ b/frontend/tests/e2e/results-dashboard.spec.ts
@@ -1,99 +1,132 @@
 import { expect, test } from '@playwright/test';
 
-test('results dashboard filter and render flow', async ({ page }) => {
-  await page.route('**/dashboard-results/filters**', async (route) => {
+function resultsViewPayload(empty = false) {
+  const rows = empty
+    ? []
+    : [
+        {
+          run_id: 'run-dashboard-1',
+          status: 'pass',
+          started_at: '2026-02-08T00:00:00.000Z',
+          ended_at: '2026-02-08T00:00:10.000Z',
+          duration_ms: 10000,
+          server_id: 'srv-local',
+          server_name: 'Local Server',
+          model_name: 'mistral:latest',
+          template_id: 'latency-benchmark',
+          template_label: 'latency-benchmark',
+          score: 100,
+          latency_ms: 80,
+          cost: 0.001,
+          tags: ['nightly'],
+          result_count: 1
+        }
+      ];
+
+  return {
+    filters_applied: {
+      date_from: '2026-02-01T00:00:00.000Z',
+      date_to: '2026-02-09T00:00:00.000Z',
+      server_ids: [],
+      model_names: [],
+      template_ids: [],
+      statuses: [],
+      tags: [],
+      score_min: null,
+      score_max: null,
+      sort_by: 'started_at',
+      sort_dir: 'desc',
+      page: 1,
+      page_size: 50
+    },
+    filter_options: {
+      servers: [{ id: 'srv-local', label: 'Local Server', count: 1 }],
+      models: [{ id: 'mistral:latest', label: 'mistral:latest', count: 1 }],
+      templates: [{ id: 'latency-benchmark', label: 'latency-benchmark', kind: 'JSON', count: 1 }],
+      statuses: [{ id: 'pass', label: 'pass', count: 1 }],
+      tags: [{ id: 'nightly', label: 'nightly', count: 1 }],
+      date_bounds: {
+        min: empty ? null : '2026-02-08T00:00:00.000Z',
+        max: empty ? null : '2026-02-08T00:00:00.000Z'
+      }
+    },
+    dashboard: {
+      scorecards: {
+        total_runs: rows.length,
+        pass_rate: rows.length ? 100 : null,
+        median_latency_ms: rows.length ? 80 : null,
+        median_cost: rows.length ? 0.001 : null
+      },
+      pass_rate_series: rows.length
+        ? [{ label: 'mistral:latest', points: [{ x: '2026-02-08', y: 100 }] }]
+        : [],
+      latency_series: rows.length
+        ? [{ label: 'mistral:latest', points: [{ x: '2026-02-08T00:00:00.000Z', y: 80 }] }]
+        : [],
+      recent_runs: rows
+    },
+    history: {
+      rows,
+      page: 1,
+      page_size: 50,
+      total: rows.length,
+      total_pages: 1
+    }
+  };
+}
+
+test('merged Results dashboard filter and render flow', async ({ page }) => {
+  await page.route('**/results-view/query', async (route) => {
+    const payload = route.request().postDataJSON() as { date_from?: string };
+    const isFutureRange = payload.date_from
+      ? Date.parse(payload.date_from) >= Date.parse('2029-12-31T00:00:00.000Z')
+      : false;
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({
-        runtimes: [{ key: 'Local Server', label: 'Local Server', count: 2 }],
-        server_versions: [{ key: '1.0.0', label: '1.0.0', count: 2 }],
-        models: [{ model_id: 'mistral:latest', display_name: 'Mistral', count: 2 }],
-        tests: [
-          { test_id: 'latency-benchmark', label: 'latency-benchmark', count: 1, has_performance_data: true },
-          { test_id: 'metadata-check', label: 'metadata-check', count: 1, has_performance_data: false }
-        ],
-        date_bounds: {
-          min: '2026-02-01T00:00:00.000Z',
-          max: '2026-02-09T00:00:00.000Z'
-        },
-        default_window_days: 15
-      })
+      body: JSON.stringify(resultsViewPayload(isFutureRange))
     });
   });
 
-  await page.route('**/dashboard-results/query', async (route) => {
-    const request = route.request();
-    const payload = request.postDataJSON() as { view_mode?: string; group_keys?: string[] };
-
-    const grouped = payload.view_mode === 'grouped' && (payload.group_keys?.length ?? 0) > 0;
+  await page.route('**/results-view/runs/run-dashboard-1', async (route) => {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
       body: JSON.stringify({
-        filters_applied: {
-          runtime_keys: ['Local Server'],
-          server_versions: ['1.0.0'],
-          model_ids: ['mistral:latest'],
-          test_ids: ['latency-benchmark', 'metadata-check'],
-          date_from: '2026-02-01T00:00:00.000Z',
-          date_to: '2026-02-09T00:00:00.000Z',
-          view_mode: grouped ? 'grouped' : 'separate',
-          group_keys: grouped ? ['runtime:ollama|model:mistral:latest|metric:latency_ms'] : [],
-          cursor: null,
-          limit: 100
-        },
-        panels: [
+        run: resultsViewPayload().history.rows[0],
+        raw_run: { id: 'run-dashboard-1', status: 'completed' },
+        results: [
           {
-            panel_id: grouped ? 'grouped:1' : 'panel-1',
-            presentation_type: 'performance_graph',
-            title: grouped ? 'Grouped: latency-benchmark' : 'latency-benchmark',
-            runtime_key: 'ollama',
-            server_version: '1.0.0',
-            model_id: 'mistral:latest',
-            test_ids: ['latency-benchmark'],
-            metric_keys: ['latency_ms'],
-            unit_keys: [],
-            grouped,
-            series: [{ label: 'latency_ms', points: [{ x: '2026-02-08T00:00:00.000Z', y: 80 }] }],
-            missing_fields: []
-          },
-          {
-            panel_id: 'panel-2',
-            presentation_type: 'data_table',
-            title: 'metadata-check',
-            runtime_key: 'ollama',
-            server_version: '1.0.0',
-            model_id: 'mistral:latest',
-            test_ids: ['metadata-check'],
-            metric_keys: [],
-            unit_keys: [],
-            grouped: false,
-            rows: [{ test_result_id: 'r1', status_code: 200, response: 'ok' }],
-            missing_fields: []
+            id: 'result-dashboard-1',
+            test_id: 'latency-benchmark',
+            template_label: 'latency-benchmark',
+            verdict: 'pass',
+            metrics: { latency_ms: 80 }
           }
         ],
-        page: { cursor: null, has_more: false, total_panels_estimate: 2 },
-        stats: { raw_results_scanned: 2, raw_results_returned: 2, query_duration_ms: 20, truncated: false },
-        warnings: []
+        documents: [{ summary: { passed_steps: 1, failed_steps: 0 } }]
       })
     });
   });
 
   await page.goto('/results?tab=dashboard');
 
-  await expect(page.getByRole('heading', { name: 'Results Dashboard' })).toBeVisible();
-  await expect(page.getByLabel('Runtime')).toBeVisible();
-  await expect(page.getByText('Query duration:')).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Results' })).toBeVisible();
+  await expect(page.getByRole('tab', { name: /Dashboard/ })).toHaveAttribute('aria-selected', 'true');
+  await expect(page.locator('[aria-label="Results filters"]')).toBeVisible();
+  await expect(page.getByText('Total runs')).toBeVisible();
+  await expect(page.getByText('Pass rate')).toBeVisible();
   await expect(page.locator('.dashboard-panel')).toHaveCount(2);
-  await expect(page.locator('[data-panel-type="graph"]')).toBeVisible();
-  await expect(page.locator('[data-panel-type="table"]')).toBeVisible();
+  await expect(page.locator('[data-panel-type="graph"]').first()).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Recent runs' })).toBeVisible();
 
-  await page.getByLabel('View Mode').selectOption('grouped');
-  await page
-    .getByLabel('Group Keys (comma-separated)')
-    .fill('runtime:ollama|model:mistral:latest|metric:latency_ms');
+  const recentRun = page.locator('.results-run-row').filter({ hasText: 'latency-benchmark' });
+  await expect(recentRun).toBeVisible();
+  await recentRun.click();
+  await expect(page.getByText('Run detail')).toBeVisible();
+  await expect(page.getByText('run-dashboard-1')).toBeVisible();
 
-  await expect(page.getByLabel('Metric')).toHaveValue('latency_ms');
-  await expect(page.locator('[data-panel-type="graph"]').getByRole('heading', { name: 'latency_ms' })).toBeVisible();
+  await page.getByRole('button', { name: 'Close' }).click();
+  await page.getByLabel('From').fill('2030-01-01T00:00');
+  await expect(page.getByText('No runs match the current filters.')).toBeVisible();
 });


### PR DESCRIPTION
- Added react-router-dom and wrapped the frontend in BrowserRouter.
- Replaced the old 8-icon/state-machine shell with a 220px expanded 5-item sidebar: Catalog, Templates, Run, Results, Evaluate.
 - Added Sidebar, SubTabBar, MergedPageHeader, and route helpers.
- Added URL-backed routes and redirects:
- /catalog?tab=servers|models
- /results?tab=dashboard|leaderboard|history
- /run, /run?legacy=compare
- legacy redirects for /servers, /models, /run-single, /compare, /dashboard, /leaderboard
- Moved model details into Catalog query params with encoded serverId/modelId.
- Removed global CPU/memory/GPU/LLM metric cards; sidebar now shows Backend, Database, and server health/count.
- Updated E2E specs away from old nav-button assumptions and added a focused navigation-shell.spec.ts.
- Updated CHANGELOG.md.
- Ignored docs-only design wireframe JSX from lint.
- Removed old standalone Leaderboard assumptions: Leaderboard page heading, CTA, date Apply/Clear, .leaderboard-table.
- Updated assertions to the merged Results shell: Results heading, active Leaderboard sub-tab, shared filter rail, sort/group controls.
- Updated populated checks to use .results-leader-row.
- Added drawer coverage by clicking a leaderboard row and expecting Evaluation detail.
- Updated filter tests to use the shared rail From / To datetime filters and Reset filters.
- Kept valid behavior: evaluations:saved now refreshes the merged leaderboard tab.