### PR TITLE
feat(layout):Implemented polish across backend and frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 - Backend run groups now persist grouped Run executions, instantiate selected templates per target, launch child runs concurrently, expose `/run-groups` create/read/cancel endpoints, and isolate per-target failures.
 - Results now has a run-backed `/results-view/query` API and `/results-view/runs/:runId` detail API for the merged Dashboard/History experience, including filter metadata, scorecards, chart series, recent runs, dense history rows, and drawer data.
 - Evaluation detail is now available at `GET /evaluations/:evaluationId` so leaderboard rows can open a detail drawer for the representative evaluation.
+- Inference parameter presets are now persisted through `/inference-param-presets` CRUD endpoints and exposed in the shared frontend context bar.
+- Evaluate now has a queue API backed by completed `test_results`, with source-linked scoring and skip persistence while preserving the existing five 1-5 leaderboard score fields.
 
 ### Changed
 
@@ -21,6 +23,7 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 - Catalog now replaces the legacy Inference Servers and Models bodies with a merged Servers/Models funnel, URL-backed server/model filters, server health view, slide-over add/edit drawer, card grids, and a full-width model inspector layout.
 - Run now uses a unified 1-8 model workflow with query-backed model chips, shared template/options controls, single-target detail rendering, multi-target comparison columns, and summary aggregation.
 - Results now uses a single merged Dashboard/Leaderboard/History page with a shared 240px filter rail, URL-owned tab/filter/sort/pagination/detail state, export/share/reset actions, run detail drawers for Dashboard and History, and evaluation detail drawers for Leaderboard.
+- Package 06 polish adds shared reg-lights, a persistent inference context bar on Run/Templates/Results/Evaluate, a two-pane Templates layout, and a manual Evaluate scoring queue.
 - Leaderboard remains backed by `evaluations` while accepting server, model, score range, sort, and group query parameters, including grouping by server and `inference_config.quantization_level`.
 - Inference server authentication can now use stored raw bearer/custom-header tokens for backend probes and runs while preserving the existing `token_env` fallback.
 

--- a/backend/src/api/routes/evaluation-queue.ts
+++ b/backend/src/api/routes/evaluation-queue.ts
@@ -1,0 +1,60 @@
+import { FastifyInstance } from 'fastify';
+
+import {
+  EvaluationQueueConflictError,
+  getEvaluationQueueDetail,
+  listEvaluationQueue,
+  scoreEvaluationQueueItem,
+  skipEvaluationQueueItem
+} from '../../services/evaluation-queue-service.js';
+import { EvaluationValidationError } from '../../services/evaluation-service.js';
+
+export function registerEvaluationQueueRoutes(app: FastifyInstance): void {
+  app.get('/evaluation-queue', async (request, reply) => {
+    const { status } = request.query as { status?: string };
+    const normalized = status === 'done' || status === 'skipped' ? status : 'pending';
+    reply.send(listEvaluationQueue(normalized));
+  });
+
+  app.get('/evaluation-queue/:testResultId', async (request, reply) => {
+    const { testResultId } = request.params as { testResultId: string };
+    const detail = getEvaluationQueueDetail(testResultId);
+    if (!detail) {
+      reply.code(404).send({ error: 'Evaluation queue item not found' });
+      return;
+    }
+    reply.send(detail);
+  });
+
+  app.post('/evaluation-queue/:testResultId/score', async (request, reply) => {
+    const { testResultId } = request.params as { testResultId: string };
+    try {
+      const evaluation = await scoreEvaluationQueueItem(testResultId, request.body as Record<string, unknown>);
+      if (!evaluation) {
+        reply.code(404).send({ error: 'Evaluation queue item not found' });
+        return;
+      }
+      reply.code(201).send(evaluation);
+    } catch (error) {
+      if (error instanceof EvaluationQueueConflictError) {
+        reply.code(409).send({ error: error.message });
+        return;
+      }
+      if (error instanceof EvaluationValidationError) {
+        reply.code(400).send({ error: 'Validation failed', issues: error.issues });
+        return;
+      }
+      throw error;
+    }
+  });
+
+  app.post('/evaluation-queue/:testResultId/skip', async (request, reply) => {
+    const { testResultId } = request.params as { testResultId: string };
+    const body = request.body as { reason?: unknown } | undefined;
+    if (!skipEvaluationQueueItem(testResultId, body?.reason)) {
+      reply.code(404).send({ error: 'Evaluation queue item not found' });
+      return;
+    }
+    reply.code(204).send();
+  });
+}

--- a/backend/src/api/routes/inference-param-presets.ts
+++ b/backend/src/api/routes/inference-param-presets.ts
@@ -1,0 +1,55 @@
+import { FastifyInstance } from 'fastify';
+
+import {
+  InferenceParamPresetValidationError,
+  createInferenceParamPreset,
+  deleteInferenceParamPreset,
+  listInferenceParamPresets,
+  updateInferenceParamPreset
+} from '../../services/inference-param-presets-service.js';
+
+export function registerInferenceParamPresetRoutes(app: FastifyInstance): void {
+  app.get('/inference-param-presets', async (_request, reply) => {
+    reply.send({ items: listInferenceParamPresets() });
+  });
+
+  app.post('/inference-param-presets', async (request, reply) => {
+    try {
+      const preset = createInferenceParamPreset(request.body as Record<string, unknown>);
+      reply.code(201).send(preset);
+    } catch (error) {
+      if (error instanceof InferenceParamPresetValidationError) {
+        reply.code(400).send({ error: error.message });
+        return;
+      }
+      throw error;
+    }
+  });
+
+  app.patch('/inference-param-presets/:id', async (request, reply) => {
+    const { id } = request.params as { id: string };
+    try {
+      const preset = updateInferenceParamPreset(id, request.body as Record<string, unknown>);
+      if (!preset) {
+        reply.code(404).send({ error: 'Preset not found' });
+        return;
+      }
+      reply.send(preset);
+    } catch (error) {
+      if (error instanceof InferenceParamPresetValidationError) {
+        reply.code(400).send({ error: error.message });
+        return;
+      }
+      throw error;
+    }
+  });
+
+  app.delete('/inference-param-presets/:id', async (request, reply) => {
+    const { id } = request.params as { id: string };
+    if (!deleteInferenceParamPreset(id)) {
+      reply.code(404).send({ error: 'Preset not found' });
+      return;
+    }
+    reply.code(204).send();
+  });
+}

--- a/backend/src/api/server.ts
+++ b/backend/src/api/server.ts
@@ -22,13 +22,26 @@ import { registerEvalInferenceRoutes } from './routes/eval-inference.js';
 import { registerEvaluationsRoutes } from './routes/evaluations.js';
 import { registerLeaderboardRoutes } from './routes/leaderboard.js';
 import { registerArchitectureRoutes } from './routes/architecture.js';
+import { registerInferenceParamPresetRoutes } from './routes/inference-param-presets.js';
+import { registerEvaluationQueueRoutes } from './routes/evaluation-queue.js';
 
 function applyColumnMigrations(): void {
   const db = getDb();
-  const columns = (db.prepare('PRAGMA table_info(models)').all() as Array<{ name: string }>).map((c) => c.name);
-  if (!columns.includes('base_model_name')) {
+  const modelColumns = (db.prepare('PRAGMA table_info(models)').all() as Array<{ name: string }>).map((c) => c.name);
+  if (!modelColumns.includes('base_model_name')) {
     db.exec('ALTER TABLE models ADD COLUMN base_model_name TEXT');
   }
+  const evaluationColumns = (db.prepare('PRAGMA table_info(evaluations)').all() as Array<{ name: string }>).map((c) => c.name);
+  if (!evaluationColumns.includes('source_test_result_id')) {
+    db.exec('ALTER TABLE evaluations ADD COLUMN source_test_result_id TEXT');
+  }
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_evaluations_source_test_result
+      ON evaluations(source_test_result_id);
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_evaluations_source_test_result_unique
+      ON evaluations(source_test_result_id)
+      WHERE source_test_result_id IS NOT NULL;
+  `);
 }
 
 export function createServer() {
@@ -99,6 +112,8 @@ export function createServer() {
   registerDashboardResultsRoutes(app);
   registerEvalInferenceRoutes(app);
   registerEvaluationsRoutes(app);
+  registerEvaluationQueueRoutes(app);
+  registerInferenceParamPresetRoutes(app);
   registerLeaderboardRoutes(app);
   registerArchitectureRoutes(app);
 

--- a/backend/src/models/evaluation.ts
+++ b/backend/src/models/evaluation.ts
@@ -8,6 +8,7 @@ export interface InferenceConfigSnapshot {
   top_p: number | null;
   max_tokens: number | null;
   quantization_level: string | null;
+  stream?: boolean | null;
 }
 
 export interface EvaluationRecord {
@@ -29,6 +30,7 @@ export interface EvaluationRecord {
   completeness_score: number;
   helpfulness_score: number;
   note: string | null;
+  source_test_result_id: string | null;
   created_at: string;
 }
 
@@ -50,6 +52,7 @@ export interface EvaluationCreateInput {
   completeness_score: number;
   helpfulness_score: number;
   note: string | null;
+  source_test_result_id?: string | null;
 }
 
 export interface EvaluationListFilters {
@@ -79,6 +82,7 @@ interface EvaluationRow {
   completeness_score: number;
   helpfulness_score: number;
   note: string | null;
+  source_test_result_id: string | null;
   created_at: string;
 }
 
@@ -98,12 +102,12 @@ export function create(input: EvaluationCreateInput): EvaluationRecord {
       id, prompt_id, model_name, server_id, inference_config, answer_text,
       input_tokens, output_tokens, total_tokens, latency_ms, word_count, estimated_cost,
       accuracy_score, relevance_score, coherence_score, completeness_score, helpfulness_score,
-      note, created_at
+      note, source_test_result_id, created_at
     ) VALUES (
       ?, ?, ?, ?, ?, ?,
       ?, ?, ?, ?, ?, ?,
       ?, ?, ?, ?, ?,
-      ?, ?
+      ?, ?, ?
     )
   `).run(
     id,
@@ -124,9 +128,23 @@ export function create(input: EvaluationCreateInput): EvaluationRecord {
     input.completeness_score,
     input.helpfulness_score,
     input.note,
+    input.source_test_result_id ?? null,
     created_at
   );
-  return rowToRecord({ ...input, id, created_at, inference_config: JSON.stringify(input.inference_config) });
+  return rowToRecord({
+    ...input,
+    id,
+    source_test_result_id: input.source_test_result_id ?? null,
+    created_at,
+    inference_config: JSON.stringify(input.inference_config)
+  });
+}
+
+export function getBySourceTestResultId(testResultId: string): EvaluationRecord | null {
+  const row = getDb()
+    .prepare('SELECT * FROM evaluations WHERE source_test_result_id = ?')
+    .get(testResultId) as EvaluationRow | undefined;
+  return row ? rowToRecord(row) : null;
 }
 
 export function getById(id: string): EvaluationRecord | null {

--- a/backend/src/models/schema.sql
+++ b/backend/src/models/schema.sql
@@ -196,6 +196,17 @@ CREATE INDEX IF NOT EXISTS idx_results_run ON test_results(run_id);
 CREATE INDEX IF NOT EXISTS idx_result_documents_run ON test_result_documents(run_id);
 CREATE INDEX IF NOT EXISTS idx_metrics_result ON metric_samples(test_result_id);
 
+CREATE TABLE IF NOT EXISTS inference_param_presets (
+  id                  TEXT PRIMARY KEY,
+  name                TEXT NOT NULL,
+  parameters          TEXT NOT NULL,
+  created_at          TEXT NOT NULL,
+  updated_at          TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_inference_param_presets_name
+  ON inference_param_presets(name);
+
 CREATE TABLE IF NOT EXISTS test_templates (
   id TEXT PRIMARY KEY,
   name TEXT NOT NULL,
@@ -264,15 +275,23 @@ CREATE TABLE IF NOT EXISTS evaluations (
   completeness_score  INTEGER NOT NULL CHECK (completeness_score BETWEEN 1 AND 5),
   helpfulness_score   INTEGER NOT NULL CHECK (helpfulness_score BETWEEN 1 AND 5),
   note                TEXT,
+  source_test_result_id TEXT,
   created_at          TEXT NOT NULL,
   FOREIGN KEY (prompt_id)  REFERENCES eval_prompts(id),
-  FOREIGN KEY (server_id)  REFERENCES inference_servers(server_id)
+  FOREIGN KEY (server_id)  REFERENCES inference_servers(server_id),
+  FOREIGN KEY (source_test_result_id) REFERENCES test_results(id) ON DELETE SET NULL
 );
 
 CREATE INDEX IF NOT EXISTS idx_evaluations_model_name  ON evaluations(model_name);
 CREATE INDEX IF NOT EXISTS idx_evaluations_prompt_id   ON evaluations(prompt_id);
 CREATE INDEX IF NOT EXISTS idx_evaluations_created_at  ON evaluations(created_at);
 CREATE INDEX IF NOT EXISTS idx_evaluations_server_id   ON evaluations(server_id);
+CREATE TABLE IF NOT EXISTS evaluation_queue_skips (
+  test_result_id TEXT PRIMARY KEY,
+  reason         TEXT,
+  skipped_at     TEXT NOT NULL,
+  FOREIGN KEY (test_result_id) REFERENCES test_results(id) ON DELETE CASCADE
+);
 
 CREATE TABLE IF NOT EXISTS model_architecture_settings (
   server_id         TEXT NOT NULL,

--- a/backend/src/schemas/evaluation.schema.json
+++ b/backend/src/schemas/evaluation.schema.json
@@ -58,6 +58,9 @@
         },
         "quantization_level": {
           "type": ["string", "null"]
+        },
+        "stream": {
+          "type": ["boolean", "null"]
         }
       }
     },
@@ -116,6 +119,9 @@
     "note": {
       "type": ["string", "null"],
       "maxLength": 2000
+    },
+    "source_test_result_id": {
+      "type": ["string", "null"]
     }
   }
 }

--- a/backend/src/services/evaluation-queue-service.ts
+++ b/backend/src/services/evaluation-queue-service.ts
@@ -1,0 +1,324 @@
+import { getDb } from '../models/db.js';
+import * as evaluationModel from '../models/evaluation.js';
+import { nowIso, parseJson } from '../models/repositories.js';
+import { createEvaluation, EvaluationValidationError } from './evaluation-service.js';
+
+type QueueStatus = 'pending' | 'done' | 'skipped';
+
+interface QueueSourceRow {
+  test_result_id: string;
+  run_id: string;
+  test_id: string;
+  verdict: string;
+  failure_reason: string | null;
+  metrics: string | null;
+  artefacts: string | null;
+  raw_events: string | null;
+  started_at: string;
+  ended_at: string | null;
+  document: string | null;
+  run_status: string;
+  environment_snapshot: string | null;
+  server_id: string;
+  server_name: string | null;
+  template_id: string | null;
+  template_name: string | null;
+  runner_type: string | null;
+}
+
+export interface EvaluationQueueItem {
+  test_result_id: string;
+  run_id: string;
+  test_id: string;
+  template_id: string;
+  template_label: string;
+  model_name: string;
+  server_id: string;
+  server_name: string;
+  verdict: string;
+  status: QueueStatus;
+  started_at: string;
+  ended_at: string | null;
+}
+
+export interface EvaluationQueueDetail extends EvaluationQueueItem {
+  inference_config: {
+    temperature: number | null;
+    top_p: number | null;
+    max_tokens: number | null;
+    quantization_level: string | null;
+    stream: boolean | null;
+  };
+  prompt_text: string;
+  answer_text: string;
+  metrics: Record<string, unknown>;
+  artefacts: Record<string, unknown>;
+  raw_events: unknown;
+  document: Record<string, unknown>;
+  evaluation_id: string | null;
+  skipped_at: string | null;
+}
+
+export class EvaluationQueueConflictError extends Error {}
+
+function safeJson<T>(value: string | null): T | null {
+  try {
+    return parseJson<T>(value);
+  } catch {
+    return null;
+  }
+}
+
+function findString(value: unknown, keys: string[]): string | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  for (const key of keys) {
+    const entry = record[key];
+    if (typeof entry === 'string' && entry.trim()) {
+      return entry.trim();
+    }
+  }
+  return null;
+}
+
+function extractPrompt(document: Record<string, unknown> | null, artefacts: Record<string, unknown> | null): string {
+  const fromArtefacts = findString(artefacts, ['prompt', 'prompt_text', 'request_prompt']);
+  if (fromArtefacts) {
+    return fromArtefacts;
+  }
+  const direct = findString(document, ['prompt', 'prompt_text', 'input', 'user_prompt']);
+  if (direct) {
+    return direct;
+  }
+  const request = document?.request;
+  const requestText = findString(request, ['prompt', 'prompt_text']);
+  if (requestText) {
+    return requestText;
+  }
+  const steps = Array.isArray(document?.steps) ? document.steps : [];
+  for (const step of steps) {
+    const text = findString(step, ['prompt', 'prompt_text', 'input', 'user_prompt']);
+    if (text) {
+      return text;
+    }
+  }
+  return 'Prompt unavailable';
+}
+
+function extractAnswer(artefacts: Record<string, unknown> | null, rawEvents: unknown): string {
+  const fromArtefacts = findString(artefacts, ['response_body', 'response_preview', 'answer_text', 'output', 'completion']);
+  if (fromArtefacts) {
+    return fromArtefacts;
+  }
+  if (typeof rawEvents === 'string' && rawEvents.trim()) {
+    return rawEvents;
+  }
+  return '';
+}
+
+function numberOrNull(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function selectedModel(snapshot: Record<string, unknown> | null, document: Record<string, unknown> | null): string {
+  const effective = snapshot?.effective_config;
+  if (effective && typeof effective === 'object') {
+    const model = (effective as Record<string, unknown>).model;
+    if (typeof model === 'string' && model.trim()) {
+      return model.trim();
+    }
+  }
+  const direct = snapshot?.model;
+  if (typeof direct === 'string' && direct.trim()) {
+    return direct.trim();
+  }
+  const selected = document?.selected_model;
+  if (selected && typeof selected === 'object') {
+    const id = (selected as Record<string, unknown>).id;
+    if (typeof id === 'string' && id.trim()) {
+      return id.trim();
+    }
+  }
+  return 'unknown';
+}
+
+function inferenceConfig(snapshot: Record<string, unknown> | null): EvaluationQueueDetail['inference_config'] {
+  const effective = snapshot?.effective_config && typeof snapshot.effective_config === 'object'
+    ? snapshot.effective_config as Record<string, unknown>
+    : {};
+  return {
+    temperature: numberOrNull(effective.temperature),
+    top_p: numberOrNull(effective.top_p),
+    max_tokens: numberOrNull(effective.max_tokens),
+    quantization_level: typeof effective.quantization_level === 'string' ? effective.quantization_level : null,
+    stream: typeof effective.stream === 'boolean' ? effective.stream : null
+  };
+}
+
+function templateLabel(row: QueueSourceRow): string {
+  return row.template_name?.replace(/\s*\([^)]*\)\s*$/, '').trim() || row.template_id || row.test_id;
+}
+
+function sourceRows(): QueueSourceRow[] {
+  return getDb().prepare(`
+    SELECT
+      tr.id AS test_result_id,
+      tr.run_id,
+      tr.test_id,
+      tr.verdict,
+      tr.failure_reason,
+      tr.metrics,
+      tr.artefacts,
+      tr.raw_events,
+      tr.started_at,
+      tr.ended_at,
+      trd.document,
+      r.status AS run_status,
+      r.environment_snapshot,
+      r.inference_server_id AS server_id,
+      i.display_name AS server_name,
+      at.template_id,
+      td.name AS template_name,
+      td.runner_type
+    FROM test_results tr
+    JOIN runs r ON r.id = tr.run_id
+    LEFT JOIN test_result_documents trd ON trd.test_result_id = tr.id
+    LEFT JOIN inference_servers i ON i.server_id = r.inference_server_id
+    LEFT JOIN active_tests at ON at.id = COALESCE(tr.test_id, r.test_id)
+    LEFT JOIN test_definitions td ON td.id = COALESCE(tr.test_id, r.test_id)
+    WHERE r.status = 'completed'
+    ORDER BY COALESCE(tr.ended_at, tr.started_at) DESC
+    LIMIT 500
+  `).all() as QueueSourceRow[];
+}
+
+function rowStatus(testResultId: string): QueueStatus {
+  const db = getDb();
+  const evaluated = db
+    .prepare('SELECT id FROM evaluations WHERE source_test_result_id = ?')
+    .get(testResultId);
+  if (evaluated) {
+    return 'done';
+  }
+  const skipped = db
+    .prepare('SELECT test_result_id FROM evaluation_queue_skips WHERE test_result_id = ?')
+    .get(testResultId);
+  return skipped ? 'skipped' : 'pending';
+}
+
+function rowToDetail(row: QueueSourceRow, status = rowStatus(row.test_result_id)): EvaluationQueueDetail {
+  const document = safeJson<Record<string, unknown>>(row.document) ?? {};
+  const metrics = safeJson<Record<string, unknown>>(row.metrics) ?? {};
+  const artefacts = safeJson<Record<string, unknown>>(row.artefacts) ?? {};
+  const rawEvents = safeJson<unknown>(row.raw_events) ?? row.raw_events ?? null;
+  const snapshot = safeJson<Record<string, unknown>>(row.environment_snapshot) ?? {};
+  const evaluation = evaluationModel.getBySourceTestResultId(row.test_result_id);
+  const skip = getDb()
+    .prepare('SELECT skipped_at FROM evaluation_queue_skips WHERE test_result_id = ?')
+    .get(row.test_result_id) as { skipped_at: string } | undefined;
+
+  return {
+    test_result_id: row.test_result_id,
+    run_id: row.run_id,
+    test_id: row.test_id,
+    template_id: row.template_id ?? row.test_id,
+    template_label: templateLabel(row),
+    model_name: selectedModel(snapshot, document),
+    server_id: row.server_id,
+    server_name: row.server_name ?? row.server_id,
+    verdict: row.verdict,
+    status,
+    started_at: row.started_at,
+    ended_at: row.ended_at,
+    inference_config: inferenceConfig(snapshot),
+    prompt_text: extractPrompt(document, artefacts),
+    answer_text: extractAnswer(artefacts, rawEvents),
+    metrics,
+    artefacts,
+    raw_events: rawEvents,
+    document,
+    evaluation_id: evaluation?.id ?? null,
+    skipped_at: skip?.skipped_at ?? null
+  };
+}
+
+export function listEvaluationQueue(status: QueueStatus = 'pending') {
+  const details = sourceRows().map((row) => rowToDetail(row));
+  const counts = details.reduce<Record<QueueStatus, number>>((acc, item) => {
+    acc[item.status] += 1;
+    return acc;
+  }, { pending: 0, done: 0, skipped: 0 });
+  return {
+    counts,
+    items: details
+      .filter((item) => item.status === status)
+      .map(({ inference_config: _inferenceConfig, prompt_text: _prompt, answer_text: _answer, metrics: _metrics, artefacts: _artefacts, raw_events: _raw, document: _document, evaluation_id: _evaluationId, skipped_at: _skippedAt, ...item }) => item)
+  };
+}
+
+export function getEvaluationQueueDetail(testResultId: string): EvaluationQueueDetail | null {
+  const row = sourceRows().find((entry) => entry.test_result_id === testResultId);
+  return row ? rowToDetail(row) : null;
+}
+
+function score(value: unknown, field: string): number {
+  if (!Number.isInteger(value) || (value as number) < 1 || (value as number) > 5) {
+    throw new EvaluationValidationError([{ message: `${field} must be an integer from 1 to 5`, path: field }]);
+  }
+  return value as number;
+}
+
+export async function scoreEvaluationQueueItem(testResultId: string, body: Record<string, unknown>) {
+  if (evaluationModel.getBySourceTestResultId(testResultId)) {
+    throw new EvaluationQueueConflictError('test result has already been scored');
+  }
+  const detail = getEvaluationQueueDetail(testResultId);
+  if (!detail) {
+    return null;
+  }
+  const metrics = detail.metrics;
+  return createEvaluation({
+    prompt_text: detail.prompt_text,
+    tags: [],
+    server_id: detail.server_id,
+    model_name: detail.model_name,
+    inference_config: {
+      temperature: detail.inference_config.temperature,
+      top_p: detail.inference_config.top_p,
+      max_tokens: detail.inference_config.max_tokens,
+      quantization_level: detail.inference_config.quantization_level
+    },
+    answer_text: detail.answer_text,
+    input_tokens: numberOrNull(metrics.prompt_tokens),
+    output_tokens: numberOrNull(metrics.completion_tokens),
+    total_tokens: numberOrNull(metrics.total_tokens),
+    latency_ms: numberOrNull(metrics.latency_ms) ?? numberOrNull(metrics.total_ms),
+    word_count: detail.answer_text.trim() ? detail.answer_text.trim().split(/\s+/).length : 0,
+    estimated_cost: numberOrNull(metrics.estimated_cost),
+    accuracy_score: score(body.accuracy_score, 'accuracy_score'),
+    relevance_score: score(body.relevance_score, 'relevance_score'),
+    coherence_score: score(body.coherence_score, 'coherence_score'),
+    completeness_score: score(body.completeness_score, 'completeness_score'),
+    helpfulness_score: score(body.helpfulness_score, 'helpfulness_score'),
+    note: typeof body.note === 'string' ? body.note : null,
+    source_test_result_id: testResultId
+  });
+}
+
+export function skipEvaluationQueueItem(testResultId: string, reason: unknown): boolean {
+  const detail = getEvaluationQueueDetail(testResultId);
+  if (!detail) {
+    return false;
+  }
+  const skippedAt = nowIso();
+  getDb().prepare(`
+    INSERT INTO evaluation_queue_skips (test_result_id, reason, skipped_at)
+    VALUES (?, ?, ?)
+    ON CONFLICT(test_result_id) DO UPDATE SET
+      reason = excluded.reason,
+      skipped_at = excluded.skipped_at
+  `).run(testResultId, typeof reason === 'string' && reason.trim() ? reason.trim() : null, skippedAt);
+  return true;
+}

--- a/backend/src/services/evaluation-service.ts
+++ b/backend/src/services/evaluation-service.ts
@@ -43,6 +43,7 @@ export interface EvaluationInput {
   completeness_score: number;
   helpfulness_score: number;
   note: string | null;
+  source_test_result_id?: string | null;
 }
 
 export async function createEvaluation(input: EvaluationInput) {
@@ -73,7 +74,8 @@ export async function createEvaluation(input: EvaluationInput) {
     coherence_score: input.coherence_score,
     completeness_score: input.completeness_score,
     helpfulness_score: input.helpfulness_score,
-    note: input.note
+    note: input.note,
+    source_test_result_id: input.source_test_result_id ?? null
   });
 
   logEvent({

--- a/backend/src/services/inference-param-presets-service.ts
+++ b/backend/src/services/inference-param-presets-service.ts
@@ -1,0 +1,131 @@
+import crypto from 'crypto';
+
+import { getDb } from '../models/db.js';
+import { nowIso } from '../models/repositories.js';
+
+export interface InferenceParamPresetParameters {
+  temperature: number | null;
+  top_p: number | null;
+  max_tokens: number | null;
+  quantization_level: string | null;
+  stream: boolean;
+}
+
+export interface InferenceParamPresetRecord {
+  id: string;
+  name: string;
+  parameters: InferenceParamPresetParameters;
+  created_at: string;
+  updated_at: string;
+}
+
+interface PresetRow {
+  id: string;
+  name: string;
+  parameters: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export class InferenceParamPresetValidationError extends Error {}
+
+function toRecord(row: PresetRow): InferenceParamPresetRecord {
+  return {
+    id: row.id,
+    name: row.name,
+    parameters: JSON.parse(row.parameters) as InferenceParamPresetParameters,
+    created_at: row.created_at,
+    updated_at: row.updated_at
+  };
+}
+
+function normalizeNumber(value: unknown, field: string): number | null {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new InferenceParamPresetValidationError(`${field} must be a finite number or null`);
+  }
+  return value;
+}
+
+export function normalizePresetParameters(input: unknown): InferenceParamPresetParameters {
+  const payload = input && typeof input === 'object' ? input as Record<string, unknown> : {};
+  const quantization = payload.quantization_level;
+  if (quantization !== null && quantization !== undefined && typeof quantization !== 'string') {
+    throw new InferenceParamPresetValidationError('quantization_level must be a string or null');
+  }
+  return {
+    temperature: normalizeNumber(payload.temperature, 'temperature'),
+    top_p: normalizeNumber(payload.top_p, 'top_p'),
+    max_tokens: normalizeNumber(payload.max_tokens, 'max_tokens'),
+    quantization_level: typeof quantization === 'string' && quantization.trim() ? quantization.trim() : null,
+    stream: typeof payload.stream === 'boolean' ? payload.stream : false
+  };
+}
+
+function normalizeName(value: unknown): string {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new InferenceParamPresetValidationError('name is required');
+  }
+  return value.trim().slice(0, 120);
+}
+
+export function listInferenceParamPresets(): InferenceParamPresetRecord[] {
+  const rows = getDb()
+    .prepare('SELECT * FROM inference_param_presets ORDER BY lower(name) ASC')
+    .all() as PresetRow[];
+  return rows.map(toRecord);
+}
+
+export function createInferenceParamPreset(input: Record<string, unknown>): InferenceParamPresetRecord {
+  const db = getDb();
+  const id = crypto.randomUUID();
+  const now = nowIso();
+  const name = normalizeName(input.name);
+  const parameters = normalizePresetParameters(input.parameters);
+  try {
+    db.prepare(`
+      INSERT INTO inference_param_presets (id, name, parameters, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?)
+    `).run(id, name, JSON.stringify(parameters), now, now);
+  } catch (error) {
+    if (error instanceof Error && /UNIQUE constraint failed/.test(error.message)) {
+      throw new InferenceParamPresetValidationError('preset name already exists');
+    }
+    throw error;
+  }
+  return { id, name, parameters, created_at: now, updated_at: now };
+}
+
+export function updateInferenceParamPreset(id: string, input: Record<string, unknown>): InferenceParamPresetRecord | null {
+  const current = getDb()
+    .prepare('SELECT * FROM inference_param_presets WHERE id = ?')
+    .get(id) as PresetRow | undefined;
+  if (!current) {
+    return null;
+  }
+  const name = input.name === undefined ? current.name : normalizeName(input.name);
+  const parameters = input.parameters === undefined
+    ? JSON.parse(current.parameters) as InferenceParamPresetParameters
+    : normalizePresetParameters(input.parameters);
+  const updatedAt = nowIso();
+  try {
+    getDb()
+      .prepare('UPDATE inference_param_presets SET name = ?, parameters = ?, updated_at = ? WHERE id = ?')
+      .run(name, JSON.stringify(parameters), updatedAt, id);
+  } catch (error) {
+    if (error instanceof Error && /UNIQUE constraint failed/.test(error.message)) {
+      throw new InferenceParamPresetValidationError('preset name already exists');
+    }
+    throw error;
+  }
+  return toRecord({ ...current, name, parameters: JSON.stringify(parameters), updated_at: updatedAt });
+}
+
+export function deleteInferenceParamPreset(id: string): boolean {
+  const result = getDb()
+    .prepare('DELETE FROM inference_param_presets WHERE id = ?')
+    .run(id);
+  return result.changes > 0;
+}

--- a/backend/tests/integration/package-06-polish.test.ts
+++ b/backend/tests/integration/package-06-polish.test.ts
@@ -1,0 +1,254 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createServer } from '../../src/api/server.js';
+import { getDb, resetDbInstance, runSchema } from '../../src/models/db.js';
+
+const AUTH_HEADERS = { 'x-api-token': 'test-token' };
+
+const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+const SCHEMA_PATH = path.resolve(moduleDir, '../../src/models/schema.sql');
+
+function seedServer(serverId = 'srv-queue') {
+  const db = getDb();
+  const now = '2026-05-01T00:00:00.000Z';
+  db.prepare(`
+    INSERT INTO inference_servers (
+      server_id, display_name, active, archived, created_at, updated_at, runtime,
+      endpoints, auth, capabilities, discovery, raw
+    ) VALUES (?, ?, 1, 0, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    serverId,
+    'Queue Server',
+    now,
+    now,
+    JSON.stringify({ api: { api_version: '1.0.0' } }),
+    JSON.stringify({ base_url: 'http://localhost:8080' }),
+    JSON.stringify({}),
+    JSON.stringify({}),
+    JSON.stringify({ model_list: { normalised: [] } }),
+    JSON.stringify({})
+  );
+}
+
+function seedQueueResult(id = 'queue-result-a') {
+  const db = getDb();
+  const now = '2026-05-01T10:00:00.000Z';
+  db.prepare(`
+    INSERT INTO active_tests (
+      id, template_id, template_version, inference_server_id, model_name,
+      status, created_at, deleted_at, version, command_preview, python_ready
+    ) VALUES ('active-queue', 'template-queue', '1.0.0', 'srv-queue', 'model-a', 'active', ?, null, '1.0.0', null, 1)
+  `).run(now);
+  db.prepare(`
+    INSERT INTO runs (
+      id, inference_server_id, suite_id, test_id, profile_id, profile_version,
+      status, started_at, ended_at, environment_snapshot, retention_days
+    ) VALUES ('run-queue', 'srv-queue', null, 'active-queue', null, null, 'completed', ?, ?, ?, 30)
+  `).run(
+    now,
+    now,
+    JSON.stringify({ effective_config: { model: 'model-a', temperature: 0.2, top_p: 0.9, max_tokens: 128, quantization_level: 'Q4', stream: true } })
+  );
+  db.prepare(`
+    INSERT INTO test_results (
+      id, run_id, test_id, verdict, failure_reason, metrics, artefacts, raw_events,
+      repetition_stats, started_at, ended_at
+    ) VALUES (?, 'run-queue', 'active-queue', 'pass', null, ?, ?, '[]', ?, ?, ?)
+  `).run(
+    id,
+    JSON.stringify({ latency_ms: 42, prompt_tokens: 7, completion_tokens: 9, total_tokens: 16, estimated_cost: 0.001 }),
+    JSON.stringify({ response_body: 'Paris is rainy.' }),
+    JSON.stringify({ repetitions: 1 }),
+    now,
+    now
+  );
+  db.prepare(`
+    INSERT INTO test_result_documents (test_result_id, run_id, test_id, schema_version, document, created_at)
+    VALUES (?, 'run-queue', 'active-queue', '1.0.0', ?, ?)
+  `).run(
+    id,
+    JSON.stringify({ prompt: 'Weather in Paris?', test: { tags: ['queue'] }, selected_model: { id: 'model-a' } }),
+    now
+  );
+}
+
+describe('package 06 backend contracts', () => {
+  process.env.AITESTBENCH_API_TOKEN = 'test-token';
+
+  beforeEach(() => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aitb-package-06-'));
+    process.env.AITESTBENCH_DB_PATH = path.join(tmpDir, 'test.sqlite');
+    resetDbInstance();
+    runSchema(fs.readFileSync(SCHEMA_PATH, 'utf8'));
+    seedServer();
+  });
+
+  afterEach(() => {
+    resetDbInstance();
+  });
+
+  it('supports inference parameter preset CRUD', async () => {
+    const app = createServer();
+    const created = await app.inject({
+      method: 'POST',
+      url: '/inference-param-presets',
+      headers: AUTH_HEADERS,
+      payload: {
+        name: 'Queue defaults',
+        parameters: { temperature: 0.2, top_p: 0.9, max_tokens: 128, quantization_level: 'Q4', stream: true }
+      }
+    });
+    expect(created.statusCode).toBe(201);
+    expect(created.json().parameters.stream).toBe(true);
+
+    const listed = await app.inject({ method: 'GET', url: '/inference-param-presets', headers: AUTH_HEADERS });
+    expect(listed.statusCode).toBe(200);
+    expect(listed.json().items).toHaveLength(1);
+
+    const patched = await app.inject({
+      method: 'PATCH',
+      url: `/inference-param-presets/${created.json().id}`,
+      headers: AUTH_HEADERS,
+      payload: { parameters: { temperature: 0.5, top_p: null, max_tokens: null, quantization_level: null, stream: false } }
+    });
+    expect(patched.statusCode).toBe(200);
+    expect(patched.json().parameters.temperature).toBe(0.5);
+
+    const deleted = await app.inject({ method: 'DELETE', url: `/inference-param-presets/${created.json().id}`, headers: AUTH_HEADERS });
+    expect(deleted.statusCode).toBe(204);
+  });
+
+  it('moves queue items through pending, done, and duplicate-score states', async () => {
+    seedQueueResult();
+    const app = createServer();
+
+    const pending = await app.inject({ method: 'GET', url: '/evaluation-queue', headers: AUTH_HEADERS });
+    expect(pending.statusCode).toBe(200);
+    expect(pending.json().counts.pending).toBe(1);
+    expect(pending.json().items[0].test_result_id).toBe('queue-result-a');
+
+    const detail = await app.inject({ method: 'GET', url: '/evaluation-queue/queue-result-a', headers: AUTH_HEADERS });
+    expect(detail.statusCode).toBe(200);
+    expect(detail.json().prompt_text).toBe('Weather in Paris?');
+    expect(detail.json().inference_config.temperature).toBe(0.2);
+
+    const score = await app.inject({
+      method: 'POST',
+      url: '/evaluation-queue/queue-result-a/score',
+      headers: AUTH_HEADERS,
+      payload: {
+        accuracy_score: 5,
+        relevance_score: 4,
+        coherence_score: 5,
+        completeness_score: 4,
+        helpfulness_score: 5,
+        note: 'Good answer'
+      }
+    });
+    expect(score.statusCode).toBe(201);
+    expect(score.json().source_test_result_id).toBe('queue-result-a');
+
+    const duplicate = await app.inject({
+      method: 'POST',
+      url: '/evaluation-queue/queue-result-a/score',
+      headers: AUTH_HEADERS,
+      payload: { accuracy_score: 5, relevance_score: 5, coherence_score: 5, completeness_score: 5, helpfulness_score: 5 }
+    });
+    expect(duplicate.statusCode).toBe(409);
+
+    const done = await app.inject({ method: 'GET', url: '/evaluation-queue?status=done', headers: AUTH_HEADERS });
+    expect(done.statusCode).toBe(200);
+    expect(done.json().counts.done).toBe(1);
+    expect(done.json().items[0].status).toBe('done');
+  });
+
+  it('persists skipped queue items', async () => {
+    seedQueueResult('queue-result-skip');
+    const app = createServer();
+    const skipped = await app.inject({
+      method: 'POST',
+      url: '/evaluation-queue/queue-result-skip/skip',
+      headers: AUTH_HEADERS,
+      payload: { reason: 'not useful' }
+    });
+    expect(skipped.statusCode).toBe(204);
+
+    const list = await app.inject({ method: 'GET', url: '/evaluation-queue?status=skipped', headers: AUTH_HEADERS });
+    expect(list.statusCode).toBe(200);
+    expect(list.json().counts.skipped).toBe(1);
+    expect(list.json().items[0].test_result_id).toBe('queue-result-skip');
+  });
+});
+
+describe('package 06 migrations', () => {
+  process.env.AITESTBENCH_API_TOKEN = 'test-token';
+
+  afterEach(() => {
+    resetDbInstance();
+  });
+
+  it('starts against a legacy evaluations table without source_test_result_id', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aitb-package-06-legacy-'));
+    process.env.AITESTBENCH_DB_PATH = path.join(tmpDir, 'test.sqlite');
+    resetDbInstance();
+    const db = getDb();
+    db.exec(`
+      CREATE TABLE inference_servers (
+        server_id TEXT PRIMARY KEY,
+        display_name TEXT NOT NULL,
+        active INTEGER NOT NULL DEFAULT 1,
+        archived INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        archived_at TEXT,
+        runtime TEXT NOT NULL,
+        endpoints TEXT NOT NULL,
+        auth TEXT NOT NULL,
+        capabilities TEXT NOT NULL,
+        discovery TEXT NOT NULL,
+        raw TEXT NOT NULL
+      );
+      CREATE TABLE eval_prompts (
+        id TEXT NOT NULL PRIMARY KEY,
+        text TEXT NOT NULL,
+        tags TEXT NOT NULL DEFAULT '[]',
+        created_at TEXT NOT NULL
+      );
+      CREATE TABLE evaluations (
+        id TEXT NOT NULL PRIMARY KEY,
+        prompt_id TEXT NOT NULL,
+        model_name TEXT NOT NULL,
+        server_id TEXT NOT NULL,
+        inference_config TEXT NOT NULL,
+        answer_text TEXT NOT NULL,
+        input_tokens INTEGER,
+        output_tokens INTEGER,
+        total_tokens INTEGER,
+        latency_ms REAL,
+        word_count INTEGER,
+        estimated_cost REAL,
+        accuracy_score INTEGER NOT NULL CHECK (accuracy_score BETWEEN 1 AND 5),
+        relevance_score INTEGER NOT NULL CHECK (relevance_score BETWEEN 1 AND 5),
+        coherence_score INTEGER NOT NULL CHECK (coherence_score BETWEEN 1 AND 5),
+        completeness_score INTEGER NOT NULL CHECK (completeness_score BETWEEN 1 AND 5),
+        helpfulness_score INTEGER NOT NULL CHECK (helpfulness_score BETWEEN 1 AND 5),
+        note TEXT,
+        created_at TEXT NOT NULL,
+        FOREIGN KEY (prompt_id) REFERENCES eval_prompts(id),
+        FOREIGN KEY (server_id) REFERENCES inference_servers(server_id)
+      );
+    `);
+
+    const app = createServer();
+    const columns = (getDb().prepare('PRAGMA table_info(evaluations)').all() as Array<{ name: string }>).map((column) => column.name);
+    const indexes = (getDb().prepare('PRAGMA index_list(evaluations)').all() as Array<{ name: string }>).map((index) => index.name);
+    expect(columns).toContain('source_test_result_id');
+    expect(indexes).toContain('idx_evaluations_source_test_result');
+    await app.close();
+  });
+});

--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from 'react';
+
+export function EmptyState({
+  title,
+  body,
+  actions,
+  className = ''
+}: {
+  title: string;
+  body: string;
+  actions?: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={`empty-state ${className}`}>
+      <div className="empty-state__blocks" aria-hidden="true">
+        <span />
+        <span />
+        <span />
+      </div>
+      <h2>{title}</h2>
+      <p>{body}</p>
+      {actions ? <div className="empty-state__actions">{actions}</div> : null}
+    </div>
+  );
+}

--- a/frontend/src/components/InferenceContextBar.tsx
+++ b/frontend/src/components/InferenceContextBar.tsx
@@ -1,0 +1,108 @@
+import { FormEvent, useEffect, useState } from 'react';
+
+import {
+  InferenceParamPreset,
+  InferenceParams,
+  createInferenceParamPreset,
+  listInferenceParamPresets
+} from '../services/inference-param-presets-api.js';
+
+function paramValue(value: number | string | boolean | null): string {
+  if (value === null || value === '') {
+    return 'default';
+  }
+  return String(value);
+}
+
+export function InferenceContextBar({
+  params,
+  onChange,
+  readOnly = false,
+  visible = true
+}: {
+  params: InferenceParams;
+  onChange?: (params: InferenceParams) => void;
+  readOnly?: boolean;
+  visible?: boolean;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(params);
+  const [presets, setPresets] = useState<InferenceParamPreset[]>([]);
+  const [message, setMessage] = useState<string | null>(null);
+
+  useEffect(() => setDraft(params), [params]);
+
+  useEffect(() => {
+    if (!visible) return;
+    listInferenceParamPresets().then(setPresets).catch(() => setPresets([]));
+  }, [visible]);
+
+  if (!visible) {
+    return null;
+  }
+
+  async function handleSavePreset() {
+    const name = window.prompt('Preset name');
+    if (!name?.trim()) {
+      return;
+    }
+    try {
+      const created = await createInferenceParamPreset({ name: name.trim(), parameters: params });
+      setPresets((current) => [...current.filter((preset) => preset.id !== created.id), created].sort((a, b) => a.name.localeCompare(b.name)));
+      setMessage(`Saved ${created.name}`);
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : 'Unable to save preset');
+    }
+  }
+
+  function applyPreset(id: string) {
+    const preset = presets.find((entry) => entry.id === id);
+    if (!preset || readOnly) {
+      return;
+    }
+    onChange?.(preset.parameters);
+    setMessage(`Loaded ${preset.name}`);
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    onChange?.(draft);
+    setEditing(false);
+  }
+
+  return (
+    <div className={readOnly ? 'context-bar is-readonly' : 'context-bar'}>
+      <span className="context-bar__label">Params</span>
+      {editing && !readOnly ? (
+        <form className="context-bar__form" onSubmit={handleSubmit}>
+          <label>temp<input type="number" step="0.01" min="0" max="2" value={draft.temperature ?? ''} onChange={(event) => setDraft({ ...draft, temperature: event.target.value ? Number(event.target.value) : null })} /></label>
+          <label>top_p<input type="number" step="0.01" min="0" max="1" value={draft.top_p ?? ''} onChange={(event) => setDraft({ ...draft, top_p: event.target.value ? Number(event.target.value) : null })} /></label>
+          <label>max_tok<input type="number" min="1" value={draft.max_tokens ?? ''} onChange={(event) => setDraft({ ...draft, max_tokens: event.target.value ? Number(event.target.value) : null })} /></label>
+          <label>quant<input value={draft.quantization_level ?? ''} onChange={(event) => setDraft({ ...draft, quantization_level: event.target.value || null })} /></label>
+          <label className="context-bar__toggle"><input type="checkbox" checked={Boolean(draft.stream)} onChange={(event) => setDraft({ ...draft, stream: event.target.checked })} /> stream</label>
+          <button type="submit">Apply</button>
+          <button type="button" className="btn btn--ghost" onClick={() => setEditing(false)}>Cancel</button>
+        </form>
+      ) : (
+        <>
+          <button type="button" className="param-chip" disabled={readOnly} onClick={() => setEditing(true)}><span>temp</span><b>{paramValue(params.temperature)}</b></button>
+          <button type="button" className="param-chip" disabled={readOnly} onClick={() => setEditing(true)}><span>top_p</span><b>{paramValue(params.top_p)}</b></button>
+          <button type="button" className="param-chip" disabled={readOnly} onClick={() => setEditing(true)}><span>max_tok</span><b>{paramValue(params.max_tokens)}</b></button>
+          <button type="button" className="param-chip" disabled={readOnly} onClick={() => setEditing(true)}><span>stream</span><b>{paramValue(params.stream)}</b></button>
+          <button type="button" className="param-chip" disabled={readOnly} onClick={() => setEditing(true)}><span>quant</span><b>{paramValue(params.quantization_level)}</b></button>
+        </>
+      )}
+      <div className="context-bar__spacer" />
+      {message ? <span className="context-bar__message">{message}</span> : null}
+      {!readOnly ? (
+        <>
+          <select value="" onChange={(event) => applyPreset(event.target.value)} aria-label="Load preset">
+            <option value="">Load preset</option>
+            {presets.map((preset) => <option key={preset.id} value={preset.id}>{preset.name}</option>)}
+          </select>
+          <button type="button" className="btn btn--ghost" onClick={handleSavePreset}>Save preset</button>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/RegLight.tsx
+++ b/frontend/src/components/RegLight.tsx
@@ -1,0 +1,50 @@
+export type RegLightState = 'healthy' | 'degraded' | 'down' | 'unknown' | 'up';
+
+export interface RegLightProps {
+  state: RegLightState;
+  label?: string;
+  latencyMs?: number | null;
+  lastProbe?: string | null;
+  statusCode?: number | string | null;
+  error?: string | null;
+  compact?: boolean;
+}
+
+function normalizedState(state: RegLightState): 'healthy' | 'degraded' | 'down' | 'unknown' {
+  return state === 'up' ? 'healthy' : state;
+}
+
+function relativeTime(value: string | null | undefined): string {
+  if (!value) return 'never';
+  const time = Date.parse(value);
+  if (Number.isNaN(time)) return 'unknown';
+  const seconds = Math.max(0, Math.round((Date.now() - time) / 1000));
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 48) return `${hours}h ago`;
+  return `${Math.round(hours / 24)}d ago`;
+}
+
+export function regLightTooltip(props: RegLightProps): string {
+  const state = normalizedState(props.state);
+  return [
+    props.label ? `${props.label}: ${state}` : state,
+    props.latencyMs != null ? `latency ${props.latencyMs}ms` : 'latency n/a',
+    `last probe ${relativeTime(props.lastProbe)}`,
+    props.statusCode != null ? `status ${props.statusCode}` : null,
+    props.error ? `error ${props.error}` : null
+  ].filter(Boolean).join(' · ');
+}
+
+export function RegLight(props: RegLightProps) {
+  const state = normalizedState(props.state);
+  const label = props.label ?? state;
+  return (
+    <span className={props.compact ? 'reg-light-wrap is-compact' : 'reg-light-wrap'} title={regLightTooltip(props)}>
+      <span className={`reg-light-dot reg-light-dot--${state}`} aria-hidden="true" />
+      {props.compact ? <span className="sr-only">{label}</span> : <span>{label}</span>}
+    </span>
+  );
+}

--- a/frontend/src/components/RunDetailDisplay.tsx
+++ b/frontend/src/components/RunDetailDisplay.tsx
@@ -1,0 +1,56 @@
+import type { EvaluationQueueDetail } from '../services/evaluation-queue-api.js';
+
+function valueOrDash(value: unknown): string {
+  if (value === null || value === undefined || value === '') {
+    return '-';
+  }
+  return String(value);
+}
+
+export function RunDetailDisplay({ detail }: { detail: EvaluationQueueDetail | null }) {
+  if (!detail) {
+    return (
+      <div className="run-detail-display is-empty">
+        <h2>No run selected</h2>
+        <p>Select a queue item to inspect the prompt, response, checks, and raw envelope.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="run-detail-display">
+      <header>
+        <div>
+          <span className="label--uppercase">Evaluating run · {detail.run_id}</span>
+          <h2>{detail.model_name} {'->'} {detail.template_label}</h2>
+        </div>
+        <span className={`run-status-pill status-${detail.verdict}`}>{detail.verdict}</span>
+      </header>
+      <div className="run-detail-columns">
+        <section>
+          <h3>Prompt</h3>
+          <pre>{detail.prompt_text}</pre>
+          <h3>Auto-checks</h3>
+          <div className="run-detail-kv">
+            <span>Verdict</span><strong>{detail.verdict}</strong>
+            <span>Latency</span><strong>{valueOrDash(detail.metrics.latency_ms ?? detail.metrics.total_ms)} ms</strong>
+            <span>Tokens</span><strong>{valueOrDash(detail.metrics.total_tokens)}</strong>
+          </div>
+        </section>
+        <section>
+          <h3>Response</h3>
+          <pre>{detail.answer_text || 'No response body captured.'}</pre>
+          <details>
+            <summary>Raw envelope</summary>
+            <pre>{JSON.stringify({
+              metrics: detail.metrics,
+              artefacts: detail.artefacts,
+              raw_events: detail.raw_events,
+              document: detail.document
+            }, null, 2)}</pre>
+          </details>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,5 +1,7 @@
 import { NavLink } from 'react-router-dom';
 
+import { RegLight } from './RegLight.js';
+
 interface SidebarHealth {
   backend: 'unknown' | 'up' | 'down';
   database: 'unknown' | 'up' | 'down';
@@ -57,7 +59,7 @@ function RegLightRow({
 }) {
   return (
     <div className={`sidebar-health-row sidebar-health-row--${status}`}>
-      <span className="sidebar-health-row__dot" aria-hidden="true" />
+      <RegLight state={status === 'up' ? 'healthy' : status} label={label} compact />
       <span>{label}</span>
       {detail ? <strong>{detail}</strong> : null}
     </div>

--- a/frontend/src/components/TemplateEditor.tsx
+++ b/frontend/src/components/TemplateEditor.tsx
@@ -7,6 +7,7 @@ interface TemplateEditorProps {
   onSave: (input: TemplateInput, isUpdate: boolean) => Promise<void>;
   error?: string | null;
   busy?: boolean;
+  initialType?: TemplateType;
 }
 
 const DEFAULT_JSON = `{
@@ -47,7 +48,7 @@ const DEFAULT_PYTHON_TEMPLATE = `{
   }
 }`;
 
-export function TemplateEditor({ template, onSave, error, busy }: TemplateEditorProps) {
+export function TemplateEditor({ template, onSave, error, busy, initialType = 'json' }: TemplateEditorProps) {
   const [id, setId] = useState('');
   const [name, setName] = useState('');
   const [type, setType] = useState<TemplateType>('json');
@@ -65,10 +66,10 @@ export function TemplateEditor({ template, onSave, error, busy }: TemplateEditor
     }
     setId('');
     setName('');
-    setType('json');
+    setType(initialType);
     setVersion('1.0.0');
-    setContent(DEFAULT_JSON);
-  }, [template]);
+    setContent(initialType === 'python' ? DEFAULT_PYTHON_TEMPLATE : DEFAULT_JSON);
+  }, [initialType, template]);
 
   const isUpdate = Boolean(template);
 
@@ -93,7 +94,7 @@ export function TemplateEditor({ template, onSave, error, busy }: TemplateEditor
   }
 
   return (
-    <form onSubmit={handleSubmit} className="card">
+    <form onSubmit={handleSubmit} className="template-editor-card">
       <h2>{isUpdate ? 'Edit template' : 'Create template'}</h2>
       {error ? <div className="error">{error}</div> : null}
       <label>

--- a/frontend/src/pages/Catalog.tsx
+++ b/frontend/src/pages/Catalog.tsx
@@ -2,6 +2,9 @@ import { FormEvent, useEffect, useMemo, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { MergedPageHeader } from '../components/MergedPageHeader.js';
+import { EmptyState } from '../components/EmptyState.js';
+import { InferenceContextBar } from '../components/InferenceContextBar.js';
+import { RegLight } from '../components/RegLight.js';
 import { catalogSearch, normalizeCatalogTab } from '../navigation.js';
 import { InferenceServerHealth, getConnectivityConfig, getInferenceServerHealth } from '../services/connectivity-api.js';
 import {
@@ -18,6 +21,7 @@ import {
 } from '../services/inference-servers-api.js';
 import { ModelFormat, ModelRecord, listModels } from '../services/models-api.js';
 import { extractBaseModelName, inferModelMetadata } from '../services/model-metadata-inference.js';
+import { DEFAULT_INFERENCE_PARAMS, type InferenceParams } from '../services/inference-param-presets-api.js';
 import { ModelDetails } from './ModelDetails.js';
 
 type CatalogModel = {
@@ -87,6 +91,10 @@ function statusLabel(status: ServerStatus): string {
     default:
       return 'unknown';
   }
+}
+
+function statusToRegLight(status: ServerStatus): 'healthy' | 'degraded' | 'down' | 'unknown' {
+  return status;
 }
 
 function relativeTime(value: string | null | undefined): string {
@@ -199,6 +207,7 @@ export function Catalog({
   const [selectedDetailId, setSelectedDetailId] = useState<string | null>(null);
   const [serverStageCollapsed, setServerStageCollapsed] = useState(() => localStorage.getItem(SERVER_STAGE_STORAGE_KEY) === 'true');
   const [serverFilters, setServerFilters] = useState({ status: new Set<string>(), runtime: new Set<string>(), gpu: new Set<string>() });
+  const [inferenceParams, setInferenceParams] = useState<InferenceParams>(DEFAULT_INFERENCE_PARAMS);
 
   const selectedServers = useMemo(() => new Set(parseCsv(searchParams.get('servers'))), [searchParams]);
   const selectedFamilies = useMemo(() => new Set(parseCsv(searchParams.get('family'))), [searchParams]);
@@ -364,6 +373,7 @@ export function Catalog({
           activeTab={activeTab}
           onTabChange={changeTab}
         />
+        <InferenceContextBar params={inferenceParams} onChange={setInferenceParams} />
         <ModelDetails
           serverId={inspectorServerId}
           modelId={inspectorModelId}
@@ -386,6 +396,7 @@ export function Catalog({
         onTabChange={changeTab}
         action={headerAction}
       />
+      <InferenceContextBar params={inferenceParams} onChange={setInferenceParams} />
       {error ? <div className="catalog-error error">{error}</div> : null}
       {loading ? <p className="catalog-loading muted">Loading catalog...</p> : null}
       {activeTab === 'servers' ? (
@@ -538,7 +549,14 @@ function ServersCatalog(props: {
               >
                 <span className="catalog-card-top">
                   <strong>{server.inference_server.display_name}</strong>
-                  <span className={`reg-light reg-light--${status}`}>{statusLabel(status)}</span>
+                  <RegLight
+                    state={statusToRegLight(status)}
+                    label={statusLabel(status)}
+                    latencyMs={props.connectivity[server.inference_server.server_id]?.response_time_ms}
+                    lastProbe={props.connectivity[server.inference_server.server_id]?.checked_at ?? server.discovery.retrieved_at}
+                    statusCode={props.connectivity[server.inference_server.server_id]?.status_code}
+                    error={props.connectivity[server.inference_server.server_id]?.error}
+                  />
                 </span>
                 <span className="catalog-url">{server.endpoints.base_url}</span>
                 <span className="catalog-card-meta">
@@ -559,7 +577,15 @@ function ServersCatalog(props: {
         <aside className="catalog-detail-rail">
           <div className="panel-header">
             <h3>{props.selectedDetail.inference_server.display_name}</h3>
-            <span className={`reg-dot reg-dot--${statusFor(props.selectedDetail, props.connectivity[props.selectedDetail.inference_server.server_id])}`} />
+            <RegLight
+              state={statusToRegLight(statusFor(props.selectedDetail, props.connectivity[props.selectedDetail.inference_server.server_id]))}
+              label={statusLabel(statusFor(props.selectedDetail, props.connectivity[props.selectedDetail.inference_server.server_id]))}
+              compact
+              latencyMs={props.connectivity[props.selectedDetail.inference_server.server_id]?.response_time_ms}
+              lastProbe={props.connectivity[props.selectedDetail.inference_server.server_id]?.checked_at ?? props.selectedDetail.discovery.retrieved_at}
+              statusCode={props.connectivity[props.selectedDetail.inference_server.server_id]?.status_code}
+              error={props.connectivity[props.selectedDetail.inference_server.server_id]?.error}
+            />
           </div>
           <div className="kv"><span>Base URL</span><strong>{props.selectedDetail.endpoints.base_url}</strong></div>
           <div className="kv"><span>Runtime</span><strong>{runtimeLabel(props.selectedDetail)}</strong></div>
@@ -661,14 +687,18 @@ function ModelsCatalog(props: {
         </div>
         {props.selectedServers.size === 0 ? (
           <div className="catalog-empty">
-            <h3>Select a server to see its models</h3>
-            <p>Models are scoped to the servers that host them. Select one or more servers from the rail.</p>
+            <EmptyState
+              title="Select a server to see its models"
+              body="Models are scoped to the servers that host them. Select one or more servers from the rail."
+            />
           </div>
         ) : props.visibleModels.length === 0 ? (
           <div className="catalog-empty">
-            <h3>No models discovered</h3>
-            <p>{props.selectedServerRows.map((server) => server.inference_server.display_name).join(', ')} returned 0 matching models.</p>
-            {props.selectedServerRows[0] ? <button type="button" onClick={() => props.onReprobe(props.selectedServerRows[0].inference_server.server_id)}>Re-probe</button> : null}
+            <EmptyState
+              title="No models discovered"
+              body={`${props.selectedServerRows.map((server) => server.inference_server.display_name).join(', ')} returned 0 matching models.`}
+              actions={props.selectedServerRows[0] ? <button type="button" onClick={() => props.onReprobe(props.selectedServerRows[0].inference_server.server_id)}>Re-probe</button> : null}
+            />
           </div>
         ) : (
           <div className="catalog-model-grid">
@@ -714,7 +744,7 @@ function ServersHealthPanel({ servers, connectivity }: { servers: InferenceServe
         </div>
         <div className="health-legend">
           {(['healthy', 'degraded', 'down', 'unknown'] as ServerStatus[]).map((status) => (
-            <span key={status}><i className={`reg-dot reg-dot--${status}`} /> {status}</span>
+            <span key={status}><RegLight state={statusToRegLight(status)} label={status} compact /> {status}</span>
           ))}
         </div>
         <div className="health-tile-grid">
@@ -723,7 +753,15 @@ function ServersHealthPanel({ servers, connectivity }: { servers: InferenceServe
             const status = statusFor(server, health);
             return (
               <div key={server.inference_server.server_id} className="health-tile">
-                <i className={`reg-dot reg-dot--${status}`} />
+                <RegLight
+                  state={statusToRegLight(status)}
+                  label={statusLabel(status)}
+                  compact
+                  latencyMs={health?.response_time_ms}
+                  lastProbe={health?.checked_at ?? server.discovery.retrieved_at}
+                  statusCode={health?.status_code}
+                  error={health?.error}
+                />
                 <strong>{server.inference_server.display_name}</strong>
               </div>
             );
@@ -736,7 +774,18 @@ function ServersHealthPanel({ servers, connectivity }: { servers: InferenceServe
             const status = statusFor(server, health);
             return (
               <div key={server.inference_server.server_id} className="health-row">
-                <span><i className={`reg-dot reg-dot--${status}`} /><strong>{server.inference_server.display_name}</strong><small>{server.endpoints.base_url}</small></span>
+                <span>
+                  <RegLight
+                    state={statusToRegLight(status)}
+                    label={statusLabel(status)}
+                    compact
+                    latencyMs={health?.response_time_ms}
+                    lastProbe={health?.checked_at ?? server.discovery.retrieved_at}
+                    statusCode={health?.status_code}
+                    error={health?.error}
+                  />
+                  <strong>{server.inference_server.display_name}</strong><small>{server.endpoints.base_url}</small>
+                </span>
                 <span>{health?.response_time_ms != null ? `${health.response_time_ms}ms` : '-'}</span>
                 <span>{relativeTime(health?.checked_at)}</span>
                 <span>{health?.status_code ?? statusLabel(status)}</span>
@@ -754,13 +803,11 @@ function NoServersState({ onAdd }: { onAdd?: () => void }) {
     <section className="catalog-page">
       <aside className="catalog-rail catalog-placeholder">Status<br />Runtime<br />GPU</aside>
       <main className="catalog-main catalog-empty catalog-empty-large">
-        <h2>No servers yet</h2>
-        <ol>
-          <li>Add an inference server.</li>
-          <li>Probe its model endpoint.</li>
-          <li>Use discovered models in tests and evaluations.</li>
-        </ol>
-        {onAdd ? <button type="button" onClick={onAdd}>+ Add server</button> : null}
+        <EmptyState
+          title="No servers yet"
+          body="Add an inference server, probe its model endpoint, then use discovered models in tests and evaluations."
+          actions={onAdd ? <button type="button" onClick={onAdd}>+ Add server</button> : null}
+        />
       </main>
     </section>
   );
@@ -846,7 +893,7 @@ function ServerDrawer({ mode, onClose, onSaved, onDelete }: {
 
   async function openInCatalog() {
     if (!savedServer) return;
-    await onSaved(savedServer, true);
+    await onSaved(savedServer, !editing);
     onClose();
   }
 

--- a/frontend/src/pages/Evaluate.tsx
+++ b/frontend/src/pages/Evaluate.tsx
@@ -1,83 +1,267 @@
-import { useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
-import type { InferenceConfig } from '../services/eval-inference-api.js';
-import { EvaluationForm } from '../components/EvaluationForm.js';
+import { EmptyState } from '../components/EmptyState.js';
+import { InferenceContextBar } from '../components/InferenceContextBar.js';
+import { RunDetailDisplay } from '../components/RunDetailDisplay.js';
+import {
+  EvaluationQueueDetail,
+  EvaluationQueueItem,
+  EvaluationQueueResponse,
+  EvaluationQueueScoreInput,
+  EvaluationQueueStatus,
+  getEvaluationQueueDetail,
+  listEvaluationQueue,
+  scoreEvaluationQueueItem,
+  skipEvaluationQueueItem,
+  validateQueueScores
+} from '../services/evaluation-queue-api.js';
+import { DEFAULT_INFERENCE_PARAMS } from '../services/inference-param-presets-api.js';
+
+const SCORE_FIELDS: Array<{ key: keyof EvaluationQueueScoreInput; label: string }> = [
+  { key: 'accuracy_score', label: 'Accuracy' },
+  { key: 'relevance_score', label: 'Relevance' },
+  { key: 'coherence_score', label: 'Coherence' },
+  { key: 'completeness_score', label: 'Completeness' },
+  { key: 'helpfulness_score', label: 'Helpfulness' }
+];
+
+const DEFAULT_SCORES: EvaluationQueueScoreInput = {
+  accuracy_score: 3,
+  relevance_score: 3,
+  coherence_score: 3,
+  completeness_score: 3,
+  helpfulness_score: 3,
+  note: null
+};
+
+const EMPTY_QUEUE_RESPONSE: EvaluationQueueResponse = {
+  counts: { pending: 0, done: 0, skipped: 0 },
+  items: []
+};
+
+function formatTime(value: string): string {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
+}
 
 export function Evaluate() {
-  const [compareMode, setCompareMode] = useState(false);
-  const [formCount, setFormCount] = useState(2);
-  const [sharedPromptText, setSharedPromptText] = useState('');
-  const [sharedInferenceConfig, setSharedInferenceConfig] = useState<InferenceConfig>({
-    temperature: null,
-    top_p: null,
-    max_tokens: null,
-    quantization_level: null
+  const [status, setStatus] = useState<EvaluationQueueStatus>('pending');
+  const [items, setItems] = useState<EvaluationQueueItem[]>([]);
+  const [counts, setCounts] = useState<Record<EvaluationQueueStatus, number>>({ pending: 0, done: 0, skipped: 0 });
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [detail, setDetail] = useState<EvaluationQueueDetail | null>(null);
+  const [scores, setScores] = useState<EvaluationQueueScoreInput>(DEFAULT_SCORES);
+  const [activeScoreIndex, setActiveScoreIndex] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const selectedParams = detail?.inference_config ?? DEFAULT_INFERENCE_PARAMS;
+  const selectedIndex = useMemo(() => items.findIndex((item) => item.test_result_id === selectedId), [items, selectedId]);
+
+  const loadQueue = useCallback(async (nextStatus = status) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await listEvaluationQueue(nextStatus);
+      setCounts(response.counts);
+      setItems(response.items);
+      setSelectedId((current) => current && response.items.some((item) => item.test_result_id === current)
+        ? current
+        : response.items[0]?.test_result_id ?? null);
+      if (response.items.length === 0) {
+        setDetail(null);
+      }
+      return response;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unable to load evaluation queue');
+      setItems([]);
+      setSelectedId(null);
+      setDetail(null);
+      return EMPTY_QUEUE_RESPONSE;
+    } finally {
+      setLoading(false);
+    }
+  }, [status]);
+
+  useEffect(() => {
+    loadQueue();
+  }, [loadQueue]);
+
+  useEffect(() => {
+    if (!selectedId) {
+      setDetail(null);
+      return;
+    }
+    getEvaluationQueueDetail(selectedId)
+      .then(setDetail)
+      .catch((err) => setError(err instanceof Error ? err.message : 'Unable to load queue item'));
+  }, [selectedId]);
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement) {
+        return;
+      }
+      if (/^[1-5]$/.test(event.key)) {
+        const field = SCORE_FIELDS[activeScoreIndex].key;
+        setScores((current) => ({ ...current, [field]: Number(event.key) }));
+      }
+      if (event.key === 'Enter' && status === 'pending') {
+        event.preventDefault();
+        handleSaveNext();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
   });
 
-  function handleToggleCompare() {
-    const next = !compareMode;
-    setCompareMode(next);
-    if (next) setFormCount(2);
+  async function handleSaveNext() {
+    if (!detail || !validateQueueScores(scores)) {
+      return;
+    }
+    const scoredId = detail.test_result_id;
+    setBusy(true);
+    setError(null);
+    try {
+      await scoreEvaluationQueueItem(scoredId, scores);
+      window.dispatchEvent(new CustomEvent('evaluations:saved'));
+      setScores(DEFAULT_SCORES);
+      setCounts((current) => ({
+        ...current,
+        pending: Math.max(0, current.pending - 1),
+        done: current.done + 1
+      }));
+      const remaining = items.filter((item) => item.test_result_id !== scoredId);
+      setItems(remaining);
+      const nextItem = remaining[Math.max(0, Math.min(selectedIndex, remaining.length - 1))] ?? null;
+      setSelectedId(nextItem?.test_result_id ?? null);
+      if (!nextItem) {
+        setDetail(null);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unable to save score');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleSkip() {
+    if (!detail) return;
+    const skippedId = detail.test_result_id;
+    setBusy(true);
+    setError(null);
+    try {
+      await skipEvaluationQueueItem(skippedId);
+      setCounts((current) => ({
+        ...current,
+        pending: Math.max(0, current.pending - 1),
+        skipped: current.skipped + 1
+      }));
+      const remaining = items.filter((item) => item.test_result_id !== skippedId);
+      setItems(remaining);
+      const nextItem = remaining[Math.max(0, Math.min(selectedIndex, remaining.length - 1))] ?? null;
+      setSelectedId(nextItem?.test_result_id ?? null);
+      if (!nextItem) {
+        setDetail(null);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unable to skip item');
+    } finally {
+      setBusy(false);
+    }
   }
 
   return (
-    <div className="page-evaluate">
-      <div className="page-header">
-        <h2>Evaluate</h2>
-        <div className="compare-controls">
-          <button type="button" onClick={handleToggleCompare}>
-            {compareMode ? 'Single Mode' : 'Compare Mode'}
-          </button>
-          {compareMode ? (
-            <div className="form-count-controls">
-              <button
-                type="button"
-                disabled={formCount <= 2}
-                onClick={() => setFormCount((n) => Math.max(2, n - 1))}
-              >
-                −
-              </button>
-              <span>{formCount} models</span>
-              <button
-                type="button"
-                disabled={formCount >= 4}
-                onClick={() => setFormCount((n) => Math.min(4, n + 1))}
-              >
-                +
-              </button>
-            </div>
-          ) : null}
+    <section className="page evaluate-queue-page">
+      <div className="page-header evaluate-header">
+        <div>
+          <h2>Evaluate</h2>
+          <p className="muted">Score completed run outputs against the five-field leaderboard rubric.</p>
         </div>
+        <button type="button" className="btn btn--ghost" onClick={() => loadQueue(status)} disabled={loading || busy}>Refresh</button>
       </div>
-
-      {compareMode ? (
-        <div className="compare-layout">
-          <div className="shared-prompt-area">
-            <label>
-              Shared Prompt
-              <textarea
-                value={sharedPromptText}
-                onChange={(e) => setSharedPromptText(e.target.value)}
-                rows={4}
-                placeholder="Enter a prompt to send to all models…"
-                maxLength={10000}
-              />
-            </label>
-          </div>
-          <div className="forms-row">
-            {Array.from({ length: formCount }).map((_, i) => (
-              <EvaluationForm
-                key={i}
-                sharedPromptText={sharedPromptText}
-                sharedInferenceConfig={sharedInferenceConfig}
-                onInferenceConfigChange={i === 0 ? setSharedInferenceConfig : undefined}
-              />
-            ))}
-          </div>
-        </div>
+      <InferenceContextBar params={selectedParams} readOnly />
+      {error ? <div className="error">{error}</div> : null}
+      {loading ? <p className="muted">Loading evaluation queue...</p> : null}
+      {!loading && items.length === 0 && status === 'pending' ? (
+        <EmptyState
+          className="evaluate-empty"
+          title="All caught up"
+          body="New evaluations appear here when completed runs are ready for scoring."
+        />
       ) : (
-        <EvaluationForm />
+        <div className="evaluate-queue-layout">
+          <aside className="evaluate-queue-rail">
+            <div className="evaluate-tabs">
+              {(['pending', 'done', 'skipped'] as EvaluationQueueStatus[]).map((entry) => (
+                <button
+                  type="button"
+                  key={entry}
+                  className={status === entry ? 'is-active' : ''}
+                  onClick={() => {
+                    setStatus(entry);
+                    loadQueue(entry);
+                  }}
+                >
+                  {entry} · {counts[entry]}
+                </button>
+              ))}
+            </div>
+            <div className="evaluate-queue-list">
+              {items.map((item) => (
+                <button
+                  type="button"
+                  key={item.test_result_id}
+                  className={selectedId === item.test_result_id ? 'evaluate-queue-row is-selected' : 'evaluate-queue-row'}
+                  onClick={() => setSelectedId(item.test_result_id)}
+                >
+                  <span>
+                    <strong>{item.test_result_id.slice(0, 8)}</strong>
+                    <small>{formatTime(item.started_at)}</small>
+                  </span>
+                  <span>{item.model_name}</span>
+                  <small>{item.template_label}</small>
+                </button>
+              ))}
+            </div>
+          </aside>
+          <main className="evaluate-run-panel">
+            <RunDetailDisplay detail={detail} />
+          </main>
+          <aside className="evaluate-rubric">
+            <div>
+              <span className="label--uppercase">Rubric</span>
+              <h3>Manual score</h3>
+            </div>
+            {SCORE_FIELDS.map((field, index) => (
+              <label key={field.key} className={activeScoreIndex === index ? 'score-row is-active' : 'score-row'}>
+                <span>{field.label}</span>
+                <strong>{scores[field.key]}/5</strong>
+                <input
+                  type="range"
+                  min="1"
+                  max="5"
+                  value={Number(scores[field.key])}
+                  onFocus={() => setActiveScoreIndex(index)}
+                  onChange={(event) => setScores((current) => ({ ...current, [field.key]: Number(event.target.value) }))}
+                />
+              </label>
+            ))}
+            <label className="evaluate-notes">
+              Notes
+              <textarea value={scores.note ?? ''} onChange={(event) => setScores((current) => ({ ...current, note: event.target.value }))} rows={5} />
+            </label>
+            <div className="evaluate-rubric-footer">
+              <span>Total <strong>{SCORE_FIELDS.reduce((sum, field) => sum + Number(scores[field.key]), 0)}/25</strong></span>
+              <div className="actions">
+                <button type="button" className="btn btn--ghost" onClick={handleSkip} disabled={!detail || busy || status !== 'pending'}>Skip</button>
+                <button type="button" onClick={handleSaveNext} disabled={!detail || busy || status !== 'pending' || !validateQueueScores(scores)}>Save & Next</button>
+              </div>
+            </div>
+          </aside>
+        </div>
       )}
-    </div>
+    </section>
   );
 }

--- a/frontend/src/pages/ResultsUnified.tsx
+++ b/frontend/src/pages/ResultsUnified.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 import { MergedPageHeader } from '../components/MergedPageHeader.js';
+import { InferenceContextBar } from '../components/InferenceContextBar.js';
 import { ResultsGraphPanel } from '../components/results-graph-panel.js';
 import { normalizeResultsTab } from '../navigation.js';
 import { getLeaderboard, type LeaderboardEntry } from '../services/leaderboard-api.js';
@@ -18,6 +19,7 @@ import {
   type ResultsTab
 } from '../services/results-view-api.js';
 import type { DashboardPanel } from '../services/dashboard-results-api.js';
+import { DEFAULT_INFERENCE_PARAMS } from '../services/inference-param-presets-api.js';
 import { toLocalInputValue } from './ResultsDashboard.js';
 import '../styles/dashboard-results.css';
 
@@ -758,6 +760,7 @@ export function ResultsUnified({ runCount }: { runCount: number | null }) {
           </div>
         }
       />
+      <InferenceContextBar params={DEFAULT_INFERENCE_PARAMS} readOnly />
       <section className="results-page">
         <ResultsFilterRail
           filters={filters}

--- a/frontend/src/pages/RunUnified.tsx
+++ b/frontend/src/pages/RunUnified.tsx
@@ -2,6 +2,8 @@ import { useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 import { InferenceServerErrors } from '../components/InferenceServerErrors.js';
+import { InferenceContextBar } from '../components/InferenceContextBar.js';
+import { DEFAULT_INFERENCE_PARAMS, type InferenceParams } from '../services/inference-param-presets-api.js';
 import { InferenceServerRecord, listInferenceServers } from '../services/inference-servers-api.js';
 import { listModels, ModelRecord } from '../services/models-api.js';
 import { TemplateRecord, listTemplates } from '../services/templates-api.js';
@@ -86,6 +88,19 @@ function extractResponseText(item: RunGroupItem | null): string {
 
 function resultMetrics(item: RunGroupItem | null): Record<string, unknown> {
   return item?.results[0]?.metrics ?? {};
+}
+
+function tokenProgress(item: RunGroupItem | null): string {
+  const metrics = resultMetrics(item);
+  const tokens = typeof metrics.completion_tokens === 'number' ? metrics.completion_tokens : null;
+  const rate = typeof metrics.tokens_per_sec === 'number' ? metrics.tokens_per_sec : null;
+  if (tokens !== null && rate !== null) {
+    return `${tokens} tokens · ${rate.toFixed(1)} tok/s`;
+  }
+  if (tokens !== null) {
+    return `${tokens} tokens`;
+  }
+  return item?.status === 'queued' ? 'Queued' : 'Streaming response';
 }
 
 function resultAssertions(item: RunGroupItem | null): { passed: number; total: number } {
@@ -348,11 +363,13 @@ function RunUnifiedEmpty() {
 function SingleResponseDetail({
   target,
   option,
-  item
+  item,
+  onRetry
 }: {
   target: RunTarget;
   option: RunModelOption | undefined;
   item: RunGroupItem | null;
+  onRetry: (targets: RunTarget[]) => void;
 }) {
   const metrics = resultMetrics(item);
   const asserts = resultAssertions(item);
@@ -368,9 +385,17 @@ function SingleResponseDetail({
           </div>
           <b className={`run-status-pill status-${item?.status ?? 'idle'}`}>{item?.status ?? 'idle'}</b>
         </header>
-        <section className="run-message-card">
+        {item?.status === 'failed' ? (
+          <div className="run-failure-banner">
+            <strong>Connection lost: {option?.server_name ?? target.inference_server_id}</strong>
+            <span>{item.failure_reason ?? item.results[0]?.failure_reason ?? 'The target failed during this run.'}</span>
+            <button type="button" onClick={() => onRetry([target])}>Retry now</button>
+          </div>
+        ) : null}
+        <section className={item?.status === 'running' || item?.status === 'queued' ? 'run-message-card is-streaming' : 'run-message-card'}>
           <span>assistant · final</span>
-          <pre>{extractResponseText(item)}</pre>
+          {(item?.status === 'running' || item?.status === 'queued') ? <small>{tokenProgress(item)}</small> : null}
+          <pre>{extractResponseText(item)}{item?.status === 'running' || item?.status === 'queued' ? <i className="stream-cursor" /> : null}</pre>
         </section>
         <section className="run-asserts">
           <h3>Asserts · {asserts.passed} of {asserts.total} pass</h3>
@@ -397,7 +422,7 @@ function SingleResponseDetail({
           <pre>{JSON.stringify(item ?? {}, null, 2)}</pre>
         </details>
         <div className="run-side-actions">
-          <button type="button" disabled>Re-run with same params</button>
+          <button type="button" onClick={() => onRetry([target])} disabled={item?.status !== 'failed'}>Re-run with same params</button>
           <button type="button" disabled>Open in Evaluate</button>
           <button type="button" disabled>Copy as cURL</button>
         </div>
@@ -410,12 +435,14 @@ function CompareColumn({
   target,
   option,
   item,
-  index
+  index,
+  onRetry
 }: {
   target: RunTarget;
   option: RunModelOption | undefined;
   item: RunGroupItem | null;
   index: number;
+  onRetry: (targets: RunTarget[]) => void;
 }) {
   const metrics = resultMetrics(item);
   const asserts = resultAssertions(item);
@@ -437,9 +464,13 @@ function CompareColumn({
       </header>
       <div className="run-column-body">
         {status === 'failed' ? (
-          <div className="run-error-card">{item?.failure_reason ?? item?.results[0]?.failure_reason ?? 'Run failed.'}</div>
+          <div className="run-error-card">
+            <strong>{item?.failure_reason ?? item?.results[0]?.failure_reason ?? 'Run failed.'}</strong>
+            <button type="button" onClick={() => onRetry([target])}>Retry</button>
+          </div>
         ) : null}
-        <pre>{extractResponseText(item)}</pre>
+        {status === 'running' || status === 'queued' ? <small>{tokenProgress(item)}</small> : null}
+        <pre>{extractResponseText(item)}{status === 'running' || status === 'queued' ? <i className="stream-cursor" /> : null}</pre>
       </div>
     </article>
   );
@@ -472,6 +503,7 @@ export function RunUnified() {
   const [customModelId, setCustomModelId] = useState('');
   const [timeoutSec, setTimeoutSec] = useState('30');
   const [seed, setSeed] = useState('');
+  const [inferenceParams, setInferenceParams] = useState<InferenceParams>(DEFAULT_INFERENCE_PARAMS);
   const [runGroup, setRunGroup] = useState<RunGroupDetail | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -546,7 +578,7 @@ export function RunUnified() {
     setSelectedTargets((current) => current.filter((entry) => targetKey(entry) !== targetKey(target)));
   }
 
-  async function handleRun() {
+  async function startRun(targets = selectedTargets) {
     setBusy(true);
     setError(null);
     try {
@@ -559,10 +591,15 @@ export function RunUnified() {
       if (seed.trim() && Number.isFinite(seedValue)) {
         testOverrides.seed = seedValue;
       }
+      testOverrides.temperature = inferenceParams.temperature;
+      testOverrides.top_p = inferenceParams.top_p;
+      testOverrides.max_tokens = inferenceParams.max_tokens;
+      testOverrides.quantization_level = inferenceParams.quantization_level;
+      testOverrides.stream = inferenceParams.stream;
       const group = await createRunGroup({
-        targets: selectedTargets,
+        targets,
         selected_template_ids: selectedTemplateIds,
-        test_overrides: Object.keys(testOverrides).length ? testOverrides : undefined
+        test_overrides: testOverrides
       });
       setRunGroup(group);
     } catch (err) {
@@ -570,6 +607,18 @@ export function RunUnified() {
     } finally {
       setBusy(false);
     }
+  }
+
+  async function handleRun() {
+    await startRun(selectedTargets);
+  }
+
+  async function handleRetry(targets: RunTarget[]) {
+    const failedTargets = targets.filter((target) => {
+      const item = findItemForTarget(runGroup, target);
+      return item?.status === 'failed';
+    });
+    await startRun(failedTargets.length ? failedTargets : targets);
   }
 
   async function handleStop() {
@@ -625,6 +674,15 @@ export function RunUnified() {
               <button type="button" disabled={!runGroup}>Export</button>
             </div>
           </header>
+          <InferenceContextBar params={inferenceParams} onChange={setInferenceParams} />
+          {runGroup?.items.some((item) => item.status === 'failed') ? (
+            <div className="run-failure-banner">
+              <strong>One or more targets failed mid-run.</strong>
+              <span>Partial output is preserved. Retry starts a new run group for the failed target(s) with the same templates and params.</span>
+              <button type="button" onClick={() => handleRetry(selectedTargets)} disabled={busy}>Retry failed</button>
+              <button type="button" onClick={handleStop} disabled={busy}>Stop run</button>
+            </div>
+          ) : null}
           <SharedPromptStrip prompt={extractPrompt(selectedTemplate)} />
           {selectedTargets.length === 0 ? (
             <RunUnifiedEmpty />
@@ -633,6 +691,7 @@ export function RunUnified() {
               target={selectedTargets[0]}
               option={optionMap.get(targetKey(selectedTargets[0]))}
               item={findItemForTarget(runGroup, selectedTargets[0])}
+              onRetry={handleRetry}
             />
           ) : (
             <>
@@ -644,6 +703,7 @@ export function RunUnified() {
                     option={optionMap.get(targetKey(target))}
                     item={findItemForTarget(runGroup, target)}
                     index={index}
+                    onRetry={handleRetry}
                   />
                 ))}
               </div>

--- a/frontend/src/pages/Templates.tsx
+++ b/frontend/src/pages/Templates.tsx
@@ -1,30 +1,66 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
+import { EmptyState } from '../components/EmptyState.js';
+import { InferenceContextBar } from '../components/InferenceContextBar.js';
 import { TemplateEditor } from '../components/TemplateEditor.js';
-import { TemplateList } from '../components/TemplateList.js';
+import { DEFAULT_INFERENCE_PARAMS } from '../services/inference-param-presets-api.js';
 import {
   TemplateInput,
   TemplateRecord,
+  TemplateType,
   createTemplate,
   deleteTemplate,
   listTemplates,
   updateTemplate
 } from '../services/templates-api.js';
 
+type TemplateMode = { kind: 'preview' } | { kind: 'create'; type: TemplateType } | { kind: 'edit' };
+
+function parseTemplateStats(template: TemplateRecord): { stepCount: number; assertionCount: number; summary: string } {
+  try {
+    const parsed = JSON.parse(template.content) as Record<string, unknown>;
+    const steps = Array.isArray(parsed.steps) ? parsed.steps.length : 0;
+    const assertions = Array.isArray(parsed.assertions) ? parsed.assertions.length : 0;
+    const description = typeof parsed.description === 'string' ? parsed.description : '';
+    return { stepCount: steps, assertionCount: assertions, summary: description || `${template.type.toUpperCase()} template` };
+  } catch {
+    return { stepCount: 0, assertionCount: 0, summary: `${template.type.toUpperCase()} template` };
+  }
+}
+
+function formatDate(value: string): string {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleDateString();
+}
+
 export function Templates() {
   const [templates, setTemplates] = useState<TemplateRecord[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [mode, setMode] = useState<TemplateMode>({ kind: 'preview' });
+  const [query, setQuery] = useState('');
+  const [typeFilter, setTypeFilter] = useState<'all' | TemplateType>('all');
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  const [params, setParams] = useState(DEFAULT_INFERENCE_PARAMS);
 
   const selectedTemplate = useMemo(
     () => templates.find((template) => template.id === selectedId) ?? null,
     [templates, selectedId]
   );
 
+  const filteredTemplates = useMemo(() => {
+    const lower = query.trim().toLowerCase();
+    return templates.filter((template) => {
+      if (typeFilter !== 'all' && template.type !== typeFilter) return false;
+      if (!lower) return true;
+      return [template.name, template.id, template.type].some((value) => value.toLowerCase().includes(lower));
+    });
+  }, [query, templates, typeFilter]);
+
   const loadTemplates = useCallback(async () => {
     const data = await listTemplates();
     setTemplates(data);
+    setSelectedId((current) => current && data.some((template) => template.id === current) ? current : data[0]?.id ?? null);
   }, []);
 
   useEffect(() => {
@@ -47,6 +83,7 @@ export function Templates() {
       }
       await loadTemplates();
       setSelectedId(input.id);
+      setMode({ kind: 'preview' });
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Unable to save template');
     } finally {
@@ -56,9 +93,7 @@ export function Templates() {
 
   async function handleDelete(template: TemplateRecord) {
     const confirmed = window.confirm(`Delete template "${template.name}"?`);
-    if (!confirmed) {
-      return;
-    }
+    if (!confirmed) return;
     setError(null);
     setBusy(true);
     try {
@@ -75,28 +110,129 @@ export function Templates() {
   }
 
   return (
-    <section className="page templates-page">
-      <div className="page-header">
-        <h2>Templates</h2>
-        <p className="muted">Manage JSON and Python templates for the test library.</p>
+    <section className="page templates-page templates-page--polish">
+      <div className="page-header templates-header">
+        <div>
+          <h2>Templates</h2>
+          <p className="muted">JSON and Python test definitions.</p>
+        </div>
+        <div className="actions">
+          <button type="button" onClick={() => setMode({ kind: 'create', type: 'json' })} disabled={busy}>New JSON</button>
+          <button type="button" className="btn btn--ghost" onClick={() => setMode({ kind: 'create', type: 'python' })} disabled={busy}>New Python</button>
+        </div>
       </div>
-      <div className="actions" style={{ marginBottom: 16 }}>
-        <button type="button" onClick={() => setSelectedId(null)} disabled={busy}>
-          New template
-        </button>
-        <button type="button" onClick={() => loadTemplates()} disabled={busy}>
-          Refresh
-        </button>
-      </div>
-      <div className="templates-grid">
-        <TemplateList
-          templates={templates}
-          selectedId={selectedId}
-          onSelect={(template) => setSelectedId(template.id)}
-          onDelete={handleDelete}
+      <InferenceContextBar params={params} onChange={setParams} visible={Boolean(selectedTemplate || mode.kind !== 'preview')} />
+      {error ? <div className="error">{error}</div> : null}
+      {templates.length === 0 && mode.kind === 'preview' ? (
+        <EmptyState
+          className="templates-empty"
+          title="Your tests live here"
+          body="Create one from a JSON schema or a Python script."
+          actions={(
+            <>
+              <button type="button" onClick={() => setMode({ kind: 'create', type: 'json' })}>New JSON</button>
+              <button type="button" className="btn btn--ghost" onClick={() => setMode({ kind: 'create', type: 'python' })}>New Python</button>
+            </>
+          )}
         />
-        <TemplateEditor template={selectedTemplate} onSave={handleSave} error={error} busy={busy} />
-      </div>
+      ) : (
+        <div className="templates-layout">
+          <aside className="templates-rail">
+            <div className="templates-rail-tools">
+              <input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="Search templates" />
+              <div className="segmented-control" aria-label="Template type">
+                {(['all', 'json', 'python'] as const).map((value) => (
+                  <button key={value} type="button" className={typeFilter === value ? 'is-active' : ''} onClick={() => setTypeFilter(value)}>
+                    {value}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="templates-list">
+              {filteredTemplates.map((template) => {
+                const stats = parseTemplateStats(template);
+                return (
+                  <button
+                    key={template.id}
+                    type="button"
+                    className={selectedId === template.id && mode.kind !== 'create' ? 'template-row is-selected' : 'template-row'}
+                    onClick={() => {
+                      setSelectedId(template.id);
+                      setMode({ kind: 'preview' });
+                    }}
+                  >
+                    <span className={`template-kind template-kind--${template.type}`}>{template.type}</span>
+                    <span>
+                      <strong>{template.name}</strong>
+                      <small>v{template.version} · {stats.stepCount} steps · {stats.assertionCount} asserts</small>
+                    </span>
+                  </button>
+                );
+              })}
+              {filteredTemplates.length === 0 ? <p className="muted">No templates match the current filters.</p> : null}
+            </div>
+          </aside>
+          <main className="templates-preview">
+            {mode.kind === 'create' ? (
+              <TemplateEditor template={null} onSave={handleSave} error={error} busy={busy} initialType={mode.type} />
+            ) : mode.kind === 'edit' && selectedTemplate ? (
+              <TemplateEditor template={selectedTemplate} onSave={handleSave} error={error} busy={busy} />
+            ) : selectedTemplate ? (
+              <TemplatePreview
+                template={selectedTemplate}
+                onEdit={() => setMode({ kind: 'edit' })}
+                onDelete={() => handleDelete(selectedTemplate)}
+              />
+            ) : (
+              <EmptyState
+                title="Select a template"
+                body="Choose a JSON or Python template from the list to preview its schema, invocation, and version details."
+              />
+            )}
+          </main>
+        </div>
+      )}
     </section>
+  );
+}
+
+function TemplatePreview({
+  template,
+  onEdit,
+  onDelete
+}: {
+  template: TemplateRecord;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  const stats = parseTemplateStats(template);
+  return (
+    <article className="template-preview-panel">
+      <header>
+        <div>
+          <span className={`template-kind template-kind--${template.type}`}>{template.type}</span>
+          <h2>{template.name}</h2>
+          <p>{stats.summary}</p>
+        </div>
+        <div className="actions">
+          <button type="button" className="btn btn--ghost" onClick={onEdit}>Edit</button>
+          <button type="button" className="btn btn--ghost" onClick={onDelete}>Delete</button>
+        </div>
+      </header>
+      <div className="template-preview-grid">
+        <div className="kv"><span>Template ID</span><strong>{template.id}</strong></div>
+        <div className="kv"><span>Version</span><strong>{template.version}</strong></div>
+        <div className="kv"><span>Updated</span><strong>{formatDate(template.updated_at)}</strong></div>
+        <div className="kv"><span>Shape</span><strong>{stats.stepCount} steps · {stats.assertionCount} asserts</strong></div>
+      </div>
+      <section>
+        <h3>Schema view</h3>
+        <pre>{template.content}</pre>
+      </section>
+      <section>
+        <h3>Example invocation</h3>
+        <code>Run {'->'} {template.id}@{template.version}</code>
+      </section>
+    </article>
   );
 }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -30,6 +30,9 @@ export async function apiPost<T>(path: string, payload: unknown): Promise<T> {
   if (!response.ok) {
     throw new Error(await parseError(response));
   }
+  if (response.status === 204) {
+    return undefined as T;
+  }
   return (await response.json()) as T;
 }
 

--- a/frontend/src/services/connectivity-api.ts
+++ b/frontend/src/services/connectivity-api.ts
@@ -6,6 +6,7 @@ export type InferenceServerHealth = {
   status_code: number | null;
   response_time_ms: number | null;
   checked_at: string;
+  error?: string | null;
 };
 
 export async function getInferenceServerHealth(): Promise<InferenceServerHealth[]> {

--- a/frontend/src/services/evaluation-queue-api.ts
+++ b/frontend/src/services/evaluation-queue-api.ts
@@ -1,0 +1,75 @@
+import { apiGet, apiPost } from './api.js';
+import type { InferenceParams } from './inference-param-presets-api.js';
+
+export type EvaluationQueueStatus = 'pending' | 'done' | 'skipped';
+
+export interface EvaluationQueueItem {
+  test_result_id: string;
+  run_id: string;
+  test_id: string;
+  template_id: string;
+  template_label: string;
+  model_name: string;
+  server_id: string;
+  server_name: string;
+  verdict: string;
+  status: EvaluationQueueStatus;
+  started_at: string;
+  ended_at: string | null;
+}
+
+export interface EvaluationQueueDetail extends EvaluationQueueItem {
+  inference_config: InferenceParams;
+  prompt_text: string;
+  answer_text: string;
+  metrics: Record<string, unknown>;
+  artefacts: Record<string, unknown>;
+  raw_events: unknown;
+  document: Record<string, unknown>;
+  evaluation_id: string | null;
+  skipped_at: string | null;
+}
+
+export interface EvaluationQueueResponse {
+  counts: Record<EvaluationQueueStatus, number>;
+  items: EvaluationQueueItem[];
+}
+
+export interface EvaluationQueueScoreInput {
+  accuracy_score: number;
+  relevance_score: number;
+  coherence_score: number;
+  completeness_score: number;
+  helpfulness_score: number;
+  note: string | null;
+}
+
+export function isValidQueueScore(value: number): boolean {
+  return Number.isInteger(value) && value >= 1 && value <= 5;
+}
+
+export function validateQueueScores(input: EvaluationQueueScoreInput): boolean {
+  return [
+    input.accuracy_score,
+    input.relevance_score,
+    input.coherence_score,
+    input.completeness_score,
+    input.helpfulness_score
+  ].every(isValidQueueScore);
+}
+
+export async function listEvaluationQueue(status: EvaluationQueueStatus): Promise<EvaluationQueueResponse> {
+  return apiGet<EvaluationQueueResponse>(`/evaluation-queue?status=${status}`);
+}
+
+export async function getEvaluationQueueDetail(testResultId: string): Promise<EvaluationQueueDetail> {
+  return apiGet<EvaluationQueueDetail>(`/evaluation-queue/${testResultId}`);
+}
+
+export async function scoreEvaluationQueueItem(testResultId: string, input: EvaluationQueueScoreInput): Promise<unknown> {
+  return apiPost(`/evaluation-queue/${testResultId}/score`, input);
+}
+
+export async function skipEvaluationQueueItem(testResultId: string, reason?: string): Promise<void> {
+  await apiPost(`/evaluation-queue/${testResultId}/skip`, { reason: reason ?? null });
+}

--- a/frontend/src/services/inference-param-presets-api.ts
+++ b/frontend/src/services/inference-param-presets-api.ts
@@ -1,0 +1,48 @@
+import { apiDelete, apiGet, apiPatch, apiPost } from './api.js';
+
+export interface InferenceParams {
+  temperature: number | null;
+  top_p: number | null;
+  max_tokens: number | null;
+  quantization_level: string | null;
+  stream: boolean | null;
+}
+
+export interface InferenceParamPreset {
+  id: string;
+  name: string;
+  parameters: InferenceParams;
+  created_at: string;
+  updated_at: string;
+}
+
+export const DEFAULT_INFERENCE_PARAMS: InferenceParams = {
+  temperature: 0.7,
+  top_p: 0.95,
+  max_tokens: 2048,
+  quantization_level: null,
+  stream: false
+};
+
+export async function listInferenceParamPresets(): Promise<InferenceParamPreset[]> {
+  const response = await apiGet<{ items: InferenceParamPreset[] }>('/inference-param-presets');
+  return response.items;
+}
+
+export async function createInferenceParamPreset(input: {
+  name: string;
+  parameters: InferenceParams;
+}): Promise<InferenceParamPreset> {
+  return apiPost<InferenceParamPreset>('/inference-param-presets', input);
+}
+
+export async function updateInferenceParamPreset(
+  id: string,
+  input: { name?: string; parameters?: InferenceParams }
+): Promise<InferenceParamPreset> {
+  return apiPatch<InferenceParamPreset>(`/inference-param-presets/${id}`, input);
+}
+
+export async function deleteInferenceParamPreset(id: string): Promise<void> {
+  await apiDelete(`/inference-param-presets/${id}`);
+}

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -269,6 +269,64 @@ h2 {
   font-size: 10px;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+}
+
+.reg-light-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  width: fit-content;
+  color: var(--ink-6);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  line-height: 1.2;
+}
+
+.reg-light-wrap.is-compact {
+  gap: 0;
+}
+
+.reg-light-dot {
+  width: 9px;
+  height: 9px;
+  display: inline-block;
+  border-radius: 999px;
+  background: var(--ink-3);
+  box-shadow: 0 0 0 3px rgba(55, 53, 47, 0.08);
+}
+
+.reg-light-dot--healthy {
+  background: var(--ok);
+  box-shadow: 0 0 0 3px var(--ok-halo);
+}
+
+.reg-light-dot--degraded {
+  background: var(--pending);
+  box-shadow: 0 0 0 3px var(--pending-halo);
+}
+
+.reg-light-dot--down {
+  background: var(--danger);
+  box-shadow: 0 0 0 3px var(--danger-halo);
+  animation: reg-light-pulse 1.4s ease-in-out infinite alternate;
+}
+
+.reg-light-dot--unknown {
+  background: var(--ink-3);
+}
+
+@keyframes reg-light-pulse {
+  from { transform: scale(0.9); opacity: 0.7; }
+  to { transform: scale(1.16); opacity: 1; }
+}
+
 .sidebar-settings strong {
   font-size: 12px;
   font-weight: 600;
@@ -535,6 +593,279 @@ button.is-pending::after {
   grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   gap: 20px;
   align-items: start;
+}
+
+.empty-state {
+  min-height: 420px;
+  display: grid;
+  place-items: center;
+  align-content: center;
+  gap: 12px;
+  padding: 40px;
+  text-align: center;
+}
+
+.empty-state h2 {
+  margin: 0;
+}
+
+.empty-state p {
+  max-width: 520px;
+  margin: 0;
+  color: var(--ink-4);
+  line-height: 1.5;
+}
+
+.empty-state__blocks {
+  display: flex;
+  gap: 10px;
+}
+
+.empty-state__blocks span {
+  width: 80px;
+  height: 104px;
+  border: 1px dashed var(--gold-4);
+  border-radius: 8px;
+  background: var(--paper-2);
+}
+
+.empty-state__actions,
+.templates-header,
+.evaluate-header,
+.context-bar,
+.context-bar__form {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.templates-header,
+.evaluate-header {
+  justify-content: space-between;
+}
+
+.context-bar {
+  min-height: 42px;
+  padding: 7px 20px;
+  border-bottom: 1px solid var(--paper-7);
+  background: var(--paper-1);
+}
+
+.context-bar__label,
+.context-bar__message {
+  color: var(--ink-3);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+}
+
+.context-bar__message {
+  text-transform: none;
+}
+
+.context-bar__spacer {
+  flex: 1;
+}
+
+.param-chip {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  min-height: 26px;
+  padding: 3px 8px;
+  border: 1px solid var(--paper-7);
+  border-radius: 999px;
+  background: var(--paper-2);
+  color: var(--ink-8);
+}
+
+.param-chip span,
+.context-bar__form label {
+  color: var(--ink-3);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  text-transform: uppercase;
+}
+
+.param-chip b {
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.context-bar__form label {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  margin: 0;
+}
+
+.context-bar__form input {
+  width: 82px;
+  min-height: 26px;
+  padding: 3px 6px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.context-bar__form .context-bar__toggle input {
+  width: auto;
+}
+
+.templates-layout {
+  display: grid;
+  grid-template-columns: 280px minmax(0, 1fr);
+  min-height: calc(100vh - 220px);
+  border: 1px solid var(--paper-7);
+  background: var(--paper-1);
+}
+
+.templates-rail {
+  border-right: 1px solid var(--paper-7);
+  background: var(--paper-2);
+}
+
+.templates-rail-tools {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+  border-bottom: 1px solid var(--paper-7);
+}
+
+.segmented-control {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  border: 1px solid var(--paper-7);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.segmented-control button {
+  border: 0;
+  border-right: 1px solid var(--paper-7);
+  border-radius: 0;
+  background: var(--paper-1);
+  color: var(--ink-4);
+  box-shadow: none;
+  font-size: 11px;
+}
+
+.segmented-control button:last-child {
+  border-right: 0;
+}
+
+.segmented-control button.is-active {
+  background: var(--ink-9);
+  color: var(--paper-1);
+}
+
+.templates-list {
+  display: grid;
+  gap: 0;
+}
+
+.template-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 10px;
+  width: 100%;
+  padding: 11px 12px;
+  border: 0;
+  border-bottom: 1px solid var(--paper-7);
+  border-left: 3px solid transparent;
+  border-radius: 0;
+  background: transparent;
+  color: var(--ink-8);
+  text-align: left;
+  box-shadow: none;
+}
+
+.template-row.is-selected {
+  border-left-color: var(--gold-9);
+  background: var(--bg-selected);
+}
+
+.template-row strong,
+.template-row small {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.template-row small {
+  margin-top: 3px;
+  color: var(--ink-3);
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+
+.template-kind {
+  align-self: start;
+  border-radius: 999px;
+  padding: 2px 7px;
+  background: var(--paper-7);
+  color: var(--ink-6);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  text-transform: uppercase;
+}
+
+.template-kind--python {
+  background: #e4eef5;
+  color: #2a5f82;
+}
+
+.templates-preview {
+  min-width: 0;
+  overflow: auto;
+  padding: 18px;
+}
+
+.template-editor-card,
+.template-preview-panel {
+  display: grid;
+  gap: 14px;
+  max-width: 980px;
+}
+
+.template-preview-panel header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.template-preview-panel h2 {
+  margin: 8px 0 4px;
+}
+
+.template-preview-panel p {
+  margin: 0;
+  color: var(--ink-4);
+}
+
+.template-preview-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.template-preview-panel pre,
+.run-detail-display pre {
+  overflow: auto;
+  max-height: 420px;
+  margin: 8px 0 0;
+  padding: 12px;
+  border: 1px solid var(--paper-7);
+  border-radius: 8px;
+  background: var(--paper-2);
+  color: var(--ink-8);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .targets-column {
@@ -1123,6 +1454,61 @@ button.is-pending::after {
   font-size: 12px;
 }
 
+.run-error-card button {
+  margin-top: 8px;
+}
+
+.run-failure-banner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 10px 20px 0;
+  padding: 10px 14px;
+  border: 1px solid #d99a9a;
+  border-radius: 8px;
+  background: #f7e4e4;
+  color: #8a2929;
+  font-size: 12px;
+}
+
+.run-transcript .run-failure-banner {
+  margin: 12px 0 0;
+}
+
+.run-failure-banner span {
+  flex: 1;
+  line-height: 1.4;
+}
+
+.run-message-card.is-streaming {
+  border-color: var(--gold-4);
+  background: #fff9ec;
+}
+
+.run-message-card small,
+.run-column-body small {
+  display: block;
+  margin-top: 6px;
+  color: var(--ink-3);
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+
+.stream-cursor {
+  display: inline-block;
+  width: 7px;
+  height: 13px;
+  margin-left: 4px;
+  vertical-align: -2px;
+  background: var(--gold-9);
+  animation: stream-cursor-blink 1s steps(2, start) infinite;
+}
+
+@keyframes stream-cursor-blink {
+  0%, 45% { opacity: 1; }
+  46%, 100% { opacity: 0; }
+}
+
 .run-summary-footer {
   display: flex;
   align-items: center;
@@ -1132,6 +1518,213 @@ button.is-pending::after {
   padding: 10px 16px;
   border-top: 1px solid var(--paper-7);
   background: var(--paper-2);
+}
+
+.evaluate-queue-layout {
+  display: grid;
+  grid-template-columns: 280px minmax(0, 1fr) 320px;
+  min-height: calc(100vh - 220px);
+  border: 1px solid var(--paper-7);
+  background: var(--paper-1);
+}
+
+.evaluate-queue-rail,
+.evaluate-rubric {
+  background: var(--paper-2);
+}
+
+.evaluate-queue-rail {
+  border-right: 1px solid var(--paper-7);
+}
+
+.evaluate-rubric {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 16px;
+  border-left: 1px solid var(--paper-7);
+}
+
+.evaluate-tabs {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  border-bottom: 1px solid var(--paper-7);
+}
+
+.evaluate-tabs button {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: var(--ink-4);
+  box-shadow: none;
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+
+.evaluate-tabs button.is-active {
+  border-bottom: 2px solid var(--gold-9);
+  background: var(--paper-1);
+  color: var(--ink-9);
+}
+
+.evaluate-queue-list {
+  display: grid;
+}
+
+.evaluate-queue-row {
+  display: grid;
+  gap: 4px;
+  width: 100%;
+  padding: 10px 12px;
+  border: 0;
+  border-bottom: 1px solid var(--paper-7);
+  border-left: 3px solid transparent;
+  border-radius: 0;
+  background: transparent;
+  color: var(--ink-8);
+  text-align: left;
+  box-shadow: none;
+}
+
+.evaluate-queue-row.is-selected {
+  border-left-color: var(--gold-9);
+  background: var(--bg-selected);
+}
+
+.evaluate-queue-row span {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.evaluate-queue-row small {
+  overflow: hidden;
+  color: var(--ink-3);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.evaluate-run-panel {
+  min-width: 0;
+  overflow: auto;
+}
+
+.run-detail-display {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+}
+
+.run-detail-display header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--paper-7);
+}
+
+.run-detail-display h2 {
+  margin: 4px 0 0;
+  font-family: var(--font-mono);
+  font-size: 16px;
+}
+
+.run-detail-display.is-empty {
+  justify-content: center;
+  align-items: center;
+  padding: 40px;
+  text-align: center;
+}
+
+.run-detail-columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  min-height: 0;
+}
+
+.run-detail-columns section {
+  min-width: 0;
+  padding: 16px;
+  border-right: 1px solid var(--paper-7);
+}
+
+.run-detail-columns section:last-child {
+  border-right: 0;
+}
+
+.run-detail-kv {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 8px 12px;
+  margin-top: 8px;
+  font-size: 12px;
+}
+
+.run-detail-kv span {
+  color: var(--ink-3);
+}
+
+.score-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+  margin: 0;
+  padding: 10px;
+  border: 1px solid var(--paper-7);
+  border-radius: 8px;
+  background: var(--paper-1);
+}
+
+.score-row.is-active {
+  border-color: var(--gold-9);
+  background: var(--bg-selected);
+}
+
+.score-row span {
+  font-weight: 600;
+}
+
+.score-row strong {
+  font-family: var(--font-mono);
+  color: var(--ink-3);
+}
+
+.score-row input {
+  grid-column: 1 / -1;
+}
+
+.evaluate-notes {
+  margin: 0;
+  color: var(--ink-3);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+}
+
+.evaluate-rubric-footer {
+  display: grid;
+  gap: 10px;
+  margin-top: auto;
+  padding-top: 12px;
+  border-top: 1px dashed var(--paper-7);
+}
+
+.evaluate-rubric-footer > span {
+  display: flex;
+  justify-content: space-between;
+}
+
+.status-pass {
+  background: #d7ebdd;
+  color: #1f6b3c;
+}
+
+.status-fail {
+  background: #f1d1d1;
+  color: #9a3030;
 }
 
 .run-summary-footer > span {

--- a/frontend/tests/e2e/evaluate.spec.ts
+++ b/frontend/tests/e2e/evaluate.spec.ts
@@ -1,128 +1,114 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 
-test.describe('Evaluate page', () => {
-  test.beforeEach(async ({ page }) => {
+const detail = {
+  test_result_id: 'queue-result-1',
+  run_id: 'run-queue-1',
+  test_id: 'template-queue-active',
+  template_id: 'tool-calling',
+  template_label: 'Tool calling',
+  model_name: 'mistral:latest',
+  server_id: 'srv-local',
+  server_name: 'Local Server',
+  verdict: 'pass',
+  status: 'pending',
+  started_at: '2026-05-09T10:00:00.000Z',
+  ended_at: '2026-05-09T10:00:01.000Z',
+  inference_config: { temperature: 0.2, top_p: 0.9, max_tokens: 128, quantization_level: 'Q4', stream: true },
+  prompt_text: 'What is the weather in Paris?',
+  answer_text: 'Paris is rainy.',
+  metrics: { latency_ms: 42, total_tokens: 16 },
+  artefacts: { response_body: 'Paris is rainy.' },
+  raw_events: [],
+  document: { prompt: 'What is the weather in Paris?' },
+  evaluation_id: null,
+  skipped_at: null
+};
+
+async function mockPresets(page: Page) {
+  await page.route('**/inference-param-presets', async (route) => {
+    await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ items: [] }) });
+  });
+}
+
+test.describe('Evaluate queue', () => {
+  test('shows the queue empty state', async ({ page }) => {
+    await mockPresets(page);
+    await page.route('**/evaluation-queue?status=pending', async (route) => {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ counts: { pending: 0, done: 0, skipped: 0 }, items: [] })
+      });
+    });
+
     await page.goto('/evaluate');
+
     await expect(page.getByRole('heading', { name: 'Evaluate' })).toBeVisible();
+    await expect(page.getByText('Params')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'All caught up' })).toBeVisible();
   });
 
-  test('shows the evaluation form with all required inputs', async ({ page }) => {
-    await expect(page.locator('.evaluation-form select').first()).toBeVisible();
-    await expect(page.getByPlaceholder('Enter your prompt...')).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Run Inference' })).toBeVisible();
-  });
+  test('scores, skips, and advances queue items', async ({ page }) => {
+    await mockPresets(page);
+    let pending = [detail];
+    let done = 0;
+    let skipped = 0;
 
-  test('validation flow — Run button is disabled without server, model, and prompt', async ({ page }) => {
-    const runButton = page.getByRole('button', { name: 'Run Inference' });
-    await expect(runButton).toBeDisabled();
-  });
+    await page.route('**/evaluation-queue**', async (route) => {
+      const request = route.request();
+      const url = new URL(request.url());
+      const parts = url.pathname.split('/').filter(Boolean);
 
-  // T040 [US4] — Compare mode
-  test('compare mode — activates with toggle and shows two forms', async ({ page }) => {
-    await page.getByRole('button', { name: 'Compare Mode' }).click();
-    await expect(page.locator('.shared-prompt-area')).toBeVisible();
-    await expect(page.locator('.evaluation-form')).toHaveCount(2);
-  });
+      if (request.method() === 'GET' && parts.length === 1) {
+        const status = url.searchParams.get('status') ?? 'pending';
+        const items = status === 'pending' ? pending : [];
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({ counts: { pending: pending.length, done, skipped }, items })
+        });
+        return;
+      }
 
-  test('compare mode — can add up to 4 models', async ({ page }) => {
-    await page.getByRole('button', { name: 'Compare Mode' }).click();
-    await page.getByRole('button', { name: '+' }).click();
-    await expect(page.locator('.evaluation-form')).toHaveCount(3);
-    await page.getByRole('button', { name: '+' }).click();
-    await expect(page.locator('.evaluation-form')).toHaveCount(4);
-    await expect(page.getByRole('button', { name: '+' })).toBeDisabled();
-  });
+      if (request.method() === 'GET' && parts[1] === detail.test_result_id) {
+        await route.fulfill({ contentType: 'application/json', body: JSON.stringify(detail) });
+        return;
+      }
 
-  test('compare mode — toggle off returns to single form', async ({ page }) => {
-    await page.getByRole('button', { name: 'Compare Mode' }).click();
-    await page.getByRole('button', { name: 'Single Mode' }).click();
-    await expect(page.locator('.evaluation-form')).toHaveCount(1);
-    await expect(page.locator('.shared-prompt-area')).not.toBeVisible();
-  });
-});
+      if (request.method() === 'POST' && parts[2] === 'score') {
+        pending = [];
+        done = 1;
+        await route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify({ id: 'eval-1', source_test_result_id: detail.test_result_id }) });
+        return;
+      }
 
-test('Evaluate page model menu uses discovered server models when model records are empty', async ({ page }) => {
-  const serverPayload = [
-    {
-      inference_server: {
-        server_id: 'srv-discovered-models',
-        display_name: 'Discovered Models Server',
-        active: true,
-        archived: false,
-        created_at: '2026-05-05T00:00:00.000Z',
-        updated_at: '2026-05-05T00:00:00.000Z',
-        archived_at: null
-      },
-      runtime: {
-        retrieved_at: '2026-05-05T00:00:00.000Z',
-        source: 'server',
-        server_software: { name: 'Test Runtime', version: null, build: null },
-        api: { schema_family: ['openai-compatible'], api_version: null },
-        platform: {
-          os: { name: 'unknown', version: null, arch: 'unknown' },
-          container: { type: 'none', image: null }
-        },
-        hardware: {
-          cpu: { model: null, cores: null },
-          gpu: [],
-          ram_mb: null
-        }
-      },
-      endpoints: { base_url: 'http://localhost:11434', health_url: null, https: false },
-      auth: { type: 'none', header_name: 'Authorization', token_env: null },
-      capabilities: {
-        server: { streaming: false, models_endpoint: true },
-        generation: { text: true, json_schema_output: false, tools: false, embeddings: false },
-        multimodal: {
-          vision: { input_images: false, output_images: false },
-          audio: { input_audio: false, output_audio: false }
-        },
-        reasoning: { exposed: false, token_budget_configurable: false },
-        concurrency: { parallel_requests: false, parallel_tool_calls: false, max_concurrent_requests: null },
-        enforcement: 'server'
-      },
-      discovery: {
-        retrieved_at: '2026-05-05T00:00:00.000Z',
-        ttl_seconds: 300,
-        model_list: {
-          raw: {},
-          normalised: [
-            {
-              model_id: 'mistral:latest',
-              display_name: 'Mistral Latest',
-              context_window_tokens: null,
-              quantisation: null
-            }
-          ]
-        }
-      },
-      raw: {}
-    }
-  ];
+      if (request.method() === 'POST' && parts[2] === 'skip') {
+        pending = [];
+        skipped = 1;
+        await route.fulfill({ status: 204 });
+        return;
+      }
 
-  await page.route('**/inference-servers?*', async (route) => {
-    await route.fulfill({
-      contentType: 'application/json',
-      body: JSON.stringify(serverPayload)
+      await route.fallback();
     });
-  });
-  await page.route('**/inference-servers', async (route) => {
-    await route.fulfill({
-      contentType: 'application/json',
-      body: JSON.stringify(serverPayload)
-    });
-  });
-  await page.route('**/models', async (route) => {
-    await route.fulfill({ contentType: 'application/json', body: JSON.stringify([]) });
-  });
 
-  await page.goto('/evaluate');
-  const formSelects = page.locator('.evaluation-form select');
-  const serverSelect = formSelects.first();
-  const modelSelect = formSelects.nth(1);
+    await page.goto('/evaluate');
+    await expect(page.locator('.evaluate-queue-list').getByText('mistral:latest', { exact: true })).toBeVisible();
+    await expect(page.locator('.run-detail-columns section').nth(1).getByText('Paris is rainy.', { exact: true })).toBeVisible();
 
-  await serverSelect.selectOption('srv-discovered-models');
-  await expect(modelSelect).toContainText('Mistral Latest');
-  await modelSelect.selectOption('mistral:latest');
-  await expect(modelSelect).toHaveValue('mistral:latest');
+    await page.keyboard.press('5');
+    await expect(page.locator('.score-row').first()).toContainText('5/5');
+    await page.getByRole('button', { name: 'Save & Next' }).click();
+    await expect(page.getByRole('heading', { name: 'All caught up' })).toBeVisible();
+
+    pending = [detail];
+    done = 0;
+    await page.getByRole('button', { name: 'Refresh' }).click();
+    await expect(page.locator('.evaluate-queue-list').getByText('mistral:latest', { exact: true })).toBeVisible();
+    await expect(page.locator('.run-detail-columns section').nth(1).getByText('Paris is rainy.', { exact: true })).toBeVisible();
+    const skipResponse = page.waitForResponse((response) => (
+      response.url().includes(`/evaluation-queue/${detail.test_result_id}/skip`) && response.status() === 204
+    ));
+    await page.locator('.evaluate-rubric').getByRole('button', { name: 'Skip', exact: true }).click();
+    await skipResponse;
+    await expect(page.getByRole('heading', { name: 'All caught up' })).toBeVisible();
+  });
 });

--- a/frontend/tests/e2e/navigation-shell.spec.ts
+++ b/frontend/tests/e2e/navigation-shell.spec.ts
@@ -27,6 +27,7 @@ test('sidebar exposes five top-level destinations and follows active routes', as
 
 test('merged page sub-tabs preserve route state', async ({ page }) => {
   await page.goto('/catalog?tab=servers');
+  await expect(page.locator('.context-bar').getByText('Params')).toBeVisible();
   await page.getByRole('tab', { name: /Models/ }).click();
   await expect(page).toHaveURL(/\/catalog\?tab=models/);
 

--- a/frontend/tests/e2e/run-single-templates.spec.ts
+++ b/frontend/tests/e2e/run-single-templates.spec.ts
@@ -77,7 +77,7 @@ test('instantiates templates in Run', async ({ page, request }) => {
 
     const inferenceServerSelect = page.getByRole('combobox', { name: 'Inference server', exact: true });
     await expect(inferenceServerSelect).toBeVisible();
-    const availableServerLabels = await inferenceServerSelect.evaluate((element) => {
+    const getServerLabels = () => inferenceServerSelect.evaluate((element) => {
       if (!(element instanceof HTMLSelectElement)) {
         return [];
       }
@@ -85,7 +85,8 @@ test('instantiates templates in Run', async ({ page, request }) => {
         .map((option) => option.text.trim())
         .filter((label) => label.length > 0 && label !== 'Select an inference server');
     });
-    expect(availableServerLabels.length).toBeGreaterThan(0);
+    await expect.poll(async () => (await getServerLabels()).length).toBeGreaterThan(0);
+    const availableServerLabels = await getServerLabels();
     if (availableServerLabels.includes(serverDisplayName)) {
       await inferenceServerSelect.selectOption({ label: serverDisplayName });
     } else {

--- a/frontend/tests/e2e/templates-crud.spec.ts
+++ b/frontend/tests/e2e/templates-crud.spec.ts
@@ -41,9 +41,8 @@ test('creates, updates, and deletes templates from the dashboard', async ({ page
 
   try {
     await page.goto('/templates');
-    const createForm = page
-      .locator('form')
-      .filter({ has: page.getByRole('heading', { name: 'Create template' }) });
+    await page.getByRole('button', { name: 'New JSON' }).first().click();
+    const createForm = page.locator('form').filter({ has: page.getByRole('heading', { name: 'Create template' }) });
     await expect(createForm).toBeVisible();
 
     await createForm.getByLabel('Template ID').fill(templateId);
@@ -52,29 +51,29 @@ test('creates, updates, and deletes templates from the dashboard', async ({ page
     await createForm.getByRole('textbox', { name: 'Content', exact: true }).fill(jsonContent);
     await createForm.getByRole('button', { name: 'Save' }).click();
 
-    const listCard = page.locator('.card').filter({ has: page.getByRole('heading', { name: 'Templates' }) });
-    const createdRow = listCard.locator('.list-item').filter({ hasText: templateId });
+    const createdRow = page.locator('.template-row').filter({ hasText: templateName });
     await expect(createdRow).toBeVisible();
     await expect(createdRow).toContainText(templateName);
 
-    await createdRow.getByRole('button', { name: 'Edit' }).click();
-    const editForm = page
-      .locator('form')
-      .filter({ has: page.getByRole('heading', { name: 'Edit template' }) });
+    await createdRow.click();
+    await expect(page.locator('.template-preview-panel')).toContainText(templateId);
+    await page.locator('.template-preview-panel').getByRole('button', { name: 'Edit' }).click();
+    const editForm = page.locator('form').filter({ has: page.getByRole('heading', { name: 'Edit template' }) });
     await expect(editForm).toBeVisible();
     await editForm.getByLabel('Name', { exact: true }).fill(updatedName);
     await editForm.getByLabel('Version', { exact: true }).fill(updatedVersion);
     await editForm.getByRole('textbox', { name: 'Content', exact: true }).fill(updatedContent);
     await editForm.getByRole('button', { name: 'Save' }).click();
 
-    const updatedRow = listCard.locator('.list-item').filter({ hasText: templateId });
+    const updatedRow = page.locator('.template-row').filter({ hasText: updatedName });
     await expect(updatedRow).toBeVisible();
     await expect(updatedRow).toContainText(updatedName);
     await expect(updatedRow).toContainText(updatedVersion);
 
     page.on('dialog', (dialog) => dialog.accept());
-    await updatedRow.getByRole('button', { name: 'Delete' }).click();
-    await expect(listCard.locator('.list-item').filter({ hasText: templateId })).toHaveCount(0);
+    await updatedRow.click();
+    await page.locator('.template-preview-panel').getByRole('button', { name: 'Delete' }).click();
+    await expect(page.locator('.template-row').filter({ hasText: updatedName })).toHaveCount(0);
   } finally {
     await cleanupTemplateIds(page.request, [templateId]);
   }

--- a/frontend/tests/unit/evaluation-queue-api.test.ts
+++ b/frontend/tests/unit/evaluation-queue-api.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { isValidQueueScore, skipEvaluationQueueItem, validateQueueScores } from '../../src/services/evaluation-queue-api.js';
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('evaluation queue score helpers', () => {
+  it('accepts only integer scores from 1 to 5', () => {
+    expect(isValidQueueScore(1)).toBe(true);
+    expect(isValidQueueScore(5)).toBe(true);
+    expect(isValidQueueScore(0)).toBe(false);
+    expect(isValidQueueScore(6)).toBe(false);
+    expect(isValidQueueScore(3.5)).toBe(false);
+  });
+
+  it('validates the five-score payload', () => {
+    expect(validateQueueScores({
+      accuracy_score: 5,
+      relevance_score: 4,
+      coherence_score: 5,
+      completeness_score: 4,
+      helpfulness_score: 5,
+      note: null
+    })).toBe(true);
+    expect(validateQueueScores({
+      accuracy_score: 5,
+      relevance_score: 4,
+      coherence_score: 9,
+      completeness_score: 4,
+      helpfulness_score: 5,
+      note: null
+    })).toBe(false);
+  });
+
+  it('treats skip 204 responses as successful', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 204,
+      json: async () => {
+        throw new Error('204 responses do not have JSON bodies');
+      }
+    } as Response);
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(skipEvaluationQueueItem('queue-result-1')).resolves.toBeUndefined();
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.method).toBe('POST');
+    expect(init.body).toBe(JSON.stringify({ reason: null }));
+  });
+});


### PR DESCRIPTION
- Added backend inference_param_presets storage and /inference-param-presets CRUD API.
  - Added evaluation queue backend API: pending/done/skipped queue, source-linked scoring, duplicate-score prevention, and skip persistence.
  - Extended evaluations with nullable source_test_result_id while preserving the existing five 1-5 score fields.
  - Added shared frontend primitives: RegLight, EmptyState, InferenceContextBar, and reusable run-detail display.
  - Reworked Templates into the left-list/right-preview layout while preserving create/update/delete.
  - Replaced Evaluate direct inference UI with the scoring queue, sliders, notes, skip, Save & Next, and keyboard 1-5 scoring.
  - Added context bar to Run/Templates/Results/Evaluate and wired Run params into createRunGroup.test_overrides.
  - Added Run streaming/error polish: progress text, blinking cursor, red failure banner, stop, and retry failed targets.
  - Updated Catalog/Sidebar reg-light usage and Package 06 empty states.
  - Updated CHANGELOG.md and aligned Evaluate/Templates E2E specs to the new layouts.