### PR TITLE
feat(layout): new-sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 
 ## [Unreleased]
 
+### Added
+
+- Results dashboard now compares raw cold-start performance across servers and models with sample-backed summary rows and box plots for cold penalty, cold total, and hot total metrics.
+
+
 ## [0.4.0] - 2026-05-10
 
 ### Added

--- a/backend/data/templates/Cold_start_penalty.pytest.json
+++ b/backend/data/templates/Cold_start_penalty.pytest.json
@@ -57,8 +57,8 @@
         ]
       }
     },
-    "iterations": 1,
-    "sleep_between_ms": 0,
+    "iterations": 5,
+    "sleep_between_ms": 60000,
     "cold_condition": {
       "mode": "unload",
       "note": "If your server supports eviction/unload, set mode accordingly."

--- a/backend/src/services/results-view-service.ts
+++ b/backend/src/services/results-view-service.ts
@@ -95,7 +95,45 @@ export interface ResultsDashboardView {
   };
   pass_rate_series: Array<{ label: string; points: Array<{ x: string; y: number | null }> }>;
   latency_series: Array<{ label: string; points: Array<{ x: string; y: number | null }> }>;
+  performance_comparison: ResultsPerformanceComparisonView;
   recent_runs: ResultsHistoryRow[];
+}
+
+export type ResultsPerformanceComparisonMetricKey = 'cold_penalty_ms' | 'cold_total_ms' | 'hot_total_ms';
+
+export interface ResultsPerformanceComparisonStats {
+  count: number;
+  min: number;
+  q1: number;
+  median: number;
+  q3: number;
+  p95: number;
+  max: number;
+  mean: number;
+}
+
+export interface ResultsPerformanceComparisonMetric {
+  metric_key: ResultsPerformanceComparisonMetricKey;
+  label: string;
+  unit: string;
+  samples: number[];
+  stats: ResultsPerformanceComparisonStats;
+}
+
+export interface ResultsPerformanceComparisonGroup {
+  group_id: string;
+  server_id: string;
+  server_name: string;
+  model_name: string;
+  template_id: string;
+  template_label: string;
+  metrics: Partial<Record<ResultsPerformanceComparisonMetricKey, ResultsPerformanceComparisonMetric>>;
+}
+
+export interface ResultsPerformanceComparisonView {
+  default_metric: ResultsPerformanceComparisonMetricKey;
+  metrics: Array<{ metric_key: ResultsPerformanceComparisonMetricKey; label: string; unit: string }>;
+  groups: ResultsPerformanceComparisonGroup[];
 }
 
 export interface ResultsRunDetail {
@@ -299,6 +337,73 @@ function median(values: Array<number | null>): number | null {
   return sorted.length % 2 ? sorted[middle] : (sorted[middle - 1] + sorted[middle]) / 2;
 }
 
+const COMPARISON_METRICS: ResultsPerformanceComparisonView['metrics'] = [
+  { metric_key: 'cold_penalty_ms', label: 'Cold penalty', unit: 'ms' },
+  { metric_key: 'cold_total_ms', label: 'Cold total', unit: 'ms' },
+  { metric_key: 'hot_total_ms', label: 'Hot total', unit: 'ms' }
+];
+
+function percentile(sortedValues: number[], percentileValue: number): number {
+  if (sortedValues.length === 0) {
+    return Number.NaN;
+  }
+  if (sortedValues.length === 1) {
+    return sortedValues[0];
+  }
+  const rank = (percentileValue / 100) * (sortedValues.length - 1);
+  const lower = Math.floor(rank);
+  const upper = Math.ceil(rank);
+  if (lower === upper) {
+    return sortedValues[lower];
+  }
+  const weight = rank - lower;
+  return sortedValues[lower] + (sortedValues[upper] - sortedValues[lower]) * weight;
+}
+
+function comparisonStats(samples: number[]): ResultsPerformanceComparisonStats {
+  const sorted = samples.slice().sort((a, b) => a - b);
+  const sum = sorted.reduce((total, value) => total + value, 0);
+  return {
+    count: sorted.length,
+    min: sorted[0],
+    q1: percentile(sorted, 25),
+    median: percentile(sorted, 50),
+    q3: percentile(sorted, 75),
+    p95: percentile(sorted, 95),
+    max: sorted[sorted.length - 1],
+    mean: sum / sorted.length
+  };
+}
+
+function sanitizeSamples(value: unknown): number[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((entry) => (typeof entry === 'number' ? entry : typeof entry === 'string' && entry.trim() ? Number(entry) : Number.NaN))
+    .filter((entry) => Number.isFinite(entry));
+}
+
+function sampleEnvelope(artefacts: Record<string, unknown> | null): Record<string, unknown> | null {
+  if (!artefacts) {
+    return null;
+  }
+  const pythonResult = artefacts.python_result;
+  if (pythonResult && typeof pythonResult === 'object' && !Array.isArray(pythonResult)) {
+    return pythonResult as Record<string, unknown>;
+  }
+  return artefacts;
+}
+
+function metricSamples(artefacts: Record<string, unknown> | null, metricKey: ResultsPerformanceComparisonMetricKey): number[] {
+  const envelope = sampleEnvelope(artefacts);
+  const samples = envelope?.samples;
+  if (!samples || typeof samples !== 'object' || Array.isArray(samples)) {
+    return [];
+  }
+  return sanitizeSamples((samples as Record<string, unknown>)[metricKey]);
+}
+
 function durationMs(startedAt: string, endedAt: string | null): number | null {
   if (!endedAt) {
     return null;
@@ -351,7 +456,7 @@ function toHistoryRow(run: RunAccumulator): ResultsHistoryRow {
     template_label: firstResult?.template_label ?? run.results[0]?.test_id ?? 'unknown',
     score: median(scores),
     latency_ms: median(allLatencies),
-    cost: allCosts.reduce((sum, value) => sum + (value ?? 0), 0) || null,
+    cost: allCosts.reduce<number>((sum, value) => sum + (value ?? 0), 0) || null,
     tags,
     result_count: run.results.length
   };
@@ -626,7 +731,108 @@ function dashboard(rows: ResultsHistoryRow[]): ResultsDashboardView {
     },
     pass_rate_series: Array.from(passSeries.entries()).map(([label, points]) => ({ label, points: points.sort((a, b) => a.x.localeCompare(b.x)) })),
     latency_series: Array.from(latencySeries.entries()).map(([label, points]) => ({ label, points: points.sort((a, b) => a.x.localeCompare(b.x)) })),
+    performance_comparison: emptyPerformanceComparison(),
     recent_runs: rows.slice().sort((a, b) => b.started_at.localeCompare(a.started_at)).slice(0, 8)
+  };
+}
+
+function emptyPerformanceComparison(): ResultsPerformanceComparisonView {
+  return {
+    default_metric: 'cold_penalty_ms',
+    metrics: COMPARISON_METRICS,
+    groups: []
+  };
+}
+
+function dashboardWithComparison(rows: ResultsHistoryRow[], runs: RunAccumulator[]): ResultsDashboardView {
+  return {
+    ...dashboard(rows),
+    performance_comparison: performanceComparison(runs)
+  };
+}
+
+function performanceComparison(runs: RunAccumulator[]): ResultsPerformanceComparisonView {
+  const groups = new Map<
+    string,
+    {
+      server_id: string;
+      server_name: string;
+      model_name: string;
+      template_id: string;
+      template_label: string;
+      samples: Record<ResultsPerformanceComparisonMetricKey, number[]>;
+    }
+  >();
+
+  for (const run of runs) {
+    const serverId = run.inference_server_id;
+    const serverName = run.server_display_name ?? serverId;
+    for (const result of run.results) {
+      const resultSamples = COMPARISON_METRICS.map((metric) => ({
+        metric,
+        samples: metricSamples(result.artefacts, metric.metric_key)
+      }));
+      if (!resultSamples.some((entry) => entry.samples.length > 0)) {
+        continue;
+      }
+
+      const modelName = selectedModel(run.environment_snapshot, result.document);
+      const groupId = [serverId, modelName, result.template_id].join('|');
+      const group = groups.get(groupId) ?? {
+        server_id: serverId,
+        server_name: serverName,
+        model_name: modelName,
+        template_id: result.template_id,
+        template_label: result.template_label,
+        samples: {
+          cold_penalty_ms: [],
+          cold_total_ms: [],
+          hot_total_ms: []
+        }
+      };
+      for (const entry of resultSamples) {
+        group.samples[entry.metric.metric_key].push(...entry.samples);
+      }
+      groups.set(groupId, group);
+    }
+  }
+
+  return {
+    default_metric: 'cold_penalty_ms',
+    metrics: COMPARISON_METRICS,
+    groups: Array.from(groups.entries())
+      .map(([groupId, group]) => ({
+        group_id: groupId,
+        server_id: group.server_id,
+        server_name: group.server_name,
+        model_name: group.model_name,
+        template_id: group.template_id,
+        template_label: group.template_label,
+        metrics: Object.fromEntries(
+          COMPARISON_METRICS.flatMap((metric) => {
+            const samples = group.samples[metric.metric_key];
+            if (samples.length === 0) {
+              return [];
+            }
+            return [
+              [
+                metric.metric_key,
+                {
+                  ...metric,
+                  samples,
+                  stats: comparisonStats(samples)
+                }
+              ]
+            ];
+          })
+        ) as Partial<Record<ResultsPerformanceComparisonMetricKey, ResultsPerformanceComparisonMetric>>
+      }))
+      .filter((group) => Object.keys(group.metrics).length > 0)
+      .sort((a, b) => {
+        const aMedian = a.metrics.cold_penalty_ms?.stats.median ?? Number.POSITIVE_INFINITY;
+        const bMedian = b.metrics.cold_penalty_ms?.stats.median ?? Number.POSITIVE_INFINITY;
+        return aMedian - bMedian || a.server_name.localeCompare(b.server_name) || a.model_name.localeCompare(b.model_name);
+      })
   };
 }
 
@@ -639,6 +845,8 @@ export function queryResultsView(payload: Record<string, unknown> | undefined): 
   const allRows = runs.map(toHistoryRow);
   const options = countOptions(allRows);
   const filteredRows = allRows.filter((row) => matchesFilters(row, normalized.value));
+  const filteredRunIds = new Set(filteredRows.map((row) => row.run_id));
+  const filteredRuns = runs.filter((run) => filteredRunIds.has(run.run_id));
   const sortedRows = sortRows(filteredRows, normalized.value);
   const start = (normalized.value.page - 1) * normalized.value.page_size;
   const pageRows = sortedRows.slice(start, start + normalized.value.page_size);
@@ -652,7 +860,7 @@ export function queryResultsView(payload: Record<string, unknown> | undefined): 
         ...options,
         date_bounds: { min: dates[0] ?? null, max: dates[dates.length - 1] ?? null }
       },
-      dashboard: dashboard(filteredRows),
+      dashboard: dashboardWithComparison(filteredRows, filteredRuns),
       history: {
         rows: pageRows,
         page: normalized.value.page,

--- a/backend/tests/integration/results-view.integration.test.ts
+++ b/backend/tests/integration/results-view.integration.test.ts
@@ -44,6 +44,11 @@ function seedRun(input: {
   latency: number;
   templateId?: string;
   serverId?: string;
+  coldStartSamples?: {
+    cold_total_ms: number[];
+    hot_total_ms: number[];
+    cold_penalty_ms: number[];
+  };
 }) {
   const db = getDb();
   const templateId = input.templateId ?? 'cold-start';
@@ -82,7 +87,15 @@ function seedRun(input: {
     input.verdict,
     input.verdict === 'fail' ? 'assertion failed' : null,
     JSON.stringify({ latency_ms: input.latency, estimated_cost: 0.001 }),
-    JSON.stringify({}),
+    JSON.stringify(
+      input.coldStartSamples
+        ? {
+            python_result: {
+              samples: input.coldStartSamples
+            }
+          }
+        : {}
+    ),
     JSON.stringify({ repetitions: 1 }),
     input.startedAt,
     input.startedAt
@@ -182,6 +195,72 @@ describe('results-view routes', () => {
       server_ids: ['srv-other'],
       model_names: ['model-a', 'model-b']
     });
+  });
+
+  it('returns cold-start sample comparisons grouped by server, model, and template', async () => {
+    const app = createServer();
+    seedServer('srv-other', 'Other Server');
+    seedRun({
+      runId: 'run-local-a',
+      serverId: 'srv-results',
+      model: 'model-a',
+      templateId: 'Cold_start_penalty',
+      verdict: 'pass',
+      startedAt: '2026-05-01T10:00:00.000Z',
+      latency: 100,
+      coldStartSamples: {
+        cold_total_ms: [300, 320, 340],
+        hot_total_ms: [200, 200, 200],
+        cold_penalty_ms: [100, 120, 140]
+      }
+    });
+    seedRun({
+      runId: 'run-other-b',
+      serverId: 'srv-other',
+      model: 'model-b',
+      templateId: 'Cold_start_penalty',
+      verdict: 'pass',
+      startedAt: '2026-05-01T11:00:00.000Z',
+      latency: 90,
+      coldStartSamples: {
+        cold_total_ms: [240, 250, 260],
+        hot_total_ms: [160, 160, 160],
+        cold_penalty_ms: [80, 90, 100]
+      }
+    });
+    seedRun({
+      runId: 'run-summary-only',
+      serverId: 'srv-results',
+      model: 'model-c',
+      templateId: 'Cold_start_penalty',
+      verdict: 'pass',
+      startedAt: '2026-05-01T12:00:00.000Z',
+      latency: 80
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/results-view/query',
+      headers: AUTH_HEADERS,
+      payload: {
+        date_from: '2026-05-01T00:00:00.000Z',
+        date_to: '2026-05-02T00:00:00.000Z',
+        template_ids: ['Cold_start_penalty']
+      }
+    });
+
+    expect(response.statusCode).toBe(200);
+    const comparison = response.json().dashboard.performance_comparison;
+    expect(comparison.default_metric).toBe('cold_penalty_ms');
+    expect(comparison.groups).toHaveLength(2);
+    expect(comparison.groups.map((group: { model_name: string }) => group.model_name)).toEqual(['model-b', 'model-a']);
+    expect(comparison.groups[0].metrics.cold_penalty_ms.stats).toMatchObject({
+      count: 3,
+      min: 80,
+      median: 90,
+      max: 100
+    });
+    expect(comparison.groups[1].metrics.cold_total_ms.samples).toEqual([300, 320, 340]);
   });
 
   it('opens run drawer detail for a history row', async () => {

--- a/frontend/src/components/results-performance-comparison-panel.tsx
+++ b/frontend/src/components/results-performance-comparison-panel.tsx
@@ -1,0 +1,171 @@
+import { useMemo, useState } from 'react';
+import type { ComponentType } from 'react';
+import _ReactECharts from 'echarts-for-react';
+import type { EChartsReactProps } from 'echarts-for-react';
+import type { EChartsOption } from 'echarts/types/dist/shared';
+
+import type {
+  ResultsPerformanceComparisonMetricKey,
+  ResultsPerformanceComparisonView
+} from '../services/results-view-api.js';
+
+const ReactECharts = _ReactECharts as unknown as ComponentType<EChartsReactProps>;
+
+interface ResultsPerformanceComparisonPanelProps {
+  comparison: ResultsPerformanceComparisonView;
+}
+
+function formatValue(value: number | null | undefined, unit = ''): string {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return 'N/A';
+  }
+  const rounded = Math.abs(value) >= 100 ? value.toFixed(0) : value.toFixed(2);
+  return unit ? `${rounded} ${unit}` : rounded;
+}
+
+function groupLabel(group: ResultsPerformanceComparisonView['groups'][number]): string {
+  return `${group.server_name} / ${group.model_name}`;
+}
+
+export function ResultsPerformanceComparisonPanel({ comparison }: ResultsPerformanceComparisonPanelProps) {
+  const metricOptions = comparison.metrics.filter((metric) =>
+    comparison.groups.some((group) => group.metrics[metric.metric_key])
+  );
+  const [selectedMetric, setSelectedMetric] = useState<ResultsPerformanceComparisonMetricKey>(
+    comparison.default_metric
+  );
+  const activeMetric = metricOptions.find((metric) => metric.metric_key === selectedMetric) ?? metricOptions[0];
+  const activeMetricKey = activeMetric?.metric_key;
+  const activeUnit = activeMetric?.unit ?? '';
+
+  const rows = useMemo(() => {
+    if (!activeMetricKey) {
+      return [];
+    }
+    return comparison.groups
+      .map((group) => {
+        const metric = group.metrics[activeMetricKey];
+        return metric ? { group, metric } : null;
+      })
+      .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
+      .sort((a, b) => a.metric.stats.median - b.metric.stats.median);
+  }, [activeMetricKey, comparison.groups]);
+
+  const option = useMemo<EChartsOption>(() => {
+    return {
+      animation: false,
+      tooltip: {
+        trigger: 'item',
+        formatter: (params: unknown) => {
+          const data = params as { name?: string; data?: number[] };
+          const values = Array.isArray(data.data) ? data.data : [];
+          return [
+            data.name ?? '',
+            `min: ${formatValue(values[0], activeUnit)}`,
+            `q1: ${formatValue(values[1], activeUnit)}`,
+            `median: ${formatValue(values[2], activeUnit)}`,
+            `q3: ${formatValue(values[3], activeUnit)}`,
+            `max: ${formatValue(values[4], activeUnit)}`
+          ].join('<br />');
+        }
+      },
+      grid: {
+        left: 64,
+        right: 24,
+        top: 24,
+        bottom: 96
+      },
+      xAxis: {
+        type: 'category',
+        data: rows.map((row) => groupLabel(row.group)),
+        axisLabel: {
+          interval: 0,
+          rotate: rows.length > 2 ? 28 : 0,
+          hideOverlap: true
+        }
+      },
+      yAxis: {
+        type: 'value',
+        scale: true,
+        name: activeMetric ? `${activeMetric.label} (${activeUnit})` : '',
+        axisLabel: {
+          formatter: (value: number) => formatValue(value, activeUnit)
+        }
+      },
+      series: [
+        {
+          name: activeMetric?.label ?? 'Performance',
+          type: 'boxplot',
+          data: rows.map((row) => [
+            row.metric.stats.min,
+            row.metric.stats.q1,
+            row.metric.stats.median,
+            row.metric.stats.q3,
+            row.metric.stats.max
+          ])
+        }
+      ]
+    };
+  }, [activeMetric, activeUnit, rows]);
+
+  if (metricOptions.length === 0 || rows.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="results-panel results-comparison-panel" data-panel-type="performance-comparison">
+      <header className="results-panel__header">
+        <div>
+          <h2>Cold-start comparison</h2>
+          <p className="muted">Raw sample performance by server and model</p>
+        </div>
+        <label className="results-comparison-metric">
+          <span>Metric</span>
+          <select
+            value={activeMetricKey}
+            onChange={(event) => setSelectedMetric(event.target.value as ResultsPerformanceComparisonMetricKey)}
+          >
+            {metricOptions.map((metric) => (
+              <option key={metric.metric_key} value={metric.metric_key}>
+                {metric.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      </header>
+      <div className="table-scroll">
+        <table className="results-comparison-table">
+          <thead>
+            <tr>
+              <th>Server</th>
+              <th>Model</th>
+              <th>Test</th>
+              <th>Samples</th>
+              <th>Median</th>
+              <th>P95</th>
+              <th>Mean</th>
+              <th>Min</th>
+              <th>Max</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map(({ group, metric }) => (
+              <tr key={`${group.group_id}:${metric.metric_key}`}>
+                <td>{group.server_name}</td>
+                <td>{group.model_name}</td>
+                <td>{group.template_label}</td>
+                <td>{metric.stats.count}</td>
+                <td>{formatValue(metric.stats.median, metric.unit)}</td>
+                <td>{formatValue(metric.stats.p95, metric.unit)}</td>
+                <td>{formatValue(metric.stats.mean, metric.unit)}</td>
+                <td>{formatValue(metric.stats.min, metric.unit)}</td>
+                <td>{formatValue(metric.stats.max, metric.unit)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <ReactECharts option={option} className="results-comparison-chart" notMerge lazyUpdate />
+    </section>
+  );
+}

--- a/frontend/src/pages/ResultsUnified.tsx
+++ b/frontend/src/pages/ResultsUnified.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { MergedPageHeader } from '../components/MergedPageHeader.js';
 import { InferenceContextBar } from '../components/InferenceContextBar.js';
 import { ResultsGraphPanel } from '../components/results-graph-panel.js';
+import { ResultsPerformanceComparisonPanel } from '../components/results-performance-comparison-panel.js';
 import { normalizeResultsTab } from '../navigation.js';
 import { getLeaderboard, type LeaderboardEntry } from '../services/leaderboard-api.js';
 import {
@@ -632,6 +633,7 @@ function FilterCheckGroup({
 
 function DashboardTab({ rows, dashboard, onOpenRun }: { rows: ResultsHistoryRow[]; dashboard: Awaited<ReturnType<typeof queryResultsView>>['dashboard']; onOpenRun: (id: string) => void }) {
   const cards = dashboard.scorecards;
+  const hasPerformanceComparison = (dashboard.performance_comparison?.groups.length ?? 0) > 0;
   return (
     <div className="results-main-stack">
       <div className="results-scorecards">
@@ -640,8 +642,14 @@ function DashboardTab({ rows, dashboard, onOpenRun }: { rows: ResultsHistoryRow[
         <div className="results-scorecard"><span>Median latency</span><strong>{formatNumber(cards.median_latency_ms, ' ms')}</strong></div>
         <div className="results-scorecard"><span>Median cost</span><strong>{cards.median_cost == null ? 'N/A' : `$${cards.median_cost.toFixed(6)}`}</strong></div>
       </div>
-      <ResultsGraphPanel panel={seriesPanel('Pass-rate over time', 'pass_rate', dashboard.pass_rate_series)} />
-      <ResultsGraphPanel panel={seriesPanel('Latency distribution', 'latency_ms', dashboard.latency_series)} />
+      {hasPerformanceComparison ? (
+        <ResultsPerformanceComparisonPanel comparison={dashboard.performance_comparison} />
+      ) : (
+        <>
+          <ResultsGraphPanel panel={seriesPanel('Pass-rate over time', 'pass_rate', dashboard.pass_rate_series)} />
+          <ResultsGraphPanel panel={seriesPanel('Latency distribution', 'latency_ms', dashboard.latency_series)} />
+        </>
+      )}
       <section className="results-panel">
         <header className="results-panel__header">
           <h2>Recent runs</h2>

--- a/frontend/src/services/results-view-api.ts
+++ b/frontend/src/services/results-view-api.ts
@@ -48,7 +48,45 @@ export interface ResultsDashboardView {
   };
   pass_rate_series: Array<{ label: string; points: Array<{ x: string; y: number | null }> }>;
   latency_series: Array<{ label: string; points: Array<{ x: string; y: number | null }> }>;
+  performance_comparison: ResultsPerformanceComparisonView;
   recent_runs: ResultsHistoryRow[];
+}
+
+export type ResultsPerformanceComparisonMetricKey = 'cold_penalty_ms' | 'cold_total_ms' | 'hot_total_ms';
+
+export interface ResultsPerformanceComparisonStats {
+  count: number;
+  min: number;
+  q1: number;
+  median: number;
+  q3: number;
+  p95: number;
+  max: number;
+  mean: number;
+}
+
+export interface ResultsPerformanceComparisonMetric {
+  metric_key: ResultsPerformanceComparisonMetricKey;
+  label: string;
+  unit: string;
+  samples: number[];
+  stats: ResultsPerformanceComparisonStats;
+}
+
+export interface ResultsPerformanceComparisonGroup {
+  group_id: string;
+  server_id: string;
+  server_name: string;
+  model_name: string;
+  template_id: string;
+  template_label: string;
+  metrics: Partial<Record<ResultsPerformanceComparisonMetricKey, ResultsPerformanceComparisonMetric>>;
+}
+
+export interface ResultsPerformanceComparisonView {
+  default_metric: ResultsPerformanceComparisonMetricKey;
+  metrics: Array<{ metric_key: ResultsPerformanceComparisonMetricKey; label: string; unit: string }>;
+  groups: ResultsPerformanceComparisonGroup[];
 }
 
 export interface ResultsFilterOptions {

--- a/frontend/src/styles/dashboard-results.css
+++ b/frontend/src/styles/dashboard-results.css
@@ -43,6 +43,32 @@
   font-size: 13px;
 }
 
+.results-comparison-panel {
+  display: grid;
+  gap: 16px;
+}
+
+.results-comparison-metric {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+}
+
+.results-comparison-metric select {
+  min-width: 150px;
+}
+
+.results-comparison-table th:not(:first-child),
+.results-comparison-table td:not(:first-child) {
+  white-space: nowrap;
+}
+
+.results-comparison-chart {
+  width: 100%;
+  height: 360px;
+}
+
 .table-scroll {
   overflow-x: auto;
 }

--- a/frontend/tests/e2e/results-dashboard.spec.ts
+++ b/frontend/tests/e2e/results-dashboard.spec.ts
@@ -89,6 +89,49 @@ function resultsViewPayload(empty = false) {
       latency_series: rows.length
         ? [{ label: 'mistral:latest', points: [{ x: '2026-02-08T00:00:00.000Z', y: 80 }] }]
         : [],
+      performance_comparison: {
+        default_metric: 'cold_penalty_ms',
+        metrics: [
+          { metric_key: 'cold_penalty_ms', label: 'Cold penalty', unit: 'ms' },
+          { metric_key: 'cold_total_ms', label: 'Cold total', unit: 'ms' },
+          { metric_key: 'hot_total_ms', label: 'Hot total', unit: 'ms' }
+        ],
+        groups: rows.length
+          ? [
+              {
+                group_id: 'srv-local|mistral:latest|latency-benchmark',
+                server_id: 'srv-local',
+                server_name: 'Local Server',
+                model_name: 'mistral:latest',
+                template_id: 'latency-benchmark',
+                template_label: 'latency-benchmark',
+                metrics: {
+                  cold_penalty_ms: {
+                    metric_key: 'cold_penalty_ms',
+                    label: 'Cold penalty',
+                    unit: 'ms',
+                    samples: [70, 80, 90],
+                    stats: { count: 3, min: 70, q1: 75, median: 80, q3: 85, p95: 89, max: 90, mean: 80 }
+                  },
+                  cold_total_ms: {
+                    metric_key: 'cold_total_ms',
+                    label: 'Cold total',
+                    unit: 'ms',
+                    samples: [150, 160, 170],
+                    stats: { count: 3, min: 150, q1: 155, median: 160, q3: 165, p95: 169, max: 170, mean: 160 }
+                  },
+                  hot_total_ms: {
+                    metric_key: 'hot_total_ms',
+                    label: 'Hot total',
+                    unit: 'ms',
+                    samples: [80, 80, 80],
+                    stats: { count: 3, min: 80, q1: 80, median: 80, q3: 80, p95: 80, max: 80, mean: 80 }
+                  }
+                }
+              }
+            ]
+          : []
+      },
       recent_runs: rows
     },
     history: {
@@ -220,8 +263,10 @@ test('merged Results dashboard filter and render flow', async ({ page }) => {
 
   await expect(page.getByText('Total runs')).toBeVisible();
   await expect(page.getByText('Pass rate')).toBeVisible();
-  await expect(page.locator('.dashboard-panel')).toHaveCount(2);
-  await expect(page.locator('[data-panel-type="graph"]').first()).toBeVisible();
+  await expect(page.locator('[data-panel-type="performance-comparison"]')).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Cold-start comparison' })).toBeVisible();
+  await expect(page.getByRole('cell', { name: 'mistral:latest' })).toBeVisible();
+  await expect(page.getByRole('cell', { name: '80.00 ms' }).first()).toBeVisible();
   await expect(page.getByRole('heading', { name: 'Recent runs' })).toBeVisible();
 
   const recentRun = page.locator('.results-run-row').filter({ hasText: 'latency-benchmark' });


### PR DESCRIPTION
- Added react-router-dom and wrapped the frontend in BrowserRouter.
- Replaced the old 8-icon/state-machine shell with a 220px expanded 5-item sidebar: Catalog, Templates, Run, Results, Evaluate.
 - Added Sidebar, SubTabBar, MergedPageHeader, and route helpers.
- Added URL-backed routes and redirects:
- /catalog?tab=servers|models
- /results?tab=dashboard|leaderboard|history
- /run, /run?legacy=compare
- legacy redirects for /servers, /models, /run-single, /compare, /dashboard, /leaderboard
- Moved model details into Catalog query params with encoded serverId/modelId.
- Removed global CPU/memory/GPU/LLM metric cards; sidebar now shows Backend, Database, and server health/count.
- Updated E2E specs away from old nav-button assumptions and added a focused navigation-shell.spec.ts.
- Updated CHANGELOG.md.
- Ignored docs-only design wireframe JSX from lint.
- Removed old standalone Leaderboard assumptions: Leaderboard page heading, CTA, date Apply/Clear, .leaderboard-table.
- Updated assertions to the merged Results shell: Results heading, active Leaderboard sub-tab, shared filter rail, sort/group controls.
- Updated populated checks to use .results-leader-row.
- Added drawer coverage by clicking a leaderboard row and expecting Evaluation detail.
- Updated filter tests to use the shared rail From / To datetime filters and Reset filters.
- Kept valid behavior: evaluations:saved now refreshes the merged leaderboard tab.