### PR TITLE
fix(tests): tests isolated from DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 
 ### Fixed
 
+- Backend Vitest runs now ignore production SQLite database defaults, use a dedicated `backend-test.sqlite` by default, and fail fast if a backend test tries to open the production DB.
 - Backend proxy support now sends plain HTTP outbound requests to the configured proxy in absolute-form while retaining CONNECT tunneling for HTTPS targets, routes backend outbound fetches through the configured Undici dispatcher directly, and no longer lets process-level `NO_PROXY` bypass backend proxy routing unless `AITESTBENCH_INFERENCE_NO_PROXY` is set.
 - Inference server API responses now mask stored raw auth tokens and expose only token presence metadata.
 

--- a/backend/src/models/db.ts
+++ b/backend/src/models/db.ts
@@ -6,6 +6,7 @@ import Database from 'better-sqlite3';
 const moduleDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(moduleDir, '..', '..', '..');
 const DEFAULT_DB_PATH = path.join(repoRoot, 'backend', 'data', 'db', 'aitestbench.sqlite');
+const DEFAULT_BACKEND_TEST_DB_PATH = path.join(repoRoot, 'backend', 'data', 'db', 'backend-test.sqlite');
 
 let dbInstance: Database.Database | null = null;
 
@@ -37,13 +38,18 @@ export function getDb(): Database.Database {
 
 export function resolvedDbPath(): string {
   const configuredPath = process.env.AITESTBENCH_DB_PATH?.trim();
-  const isSpecialPath = configuredPath === ':memory:' || configuredPath?.startsWith('file:');
-  if (isSpecialPath) {
-    return configuredPath!;
+  const isBackendTest = isBackendTestRun();
+  if (configuredPath) {
+    const dbPath = resolveConfiguredDbPath(configuredPath);
+    assertBackendTestDbIsSafe(dbPath, isBackendTest);
+    return dbPath;
   }
-  return configuredPath
-    ? (path.isAbsolute(configuredPath) ? configuredPath : path.resolve(repoRoot, configuredPath))
-    : DEFAULT_DB_PATH;
+  if (isBackendTest) {
+    const dbPath = resolveBackendTestDbPath();
+    assertBackendTestDbIsSafe(dbPath, isBackendTest);
+    return dbPath;
+  }
+  return DEFAULT_DB_PATH;
 }
 
 export function runSchema(sql: string): void {
@@ -57,4 +63,32 @@ export function resetDbInstance(): void {
   }
   dbInstance.close();
   dbInstance = null;
+}
+
+function isBackendTestRun(): boolean {
+  return process.env.AITESTBENCH_BACKEND_TESTS === '1' || process.env.VITEST === 'true';
+}
+
+function resolveBackendTestDbPath(): string {
+  const configuredPath = process.env.AITESTBENCH_BACKEND_TEST_DB_PATH?.trim();
+  return configuredPath ? resolveConfiguredDbPath(configuredPath) : DEFAULT_BACKEND_TEST_DB_PATH;
+}
+
+function resolveConfiguredDbPath(configuredPath: string): string {
+  if (configuredPath === ':memory:' || configuredPath.startsWith('file:')) {
+    return configuredPath;
+  }
+  return path.isAbsolute(configuredPath) ? configuredPath : path.resolve(repoRoot, configuredPath);
+}
+
+function assertBackendTestDbIsSafe(dbPath: string, isBackendTest: boolean): void {
+  if (!isBackendTest || dbPath === ':memory:' || dbPath.startsWith('file:')) {
+    return;
+  }
+  if (dbPath === DEFAULT_DB_PATH) {
+    throw new Error(
+      `Backend tests cannot use the production SQLite database at ${DEFAULT_DB_PATH}. ` +
+        'Set BACKEND_TEST_DB_PATH or AITESTBENCH_DB_PATH to a dedicated test database.'
+    );
+  }
 }

--- a/backend/tests/setup-db.ts
+++ b/backend/tests/setup-db.ts
@@ -1,0 +1,6 @@
+import { applyBackendTestDbEnv, removeSqliteFiles } from './support/backend-test-db.js';
+
+export default function setupBackendTestDb(): void {
+  const dbPath = applyBackendTestDbEnv();
+  removeSqliteFiles(dbPath);
+}

--- a/backend/tests/setup-env.ts
+++ b/backend/tests/setup-env.ts
@@ -1,0 +1,3 @@
+import { applyBackendTestDbEnv } from './support/backend-test-db.js';
+
+applyBackendTestDbEnv();

--- a/backend/tests/support/backend-test-db.ts
+++ b/backend/tests/support/backend-test-db.ts
@@ -1,0 +1,39 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(dirname, '../../..');
+const DEFAULT_BACKEND_TEST_DB_PATH = path.resolve(repoRoot, 'backend', 'data', 'db', 'backend-test.sqlite');
+
+function resolveFromRepo(value: string | undefined, fallback: string): string {
+  if (!value) {
+    return fallback;
+  }
+  return path.isAbsolute(value) ? value : path.resolve(repoRoot, value);
+}
+
+export function backendTestDbPath(): string {
+  return resolveFromRepo(
+    process.env.BACKEND_TEST_DB_PATH ?? process.env.AITESTBENCH_BACKEND_TEST_DB_PATH,
+    DEFAULT_BACKEND_TEST_DB_PATH
+  );
+}
+
+export function applyBackendTestDbEnv(): string {
+  const dbPath = backendTestDbPath();
+  process.env.AITESTBENCH_BACKEND_TESTS = '1';
+  process.env.AITESTBENCH_BACKEND_TEST_DB_PATH = dbPath;
+  process.env.AITESTBENCH_DB_PATH = dbPath;
+  return dbPath;
+}
+
+export function removeSqliteFiles(dbPath: string): void {
+  for (const ext of ['', '-shm', '-wal']) {
+    try {
+      fs.unlinkSync(dbPath + ext);
+    } catch {
+      // File did not exist.
+    }
+  }
+}

--- a/backend/tests/unit/db-safety.test.ts
+++ b/backend/tests/unit/db-safety.test.ts
@@ -1,0 +1,45 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { resolvedDbPath } from '../../src/models/db.js';
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(dirname, '../../..');
+const productionDbPath = path.resolve(repoRoot, 'backend', 'data', 'db', 'aitestbench.sqlite');
+const backendTestDbPath = path.resolve(repoRoot, 'backend', 'data', 'db', 'backend-test.sqlite');
+const dbEnvKeys = [
+  'AITESTBENCH_BACKEND_TESTS',
+  'AITESTBENCH_DB_PATH',
+  'AITESTBENCH_BACKEND_TEST_DB_PATH'
+] as const;
+const originalEnv = Object.fromEntries(dbEnvKeys.map((key) => [key, process.env[key]]));
+
+describe('backend test database safety', () => {
+  afterEach(() => {
+    for (const key of dbEnvKeys) {
+      const value = originalEnv[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
+  it('falls back to the dedicated backend test database during backend tests', () => {
+    process.env.AITESTBENCH_BACKEND_TESTS = '1';
+    delete process.env.AITESTBENCH_DB_PATH;
+    delete process.env.AITESTBENCH_BACKEND_TEST_DB_PATH;
+
+    expect(resolvedDbPath()).toBe(backendTestDbPath);
+  });
+
+  it('rejects the production SQLite database during backend tests', () => {
+    process.env.AITESTBENCH_BACKEND_TESTS = '1';
+    process.env.AITESTBENCH_DB_PATH = productionDbPath;
+
+    expect(() => resolvedDbPath()).toThrow('Backend tests cannot use the production SQLite database');
+  });
+});

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from 'vitest/config';
 
+import { applyBackendTestDbEnv } from './tests/support/backend-test-db.js';
+
+applyBackendTestDbEnv();
+
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['tests/**/*.{test,spec}.ts']
+    globalSetup: ['./tests/setup-db.ts'],
+    include: ['tests/**/*.{test,spec}.ts'],
+    setupFiles: ['./tests/setup-env.ts']
   }
 });


### PR DESCRIPTION
- backend/vitest.config.ts:3 now forces backend Vitest runs onto a dedicated test DB before tests load.
- backend/tests/support/backend-test-db.ts:16 centralizes the backend test DB env setup and cleanup.
- backend/src/models/db.ts:39 now fails fast if backend test mode tries to open backend/data/db/aitestbench.sqlite.
- backend/tests/unit/db-safety.test.ts:31 covers fallback to backend-test.sqlite and rejection of the production SQLite path.