### PR TITLE
feat: Add guarded run deletion from results detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 ### Added
 
 - Results dashboard now compares raw cold-start performance across servers and models with sample-backed summary rows and box plots for cold penalty, cold total, and hot total metrics.
+- Results run detail drawers now support guarded hard deletion of completed runs, removing result documents, metric samples, queue skips, and run-group item links while preserving linked evaluations.
 
 
 ## [0.4.0] - 2026-05-10

--- a/backend/data/templates/Cold_start_penalty.pytest.json
+++ b/backend/data/templates/Cold_start_penalty.pytest.json
@@ -58,7 +58,7 @@
       }
     },
     "iterations": 5,
-    "sleep_between_ms": 60000,
+    "sleep_between_ms": 10,
     "cold_condition": {
       "mode": "unload",
       "note": "If your server supports eviction/unload, set mode accordingly."

--- a/backend/src/api/routes/runs.ts
+++ b/backend/src/api/routes/runs.ts
@@ -1,7 +1,7 @@
 import { FastifyInstance } from 'fastify';
 
 import { getDb } from '../../models/db.js';
-import { createSingleRun, getRun, listRunResults, requestCancelRun } from '../../services/run-service.js';
+import { createSingleRun, deleteRun, getRun, listRunResults, requestCancelRun } from '../../services/run-service.js';
 
 export function registerRunsRoutes(app: FastifyInstance): void {
   app.post('/runs', async (request, reply) => {
@@ -48,6 +48,16 @@ export function registerRunsRoutes(app: FastifyInstance): void {
       return;
     }
     reply.send(run);
+  });
+
+  app.delete('/runs/:runId', async (request, reply) => {
+    const { runId } = request.params as { runId: string };
+    const deleted = deleteRun(runId);
+    if (!deleted.ok) {
+      reply.code(deleted.code === 'RUN_ACTIVE' ? 409 : 404).send({ error: deleted.error });
+      return;
+    }
+    reply.code(204).send();
   });
 
   app.get('/runs/:runId/results', async (request, reply) => {

--- a/backend/src/services/run-service.ts
+++ b/backend/src/services/run-service.ts
@@ -41,6 +41,10 @@ export interface RunResultRecord {
   ended_at: string | null;
 }
 
+export type DeleteRunResult =
+  | { ok: true }
+  | { ok: false; code: 'RUN_NOT_FOUND' | 'RUN_ACTIVE'; error: string };
+
 export interface CreateRunInput {
   run_id?: string | null;
   inference_server_id: string;
@@ -453,4 +457,39 @@ export function listRunResults(runId: string): RunResultRecord[] {
     raw_events: parseJson(row.raw_events as unknown as string),
     repetition_stats: parseJson(row.repetition_stats as unknown as string)
   }));
+}
+
+export function deleteRun(id: string): DeleteRunResult {
+  const db = getDb();
+  const row = db.prepare('SELECT id, status FROM runs WHERE id = ?').get(id) as { id: string; status: string } | undefined;
+  if (!row) {
+    return { ok: false, code: 'RUN_NOT_FOUND', error: 'Run not found' };
+  }
+  if (row.status === 'queued' || row.status === 'running') {
+    return { ok: false, code: 'RUN_ACTIVE', error: 'Active runs cannot be deleted' };
+  }
+
+  const transaction = db.transaction((runId: string) => {
+    const resultRows = db.prepare('SELECT id FROM test_results WHERE run_id = ?').all(runId) as Array<{ id: string }>;
+    const resultIds = resultRows.map((result) => result.id);
+
+    if (resultIds.length > 0) {
+      const placeholders = resultIds.map(() => '?').join(',');
+      db.prepare(`DELETE FROM metric_samples WHERE test_result_id IN (${placeholders})`).run(...resultIds);
+      db.prepare(`DELETE FROM evaluation_queue_skips WHERE test_result_id IN (${placeholders})`).run(...resultIds);
+      db.prepare(`DELETE FROM test_result_documents WHERE test_result_id IN (${placeholders})`).run(...resultIds);
+    }
+
+    db.prepare('DELETE FROM test_results WHERE run_id = ?').run(runId);
+    db.prepare('DELETE FROM run_group_items WHERE child_run_id = ?').run(runId);
+    db.prepare('DELETE FROM runs WHERE id = ?').run(runId);
+  });
+
+  transaction(id);
+  logEvent({
+    level: 'info',
+    message: 'run deleted',
+    meta: { run_id: id }
+  });
+  return { ok: true };
 }

--- a/backend/tests/integration/runs-single.test.ts
+++ b/backend/tests/integration/runs-single.test.ts
@@ -1,12 +1,124 @@
-import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { createServer } from '../../src/api/server.js';
+import { getDb, resetDbInstance, runSchema } from '../../src/models/db.js';
 import { createInferenceServerRecord } from '../../src/services/inference-servers-repository.js';
 import { upsertTestDefinition } from '../../src/models/test-definition.js';
 
+const AUTH_HEADERS = { 'x-api-token': 'test-token' };
+const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+const SCHEMA_PATH = path.resolve(moduleDir, '../../src/models/schema.sql');
+
+function seedServer(serverId = 'srv-delete') {
+  const db = getDb();
+  const now = '2026-05-01T00:00:00.000Z';
+  db.prepare(`
+    INSERT INTO inference_servers (
+      server_id, display_name, active, archived, created_at, updated_at, runtime,
+      endpoints, auth, capabilities, discovery, raw
+    ) VALUES (?, ?, 1, 0, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    serverId,
+    'Delete Server',
+    now,
+    now,
+    JSON.stringify({ api: { api_version: '1.0.0' } }),
+    JSON.stringify({ base_url: 'http://localhost:8080' }),
+    JSON.stringify({}),
+    JSON.stringify({}),
+    JSON.stringify({ model_list: { normalised: [] } }),
+    JSON.stringify({})
+  );
+}
+
+function seedRunWithDependencies(input: { runId: string; status?: string; resultId?: string }) {
+  const db = getDb();
+  const now = '2026-05-01T10:00:00.000Z';
+  const runId = input.runId;
+  const resultId = input.resultId ?? `result-${runId}`;
+  db.prepare(`
+    INSERT INTO runs (
+      id, inference_server_id, suite_id, test_id, profile_id, profile_version,
+      status, started_at, ended_at, environment_snapshot, retention_days
+    ) VALUES (?, 'srv-delete', null, 'delete-test', null, null, ?, ?, ?, ?, 30)
+  `).run(
+    runId,
+    input.status ?? 'completed',
+    now,
+    now,
+    JSON.stringify({ effective_config: { model: 'model-delete' } })
+  );
+  db.prepare(`
+    INSERT INTO test_results (
+      id, run_id, test_id, verdict, failure_reason, metrics, artefacts, raw_events,
+      repetition_stats, started_at, ended_at
+    ) VALUES (?, ?, 'delete-test', 'pass', null, ?, ?, '[]', ?, ?, ?)
+  `).run(
+    resultId,
+    runId,
+    JSON.stringify({ latency_ms: 42 }),
+    JSON.stringify({ response_body: 'ok' }),
+    JSON.stringify({ repetitions: 1 }),
+    now,
+    now
+  );
+  db.prepare(`
+    INSERT INTO test_result_documents (test_result_id, run_id, test_id, schema_version, document, created_at)
+    VALUES (?, ?, 'delete-test', '1.0.0', ?, ?)
+  `).run(resultId, runId, JSON.stringify({ test: { tags: ['delete'] }, selected_model: { id: 'model-delete' } }), now);
+  db.prepare(`
+    INSERT INTO metric_samples (id, test_result_id, repetition_index, total_ms, created_at)
+    VALUES (?, ?, 0, 42, ?)
+  `).run(`metric-${runId}`, resultId, now);
+  db.prepare(`
+    INSERT INTO evaluation_queue_skips (test_result_id, reason, skipped_at)
+    VALUES (?, 'not useful', ?)
+  `).run(resultId, now);
+  db.prepare(`
+    INSERT INTO eval_prompts (id, text, tags, created_at)
+    VALUES (?, 'Prompt', '[]', ?)
+  `).run(`prompt-${runId}`, now);
+  db.prepare(`
+    INSERT INTO evaluations (
+      id, prompt_id, model_name, server_id, inference_config, answer_text,
+      input_tokens, output_tokens, total_tokens, latency_ms, word_count,
+      estimated_cost, accuracy_score, relevance_score, coherence_score,
+      completeness_score, helpfulness_score, note, source_test_result_id, created_at
+    ) VALUES (?, ?, 'model-delete', 'srv-delete', '{}', 'Answer', 1, 1, 2, 42, 1, 0.001, 5, 5, 5, 5, 5, null, ?, ?)
+  `).run(`evaluation-${runId}`, `prompt-${runId}`, resultId, now);
+  db.prepare(`
+    INSERT INTO run_groups (
+      id, status, selected_template_ids, test_overrides, profile_id, profile_version,
+      created_at, started_at, ended_at, updated_at
+    ) VALUES (?, 'completed', '[]', null, null, null, ?, ?, ?, ?)
+  `).run(`group-${runId}`, now, now, now, now);
+  db.prepare(`
+    INSERT INTO run_group_items (
+      id, group_id, child_run_id, inference_server_id, model_id, stable_letter,
+      accent_index, status, failure_reason, created_at, started_at, ended_at, updated_at
+    ) VALUES (?, ?, ?, 'srv-delete', 'model-delete', 'A', 0, 'completed', null, ?, ?, ?, ?)
+  `).run(`group-item-${runId}`, `group-${runId}`, runId, now, now, now, now);
+}
+
+beforeEach(() => {
+  process.env.AITESTBENCH_API_TOKEN = 'test-token';
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aitb-runs-single-'));
+  process.env.AITESTBENCH_DB_PATH = path.join(tmpDir, 'test.sqlite');
+  resetDbInstance();
+  runSchema(fs.readFileSync(SCHEMA_PATH, 'utf8'));
+});
+
+afterEach(() => {
+  resetDbInstance();
+});
+
 describe('runs API', () => {
   it('creates a single run', async () => {
-    process.env.AITESTBENCH_API_TOKEN = 'test-token';
     const app = createServer();
     const server = createInferenceServerRecord({
       inference_server: { display_name: `local-${Date.now()}` },
@@ -30,10 +142,82 @@ describe('runs API', () => {
     const response = await app.inject({
       method: 'POST',
       url: '/runs',
-      headers: { 'x-api-token': 'test-token' },
+      headers: AUTH_HEADERS,
       payload: { inference_server_id: server.inference_server.server_id, test_id: 'test-1' }
     });
 
     expect(response.statusCode).toBe(201);
+  });
+
+  it('deletes a completed run and its result-owned data', async () => {
+    seedServer();
+    seedRunWithDependencies({ runId: 'run-delete' });
+    const app = createServer();
+
+    const deleted = await app.inject({
+      method: 'DELETE',
+      url: '/runs/run-delete',
+      headers: AUTH_HEADERS
+    });
+
+    expect(deleted.statusCode).toBe(204);
+    expect((await app.inject({ method: 'GET', url: '/runs/run-delete', headers: AUTH_HEADERS })).statusCode).toBe(404);
+    expect((await app.inject({ method: 'GET', url: '/results-view/runs/run-delete', headers: AUTH_HEADERS })).statusCode).toBe(404);
+    const listed = await app.inject({ method: 'GET', url: '/runs', headers: AUTH_HEADERS });
+    expect(listed.json().some((run: { id: string }) => run.id === 'run-delete')).toBe(false);
+    const resultsView = await app.inject({
+      method: 'POST',
+      url: '/results-view/query',
+      headers: AUTH_HEADERS,
+      payload: {
+        date_from: '2026-05-01T00:00:00.000Z',
+        date_to: '2026-05-02T00:00:00.000Z'
+      }
+    });
+    expect(resultsView.json().history.total).toBe(0);
+
+    const db = getDb();
+    expect((db.prepare('SELECT COUNT(1) AS count FROM runs WHERE id = ?').get('run-delete') as { count: number }).count).toBe(0);
+    expect((db.prepare('SELECT COUNT(1) AS count FROM test_results WHERE run_id = ?').get('run-delete') as { count: number }).count).toBe(0);
+    expect((db.prepare('SELECT COUNT(1) AS count FROM test_result_documents WHERE run_id = ?').get('run-delete') as { count: number }).count).toBe(0);
+    expect((db.prepare('SELECT COUNT(1) AS count FROM metric_samples WHERE test_result_id = ?').get('result-run-delete') as { count: number }).count).toBe(0);
+    expect((db.prepare('SELECT COUNT(1) AS count FROM evaluation_queue_skips WHERE test_result_id = ?').get('result-run-delete') as { count: number }).count).toBe(0);
+    expect((db.prepare('SELECT COUNT(1) AS count FROM run_group_items WHERE child_run_id = ?').get('run-delete') as { count: number }).count).toBe(0);
+    expect((db.prepare('SELECT COUNT(1) AS count FROM run_groups WHERE id = ?').get('group-run-delete') as { count: number }).count).toBe(1);
+    expect(
+      (db.prepare('SELECT source_test_result_id FROM evaluations WHERE id = ?').get('evaluation-run-delete') as { source_test_result_id: string | null }).source_test_result_id
+    ).toBeNull();
+  });
+
+  it('returns 404 when deleting an unknown run', async () => {
+    seedServer();
+    const app = createServer();
+
+    const response = await app.inject({
+      method: 'DELETE',
+      url: '/runs/missing-run',
+      headers: AUTH_HEADERS
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json().error).toBe('Run not found');
+  });
+
+  it.each(['queued', 'running'])('blocks deleting %s runs', async (status) => {
+    seedServer();
+    seedRunWithDependencies({ runId: `run-${status}`, status });
+    const app = createServer();
+
+    const response = await app.inject({
+      method: 'DELETE',
+      url: `/runs/run-${status}`,
+      headers: AUTH_HEADERS
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json().error).toBe('Active runs cannot be deleted');
+    const db = getDb();
+    expect((db.prepare('SELECT COUNT(1) AS count FROM runs WHERE id = ?').get(`run-${status}`) as { count: number }).count).toBe(1);
+    expect((db.prepare('SELECT COUNT(1) AS count FROM test_results WHERE run_id = ?').get(`run-${status}`) as { count: number }).count).toBe(1);
   });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -201,11 +201,13 @@ export function App() {
     refreshCounts();
     const intervalId = window.setInterval(refreshCounts, 30000);
     window.addEventListener('database:cleared', refreshCounts);
+    window.addEventListener('runs:changed', refreshCounts);
 
     return () => {
       isActive = false;
       window.clearInterval(intervalId);
       window.removeEventListener('database:cleared', refreshCounts);
+      window.removeEventListener('runs:changed', refreshCounts);
     };
   }, []);
 

--- a/frontend/src/pages/ResultsUnified.tsx
+++ b/frontend/src/pages/ResultsUnified.tsx
@@ -8,6 +8,7 @@ import { ResultsPerformanceComparisonPanel } from '../components/results-perform
 import { normalizeResultsTab } from '../navigation.js';
 import { getLeaderboard, type LeaderboardEntry } from '../services/leaderboard-api.js';
 import {
+  deleteRun,
   getResultsEvaluationDetail,
   getResultsRunDetail,
   queryResultsView,
@@ -842,24 +843,43 @@ function DetailDrawer({
   runDetail,
   evaluationDetail,
   loading,
-  onClose
+  deletingRun,
+  deleteRunError,
+  onClose,
+  onDeleteRun
 }: {
   runDetail: ResultsRunDetail | null;
   evaluationDetail: ResultsEvaluationDetail | null;
   loading: boolean;
+  deletingRun: boolean;
+  deleteRunError: string | null;
   onClose: () => void;
+  onDeleteRun: () => void;
 }) {
   return (
-    <div className="results-drawer-backdrop" role="presentation" onClick={onClose}>
+    <div className="results-drawer-backdrop" role="presentation" onClick={() => {
+      if (!deletingRun) {
+        onClose();
+      }
+    }}>
       <aside className="results-drawer" role="dialog" aria-modal="true" onClick={(event) => event.stopPropagation()}>
         <header className="results-drawer__header">
-          <button type="button" className="ghost-button" onClick={onClose}>Close</button>
+          <div className="results-drawer__actions">
+            <button type="button" className="ghost-button" onClick={onClose} disabled={deletingRun}>Close</button>
+            {runDetail ? (
+              <button type="button" className="btn btn--danger" onClick={onDeleteRun} disabled={deletingRun || loading}>
+                {deletingRun ? 'Deleting...' : 'Delete run'}
+              </button>
+            ) : null}
+          </div>
           <div>
             <h2>{runDetail ? runDetail.run.run_id : evaluationDetail ? evaluationDetail.evaluation.id : 'Detail'}</h2>
             <p>{runDetail ? 'Run detail' : 'Evaluation detail'}</p>
           </div>
         </header>
         {loading ? <p className="muted">Loading detail...</p> : null}
+        {deletingRun ? <p className="muted">Deleting run...</p> : null}
+        {deleteRunError ? <div className="error" role="alert">{deleteRunError}</div> : null}
         {runDetail ? <RunDetailBody detail={runDetail} /> : null}
         {evaluationDetail ? <EvaluationDetailBody detail={evaluationDetail} /> : null}
       </aside>
@@ -937,6 +957,7 @@ export function ResultsUnified({ runCount }: { runCount: number | null }) {
   const [data, setData] = useState<Awaited<ReturnType<typeof queryResultsView>> | null>(null);
   const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[]>([]);
   const [loading, setLoading] = useState(false);
+  const [resultsRefreshToken, setResultsRefreshToken] = useState(0);
   const [leaderboardLoading, setLeaderboardLoading] = useState(false);
   const [leaderboardRefreshToken, setLeaderboardRefreshToken] = useState(0);
   const [error, setError] = useState<string | null>(null);
@@ -945,6 +966,8 @@ export function ResultsUnified({ runCount }: { runCount: number | null }) {
   const [runDetail, setRunDetail] = useState<ResultsRunDetail | null>(null);
   const [evaluationDetail, setEvaluationDetail] = useState<ResultsEvaluationDetail | null>(null);
   const [detailLoading, setDetailLoading] = useState(false);
+  const [deletingRun, setDeletingRun] = useState(false);
+  const [deleteRunError, setDeleteRunError] = useState<string | null>(null);
   const hasExplicitDateTo = searchParams.has('date_to');
 
   useEffect(() => {
@@ -972,7 +995,7 @@ export function ResultsUnified({ runCount }: { runCount: number | null }) {
     return () => {
       active = false;
     };
-  }, [filters]);
+  }, [filters, resultsRefreshToken]);
 
   useEffect(() => {
     if (activeTab !== 'leaderboard') {
@@ -1025,10 +1048,12 @@ export function ResultsUnified({ runCount }: { runCount: number | null }) {
     if (!runId && !evaluationId) {
       setRunDetail(null);
       setEvaluationDetail(null);
+      setDeleteRunError(null);
       return;
     }
     let active = true;
     setDetailLoading(true);
+    setDeleteRunError(null);
     setRunDetail(null);
     setEvaluationDetail(null);
     const request = runId ? getResultsRunDetail(runId).then((detail) => ({ run: detail })) : getResultsEvaluationDetail(evaluationId as string).then((detail) => ({ evaluation: detail }));
@@ -1079,10 +1104,40 @@ export function ResultsUnified({ runCount }: { runCount: number | null }) {
   }
 
   function closeDrawer() {
+    if (deletingRun) {
+      return;
+    }
     const next = new URLSearchParams(searchParams);
     next.delete('run');
     next.delete('evaluation');
     setSearchParams(next);
+  }
+
+  async function handleDeleteRun() {
+    if (!runDetail || deletingRun) {
+      return;
+    }
+    const confirmed = window.confirm(`Delete run ${runDetail.run.run_id} and its results? This cannot be undone.`);
+    if (!confirmed) {
+      return;
+    }
+
+    setDeletingRun(true);
+    setDeleteRunError(null);
+    try {
+      await deleteRun(runDetail.run.run_id);
+      const next = new URLSearchParams(searchParams);
+      next.delete('run');
+      next.delete('evaluation');
+      setSearchParams(next);
+      setRunDetail(null);
+      setResultsRefreshToken((current) => current + 1);
+      window.dispatchEvent(new CustomEvent('runs:changed'));
+    } catch (err) {
+      setDeleteRunError(err instanceof Error ? err.message : 'Unable to delete run');
+    } finally {
+      setDeletingRun(false);
+    }
   }
 
   function exportView() {
@@ -1187,7 +1242,15 @@ export function ResultsUnified({ runCount }: { runCount: number | null }) {
         </main>
       </section>
       {runDetail || evaluationDetail || detailLoading ? (
-        <DetailDrawer runDetail={runDetail} evaluationDetail={evaluationDetail} loading={detailLoading} onClose={closeDrawer} />
+        <DetailDrawer
+          runDetail={runDetail}
+          evaluationDetail={evaluationDetail}
+          loading={detailLoading}
+          deletingRun={deletingRun}
+          deleteRunError={deleteRunError}
+          onClose={closeDrawer}
+          onDeleteRun={handleDeleteRun}
+        />
       ) : null}
     </>
   );

--- a/frontend/src/services/results-view-api.ts
+++ b/frontend/src/services/results-view-api.ts
@@ -1,4 +1,4 @@
-import { apiGet, apiPost } from './api.js';
+import { apiDelete, apiGet, apiPost } from './api.js';
 
 export type ResultsTab = 'dashboard' | 'leaderboard' | 'history';
 export type ResultsStatus = 'pass' | 'fail' | 'partial' | 'streaming';
@@ -155,4 +155,8 @@ export function getResultsRunDetail(runId: string): Promise<ResultsRunDetail> {
 
 export function getResultsEvaluationDetail(evaluationId: string): Promise<ResultsEvaluationDetail> {
   return apiGet<ResultsEvaluationDetail>(`/evaluations/${encodeURIComponent(evaluationId)}`);
+}
+
+export async function deleteRun(runId: string): Promise<void> {
+  await apiDelete(`/runs/${encodeURIComponent(runId)}`);
 }

--- a/frontend/src/styles/dashboard-results.css
+++ b/frontend/src/styles/dashboard-results.css
@@ -591,6 +591,13 @@
   background: var(--paper-1);
 }
 
+.results-drawer__actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
 .results-drawer__header h2 {
   margin: 0;
   font-family: var(--font-mono);

--- a/frontend/tests/e2e/results-dashboard.spec.ts
+++ b/frontend/tests/e2e/results-dashboard.spec.ts
@@ -282,3 +282,80 @@ test('merged Results dashboard filter and render flow', async ({ page }) => {
   await expect(page.getByRole('heading', { name: 'No runs in the selected range' })).toBeVisible();
   await expect(page.getByRole('button', { name: 'Go to Run page' })).toBeVisible();
 });
+
+test('deletes a run from the run detail drawer after confirmation', async ({ page }) => {
+  let deleted = false;
+  let deleteRequests = 0;
+  let dialogCount = 0;
+
+  await page.route('**/results-view/query', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(resultsViewPayload(deleted))
+    });
+  });
+
+  await page.route('**/results-view/runs/run-dashboard-1', async (route) => {
+    if (deleted) {
+      await route.fulfill({
+        status: 404,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'Run not found' })
+      });
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        run: resultsViewPayload().history.rows[0],
+        raw_run: { id: 'run-dashboard-1', status: 'completed' },
+        results: [
+          {
+            id: 'result-dashboard-1',
+            test_id: 'latency-benchmark',
+            template_label: 'latency-benchmark',
+            verdict: 'pass',
+            metrics: { latency_ms: 80 }
+          }
+        ],
+        documents: [{ summary: { passed_steps: 1, failed_steps: 0 } }]
+      })
+    });
+  });
+
+  await page.route('**/runs/run-dashboard-1', async (route) => {
+    if (route.request().method() !== 'DELETE') {
+      await route.fallback();
+      return;
+    }
+    deleteRequests += 1;
+    deleted = true;
+    await route.fulfill({ status: 204 });
+  });
+
+  page.on('dialog', async (dialog) => {
+    dialogCount += 1;
+    if (dialogCount === 1) {
+      await dialog.dismiss();
+      return;
+    }
+    await dialog.accept();
+  });
+
+  await page.goto('/results?tab=dashboard');
+  await page.locator('.results-run-row').filter({ hasText: 'latency-benchmark' }).click();
+  await expect(page.getByText('Run detail')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Delete run' })).toBeVisible();
+
+  await page.getByRole('button', { name: 'Delete run' }).click();
+  expect(deleteRequests).toBe(0);
+  await expect(page.getByText('Run detail')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Delete run' }).click();
+  await expect(page.getByText('Run detail')).toHaveCount(0);
+  expect(deleteRequests).toBe(1);
+  expect(page.url()).not.toContain('run=run-dashboard-1');
+  await expect(page.getByRole('heading', { name: 'No runs in the selected range' })).toBeVisible();
+});


### PR DESCRIPTION
Add a DELETE /runs/:runId endpoint that hard-deletes terminal runs and cleans up result-owned rows in a transaction, including metric samples, result documents, evaluation queue skips, test results, and run-group item links. Active queued or running runs now return a 409 instead of being deleted. Expose the delete action from the active Results run detail drawer with a confirmation prompt, disabled in-progress state, inline error handling, and post-delete refresh of results data and run counts. Cover dependency cleanup, active-run blocking, missing-run handling, and the drawer confirmation flow with backend integration and Playwright tests.