### PR TITLE
fix(discovery):Persist probe-derived model metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 
 - Results dashboard now compares raw cold-start performance across servers and models with sample-backed summary rows and box plots for cold penalty, cold total, and hot total metrics.
 - Results run detail drawers now support guarded hard deletion of completed runs, removing result documents, metric samples, queue skips, and run-group item links while preserving linked evaluations.
+- Server discovery now upserts discovered models with persisted parser-derived metadata, including clean base names, quantized providers, parameter labels, active MoE labels, formats, quantization bits, and use-case tags.
+
+### Changed
+
+- Catalog and Models metadata filters/details now use persisted `/models` records as their source of truth instead of inferring provider, format, quantized provider, or use cases from raw model IDs.
 
 
 ## [0.4.0] - 2026-05-10

--- a/backend/src/api/routes/architecture.ts
+++ b/backend/src/api/routes/architecture.ts
@@ -16,8 +16,7 @@ import {
   InspectorError,
 } from '../../adapters/architecture-inspector.js';
 import { validateWithSchema } from '../../services/schema-validator.js';
-import { guessModelCharacteristics } from '../../services/model-name-parser.js';
-import { InvalidModelError, upsertModelRecord } from '../../services/models-repository.js';
+import { InvalidModelError, upsertDiscoveredModelRecord } from '../../services/models-repository.js';
 
 const moduleDir = path.dirname(fileURLToPath(import.meta.url));
 const SETTINGS_SCHEMA = path.resolve(moduleDir, '../../schemas/architecture-settings.schema.json');
@@ -98,34 +97,6 @@ function getArchitectureSettings(serverId: string, modelId: string): { trust_rem
   return { trust_remote_code: row ? row.trust_remote_code === 1 : false };
 }
 
-function inferFormat(modelId: string): 'MLX' | 'GGUF' | 'GPTQ' | 'AWQ' | 'SafeTensors' | null {
-  if (/\bmlx\b/i.test(modelId)) return 'MLX';
-  if (/\b(?:gguf|gcuf)\b/i.test(modelId)) return 'GGUF';
-  if (/\bgptq\b/i.test(modelId)) return 'GPTQ';
-  if (/\bawq\b/i.test(modelId)) return 'AWQ';
-  if (/\bsafetensors\b/i.test(modelId)) return 'SafeTensors';
-  return null;
-}
-
-function discoveryQuantisation(modelId: string, discovered: DiscoveryModel): ModelRecord['architecture']['quantisation'] {
-  if (discovered.quantisation && typeof discovered.quantisation === 'object') {
-    return {
-      method: discovered.quantisation.method as ModelRecord['architecture']['quantisation']['method'],
-      bits: discovered.quantisation.bits,
-      group_size: discovered.quantisation.group_size,
-      scheme: discovered.quantisation.scheme as ModelRecord['architecture']['quantisation']['scheme'],
-      variant: discovered.quantisation.variant as ModelRecord['architecture']['quantisation']['variant'],
-      weight_format: discovered.quantisation.weight_format,
-    };
-  }
-  const guessed = guessModelCharacteristics(modelId);
-  return {
-    method: guessed.quantisation.method ?? 'unknown',
-    bits: guessed.quantisation.bits,
-    group_size: null,
-  };
-}
-
 function getOrCreateModelForInspection(serverId: string, modelId: string): ModelRecord | null {
   const existing = getModelById(serverId, modelId);
   if (existing) {
@@ -141,22 +112,12 @@ function getOrCreateModelForInspection(serverId: string, modelId: string): Model
   }
 
   try {
-    return upsertModelRecord({
-      model: {
-        server_id: serverId,
-        model_id: modelId,
-        display_name: discovered.display_name ?? modelId,
-      },
-      identity: {
-        provider: guessModelCharacteristics(modelId).provider ?? 'unknown',
-      },
-      architecture: {
-        format: inferFormat(modelId),
-        quantisation: discoveryQuantisation(modelId, discovered),
-      },
-      limits: {
-        context_window_tokens: discovered.context_window_tokens,
-      },
+    return upsertDiscoveredModelRecord({
+      server_id: serverId,
+      model_id: modelId,
+      display_name: discovered.display_name ?? modelId,
+      context_window_tokens: discovered.context_window_tokens,
+      quantisation: typeof discovered.quantisation === 'object' ? discovered.quantisation : null,
       raw: { discovery_model: discovered },
     });
   } catch (error) {

--- a/backend/src/models/model.ts
+++ b/backend/src/models/model.ts
@@ -1,7 +1,7 @@
 import { getDb } from './db.js';
 import { nowIso, parseJson, serializeJson } from './repositories.js';
 
-export const MODEL_SCHEMA_VERSION = '1.1.0';
+export const MODEL_SCHEMA_VERSION = '1.2.0';
 
 export type ModelProvider =
   | 'openai'
@@ -49,6 +49,8 @@ export interface ModelIdentity {
 export interface ModelArchitecture {
   type: ModelArchitectureType;
   parameter_count: number | null;
+  parameter_count_label: string | null;
+  active_parameter_label: string | null;
   precision: ModelPrecision;
   quantisation: {
     method: ModelQuantisationMethod;
@@ -158,6 +160,8 @@ function defaultArchitecture(): ModelArchitecture {
   return {
     type: 'unknown',
     parameter_count: null,
+    parameter_count_label: null,
+    active_parameter_label: null,
     precision: 'unknown',
     quantisation: {
       method: 'unknown',

--- a/backend/src/schemas/model-schema.json
+++ b/backend/src/schemas/model-schema.json
@@ -1,5 +1,5 @@
 {
-  "model_schema_version": "1.0.0",
+  "model_schema_version": "1.2.0",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Model Schema",
   "type": "object",
@@ -74,6 +74,8 @@
       "properties": {
         "type": { "type": "string", "enum": ["decoder-only", "encoder-decoder", "other", "unknown"] },
         "parameter_count": { "type": ["number", "null"] },
+        "parameter_count_label": { "type": ["string", "null"] },
+        "active_parameter_label": { "type": ["string", "null"] },
         "precision": {
           "type": "string",
           "enum": ["fp32", "fp16", "bf16", "int8", "int4", "mixed", "unknown"]

--- a/backend/src/services/inference-proxy.ts
+++ b/backend/src/services/inference-proxy.ts
@@ -14,6 +14,8 @@ export interface InferenceProxyConfig {
 }
 
 let backendFetchDispatcher: Dispatcher | null = null;
+type UndiciFetchInput = Parameters<typeof undiciFetch>[0];
+type UndiciFetchInit = Parameters<typeof undiciFetch>[1];
 
 export function resolveInferenceProxyConfig(
   env: NodeJS.ProcessEnv = process.env
@@ -40,18 +42,21 @@ export function configureInferenceProxyFromEnv(env: NodeJS.ProcessEnv = process.
     proxyTunnel: false
   });
   setGlobalDispatcher(backendFetchDispatcher);
-  globalThis.fetch = backendFetch;
+  globalThis.fetch = backendFetch as typeof globalThis.fetch;
 
   return true;
 }
 
-export function backendFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+export function backendFetch(input: UndiciFetchInput, init?: UndiciFetchInit): ReturnType<typeof undiciFetch> {
   if (!backendFetchDispatcher) {
-    return globalThis.fetch(input, init);
+    return globalThis.fetch(
+      input as Parameters<typeof globalThis.fetch>[0],
+      init as Parameters<typeof globalThis.fetch>[1]
+    ) as ReturnType<typeof undiciFetch>;
   }
 
   return undiciFetch(input, {
     ...(init ?? {}),
     dispatcher: backendFetchDispatcher
-  } as RequestInit & { dispatcher: Dispatcher }) as unknown as Promise<Response>;
+  });
 }

--- a/backend/src/services/inference-server-refresh.ts
+++ b/backend/src/services/inference-server-refresh.ts
@@ -6,6 +6,7 @@ import { updateInferenceServerRecord } from './inference-servers-repository.js';
 import { buildInferenceServerAuthHeaders } from './inference-server-auth.js';
 import { backendFetch } from './inference-proxy.js';
 import { extractQuantisationLabel, normaliseQuantisationFromLabel } from './quantisation-normalizer.js';
+import { upsertDiscoveredModelRecord } from './models-repository.js';
 
 export class InferenceServerRefreshError extends Error {
   details: {
@@ -211,6 +212,16 @@ export async function refreshDiscovery(server: InferenceServerRecord): Promise<I
       attempted_url: server.endpoints.base_url,
       message: 'Unable to persist discovery response',
       timestamp: nowIso()
+    });
+  }
+  for (const model of normalised) {
+    upsertDiscoveredModelRecord({
+      server_id: server.inference_server.server_id,
+      model_id: model.model_id,
+      display_name: model.display_name,
+      context_window_tokens: model.context_window_tokens,
+      quantisation: model.quantisation,
+      raw: { discovery_model: model }
     });
   }
   return updated;

--- a/backend/src/services/model-name-parser.ts
+++ b/backend/src/services/model-name-parser.ts
@@ -4,11 +4,20 @@ export interface ModelNameGuess {
   provider: ModelProvider | null;
   parameter_count: number | null;
   parameter_count_label: string | null;
+  active_parameter_label: string | null;
+  quantized_provider: string | null;
+  format: 'MLX' | 'GGUF' | 'GPTQ' | 'AWQ' | 'SafeTensors' | null;
   quantisation: {
     method: ModelQuantisationMethod | null;
     bits: number | null;
   };
   precision: ModelPrecision | null;
+  use_case: {
+    thinking: boolean;
+    coding: boolean;
+    instruct: boolean;
+    mixture_of_experts: boolean;
+  };
 }
 
 const providerHints: Array<{ provider: ModelProvider; patterns: RegExp[] }> = [
@@ -89,32 +98,62 @@ function parseQuantisationBits(text: string): number | null {
   return null;
 }
 
-const DROP_PATTERNS = [
-  /^mlx$/i,
-  /^gguf$/i,
-  /^gcuf$/i,
-  /^gptq$/i,
-  /^awq$/i,
-  /^safetensors$/i,
-  /^\d+(\.\d+)?bit$/i,
-  /^q\d+(_k_[sml]|_[0-3])?$/i,
-  /^\d{4,}$/,
-  /^fp(16|32)$/i,
-  /^bf16$/i,
-  /^int[48]$/i
-];
-
 export function extractBaseModelName(modelId: string): string | null {
   if (!modelId.trim()) {
     return null;
   }
-  const stripped = modelId.replace(/^\/?[^/]+\//, '');
-  const parts = stripped.split(/[-_]/);
-  while (parts.length > 0 && DROP_PATTERNS.some((p) => p.test(parts[parts.length - 1]))) {
-    parts.pop();
+  let name = modelId.replace(/^\/+/, '').split('/').filter(Boolean).pop() ?? '';
+  let previous: string;
+  do {
+    previous = name;
+    name = name.replace(
+      /[-_](?:mlx|gguf|gcuf|gptq|awq|safetensors|\d+(?:\.\d+)?bit|q\d+(?:_k_[sml]|_[0-3])?|\d{4,}|a\d+(?:\.\d+)?[bm]|\d+(?:\.\d+)?(?:b|bn|billion|m|million)|instruct|chat|fp(?:16|32)|bf16|int[48])$/i,
+      ''
+    );
+  } while (name !== previous);
+  return name || null;
+}
+
+function parseActiveParameterLabel(text: string): string | null {
+  const match = text.match(/(?:^|[-_\s])A(\d+(?:\.\d+)?[BM])(?:[-_\s]|$)/i);
+  return match ? `A${match[1].toUpperCase()}` : null;
+}
+
+function parseModelFormat(text: string): ModelNameGuess['format'] {
+  if (/\bmlx\b/i.test(text)) return 'MLX';
+  if (/\b(?:gguf|gcuf)\b/i.test(text)) return 'GGUF';
+  if (/\bgptq\b/i.test(text)) return 'GPTQ';
+  if (/\bawq\b/i.test(text)) return 'AWQ';
+  if (/\bsafetensors\b/i.test(text)) return 'SafeTensors';
+  return null;
+}
+
+function quantMethodForFormat(format: ModelNameGuess['format']): ModelQuantisationMethod | null {
+  if (format === 'MLX') return 'mlx';
+  if (format === 'GGUF') return 'gguf';
+  if (format === 'GPTQ') return 'gptq';
+  if (format === 'AWQ') return 'awq';
+  return null;
+}
+
+function parseQuantizedProvider(modelId: string, hasQuantizedMetadata: boolean): string | null {
+  if (!hasQuantizedMetadata) {
+    return null;
   }
-  const result = parts.join('-');
-  return result || null;
+  const parts = modelId.replace(/^\/+/, '').split('/').filter(Boolean);
+  if (parts.length < 2) {
+    return null;
+  }
+  return parts[0].includes('.') && parts.length > 2 ? parts[1] : parts[0];
+}
+
+function inferUseCase(text: string, activeParameterLabel: string | null): ModelNameGuess['use_case'] {
+  return {
+    thinking: /\b(thinking|reasoning|reasoner|qwq|r1)\b/i.test(text),
+    coding: /\b(code|coder|coding|devstral)\b/i.test(text),
+    instruct: /\b(instruct|chat)\b/i.test(text),
+    mixture_of_experts: Boolean(activeParameterLabel) || /\b(moe|mixture[-_ ]?of[-_ ]?experts|mixtral)\b/i.test(text)
+  };
 }
 
 export function guessModelCharacteristics(modelName: string): ModelNameGuess {
@@ -129,16 +168,23 @@ export function guessModelCharacteristics(modelName: string): ModelNameGuess {
     matchFirst(normalized, precisionHints.map((entry) => ({ value: entry.precision, patterns: entry.patterns }))) ??
     null;
   const parameter = parseParameterCount(normalized);
+  const activeParameterLabel = parseActiveParameterLabel(normalized);
+  const format = parseModelFormat(normalized);
   const quantBits = parseQuantisationBits(normalized);
+  const effectiveQuantMethod = quantMethod ?? quantMethodForFormat(format);
 
   return {
     provider,
     parameter_count: parameter?.count ?? null,
     parameter_count_label: parameter?.label ?? null,
+    active_parameter_label: activeParameterLabel,
+    quantized_provider: parseQuantizedProvider(normalized, Boolean(format || quantBits != null || effectiveQuantMethod)),
+    format,
     quantisation: {
-      method: quantMethod,
+      method: effectiveQuantMethod,
       bits: quantBits
     },
-    precision
+    precision,
+    use_case: inferUseCase(normalized, activeParameterLabel)
   };
 }

--- a/backend/src/services/models-repository.ts
+++ b/backend/src/services/models-repository.ts
@@ -22,19 +22,39 @@ import {
   updateModel
 } from '../models/model.js';
 import { nowIso } from '../models/repositories.js';
-import { extractBaseModelName } from './model-name-parser.js';
+import { extractBaseModelName, guessModelCharacteristics } from './model-name-parser.js';
 import { validateWithSchema } from './schema-validator.js';
 
 export interface ModelInput {
   model?: Partial<ModelInfo>;
   identity?: Partial<ModelIdentity>;
-  architecture?: Partial<ModelArchitecture>;
+  architecture?: Partial<Omit<ModelArchitecture, 'quantisation'>> & {
+    quantisation?: Partial<ModelArchitecture['quantisation']>;
+  };
   modalities?: Partial<ModelModalities>;
-  capabilities?: Partial<ModelCapabilities>;
+  capabilities?: Partial<Omit<ModelCapabilities, 'use_case'>> & {
+    use_case?: Partial<ModelCapabilities['use_case']>;
+  };
   limits?: Partial<ModelLimits>;
   performance?: Partial<ModelPerformance>;
   configuration?: Partial<ModelConfiguration>;
   discovery?: Partial<ModelDiscovery>;
+  raw?: Record<string, unknown>;
+}
+
+export interface DiscoveredModelInput {
+  server_id: string;
+  model_id: string;
+  display_name?: string | null;
+  context_window_tokens?: number | null;
+  quantisation?: {
+    method?: string | null;
+    bits?: number | null;
+    group_size?: number | null;
+    scheme?: string | null;
+    variant?: string | null;
+    weight_format?: string | null;
+  } | null;
   raw?: Record<string, unknown>;
 }
 
@@ -65,6 +85,8 @@ function defaultArchitecture(): ModelArchitecture {
   return {
     type: 'unknown',
     parameter_count: null,
+    parameter_count_label: null,
+    active_parameter_label: null,
     precision: 'unknown',
     quantisation: { method: 'unknown', bits: null, group_size: null },
     format: null
@@ -130,7 +152,7 @@ function mergeIdentity(existing: ModelIdentity | null, updates: Partial<ModelIde
 
 function mergeArchitecture(
   existing: ModelArchitecture | null,
-  updates: Partial<ModelArchitecture> | undefined
+  updates: ModelInput['architecture'] | undefined
 ): ModelArchitecture {
   const base = existing ?? defaultArchitecture();
   if (!updates) {
@@ -193,7 +215,7 @@ function mergeModalities(
 
 function mergeCapabilities(
   existing: ModelCapabilities | null,
-  updates: Partial<ModelCapabilities> | undefined
+  updates: ModelInput['capabilities'] | undefined
 ): ModelCapabilities {
   const base = existing ?? defaultCapabilities();
   if (!updates) {
@@ -261,6 +283,120 @@ function validateModelRecord(record: ModelRecord): void {
     .map((issue) => (issue.path ? `${issue.path}: ${issue.message}` : issue.message))
     .join('; ');
   throw new InvalidModelError(`Schema validation failed: ${detail}`);
+}
+
+function isBlankText(value: string | null | undefined): boolean {
+  return value == null || value.trim() === '' || value.trim().toLowerCase() === 'unknown';
+}
+
+function inferredModelInput(input: DiscoveredModelInput): ModelInput {
+  const guessed = guessModelCharacteristics(input.model_id);
+  const discoveredMethod = input.quantisation?.method;
+  const quantisationMethod =
+    discoveredMethod && discoveredMethod !== 'unknown'
+      ? discoveredMethod
+      : guessed.quantisation.method ?? 'unknown';
+  return {
+    model: {
+      model_id: input.model_id,
+      server_id: input.server_id,
+      display_name: input.display_name?.trim() || input.model_id,
+      base_model_name: extractBaseModelName(input.model_id)
+    },
+    identity: {
+      provider: guessed.provider ?? 'unknown',
+      quantized_provider: guessed.quantized_provider
+    },
+    architecture: {
+      parameter_count: guessed.parameter_count,
+      parameter_count_label: guessed.parameter_count_label,
+      active_parameter_label: guessed.active_parameter_label,
+      format: guessed.format,
+      quantisation: {
+        method: quantisationMethod as ModelArchitecture['quantisation']['method'],
+        bits: input.quantisation?.bits ?? guessed.quantisation.bits,
+        group_size: input.quantisation?.group_size ?? null,
+        scheme: (input.quantisation?.scheme ?? null) as ModelArchitecture['quantisation']['scheme'],
+        variant: (input.quantisation?.variant ?? null) as ModelArchitecture['quantisation']['variant'],
+        weight_format: input.quantisation?.weight_format ?? null
+      }
+    },
+    capabilities: {
+      use_case: guessed.use_case
+    },
+    limits: {
+      context_window_tokens: input.context_window_tokens ?? null
+    },
+    discovery: {
+      retrieved_at: nowIso(),
+      source: 'server'
+    },
+    raw: input.raw ?? {}
+  };
+}
+
+function fillMissingModelInput(existing: ModelRecord, inferred: ModelInput): ModelInput {
+  const updates: ModelInput = {};
+  if (isBlankText(existing.model.base_model_name) && inferred.model?.base_model_name) {
+    updates.model = { base_model_name: inferred.model.base_model_name };
+  }
+  if (isBlankText(existing.identity.provider) && inferred.identity?.provider) {
+    updates.identity = { ...(updates.identity ?? {}), provider: inferred.identity.provider };
+  }
+  if (isBlankText(existing.identity.quantized_provider) && inferred.identity?.quantized_provider) {
+    updates.identity = { ...(updates.identity ?? {}), quantized_provider: inferred.identity.quantized_provider };
+  }
+  if (existing.architecture.parameter_count == null && inferred.architecture?.parameter_count != null) {
+    updates.architecture = { ...(updates.architecture ?? {}), parameter_count: inferred.architecture.parameter_count };
+  }
+  if (isBlankText(existing.architecture.parameter_count_label) && inferred.architecture?.parameter_count_label) {
+    updates.architecture = { ...(updates.architecture ?? {}), parameter_count_label: inferred.architecture.parameter_count_label };
+  }
+  if (isBlankText(existing.architecture.active_parameter_label) && inferred.architecture?.active_parameter_label) {
+    updates.architecture = { ...(updates.architecture ?? {}), active_parameter_label: inferred.architecture.active_parameter_label };
+  }
+  if (existing.architecture.format == null && inferred.architecture?.format) {
+    updates.architecture = { ...(updates.architecture ?? {}), format: inferred.architecture.format };
+  }
+  if (inferred.architecture?.quantisation) {
+    const quantUpdates: Partial<ModelArchitecture['quantisation']> = {};
+    const current = existing.architecture.quantisation;
+    const inferredQuant = inferred.architecture.quantisation;
+    if ((current.method === 'unknown' || current.method == null) && inferredQuant.method && inferredQuant.method !== 'unknown') {
+      quantUpdates.method = inferredQuant.method;
+    }
+    if (current.bits == null && inferredQuant.bits != null) {
+      quantUpdates.bits = inferredQuant.bits;
+    }
+    if (current.group_size == null && inferredQuant.group_size != null) {
+      quantUpdates.group_size = inferredQuant.group_size;
+    }
+    if (current.scheme == null && inferredQuant.scheme != null) {
+      quantUpdates.scheme = inferredQuant.scheme;
+    }
+    if (current.variant == null && inferredQuant.variant != null) {
+      quantUpdates.variant = inferredQuant.variant;
+    }
+    if (isBlankText(current.weight_format) && inferredQuant.weight_format) {
+      quantUpdates.weight_format = inferredQuant.weight_format;
+    }
+    if (Object.keys(quantUpdates).length) {
+      updates.architecture = { ...(updates.architecture ?? {}), quantisation: quantUpdates };
+    }
+  }
+  if (existing.limits.context_window_tokens == null && inferred.limits?.context_window_tokens != null) {
+    updates.limits = { context_window_tokens: inferred.limits.context_window_tokens };
+  }
+  const useCaseUpdates: Partial<ModelCapabilities['use_case']> = {};
+  for (const key of ['thinking', 'coding', 'instruct', 'mixture_of_experts'] as const) {
+    if (!existing.capabilities.use_case[key] && inferred.capabilities?.use_case?.[key]) {
+      useCaseUpdates[key] = true;
+    }
+  }
+  if (Object.keys(useCaseUpdates).length) {
+    updates.capabilities = { use_case: useCaseUpdates };
+  }
+  return updates;
 }
 
 export function fetchModels(filters?: {
@@ -419,6 +555,24 @@ export function upsertModelRecord(input: ModelInput): ModelRecord {
     ...input,
     model: { ...modelInfo, model_id: modelId, server_id: serverId }
   });
+}
+
+export function upsertDiscoveredModelRecord(input: DiscoveredModelInput): ModelRecord {
+  const inferred = inferredModelInput(input);
+  const existing = getModelById(input.server_id, input.model_id);
+  if (!existing) {
+    return createModelRecord(inferred);
+  }
+  const updates = fillMissingModelInput(existing, inferred);
+  updates.discovery = inferred.discovery;
+  if (input.raw) {
+    updates.raw = { ...existing.raw, ...input.raw };
+  }
+  const updated = updateModelRecord(input.server_id, input.model_id, updates);
+  if (!updated) {
+    throw new InvalidModelError('Unable to update discovered model record');
+  }
+  return updated;
 }
 
 export function archiveModel(serverId: string, modelId: string): ModelRecord | null {

--- a/backend/tests/contract/inference-servers.spec.ts
+++ b/backend/tests/contract/inference-servers.spec.ts
@@ -14,6 +14,11 @@ function resetDb() {
     // Table may not exist before schema bootstrap in first test.
   }
   try {
+    db.prepare('DELETE FROM models').run();
+  } catch {
+    // Table may not exist before schema bootstrap in first test.
+  }
+  try {
     db.prepare('DELETE FROM inference_servers').run();
   } catch {
     // Table may not exist before schema bootstrap in first test.
@@ -205,6 +210,98 @@ describe('inference servers contract', () => {
     const refreshed = refreshResponse.json();
     expect(refreshed.discovery.model_list.raw).toEqual(payload);
     expect(refreshed.discovery.model_list.normalised[0].model_id).toBe('gpt-test');
+
+    const modelsResponse = await app.inject({
+      method: 'GET',
+      url: '/models',
+      headers: AUTH_HEADERS
+    });
+    expect(modelsResponse.statusCode).toBe(200);
+    expect(modelsResponse.json().map((model: { model: { model_id: string } }) => model.model.model_id)).toEqual([
+      'gpt-test'
+    ]);
+  });
+
+  it('refresh-discovery persists parsed model metadata and preserves manual edits', async () => {
+    const app = createServer();
+    const createResponse = await app.inject({
+      method: 'POST',
+      url: '/inference-servers',
+      headers: AUTH_HEADERS,
+      payload: buildCreatePayload()
+    });
+    if (createResponse.statusCode !== 201) {
+      throw new Error(`create inference server failed: ${createResponse.statusCode} ${createResponse.body}`);
+    }
+    const created = createResponse.json();
+    const modelId = 'inferencerlabs/Qwen3-Coder-30B-A3B-Instruct-MLX-6.5bit';
+    const payload = { data: [{ id: modelId }] };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          ({
+            ok: true,
+            headers: { get: () => 'application/json' },
+            json: async () => payload
+          }) as any
+      )
+    );
+
+    const refreshResponse = await app.inject({
+      method: 'POST',
+      url: `/inference-servers/${created.inference_server.server_id}/refresh-discovery`,
+      headers: AUTH_HEADERS
+    });
+    expect(refreshResponse.statusCode).toBe(200);
+
+    const modelsResponse = await app.inject({
+      method: 'GET',
+      url: '/models',
+      headers: AUTH_HEADERS
+    });
+    const [model] = modelsResponse.json();
+    expect(model.model.base_model_name).toBe('Qwen3-Coder');
+    expect(model.identity.quantized_provider).toBe('inferencerlabs');
+    expect(model.architecture.parameter_count).toBe(30_000_000_000);
+    expect(model.architecture.parameter_count_label).toBe('30B');
+    expect(model.architecture.active_parameter_label).toBe('A3B');
+    expect(model.architecture.format).toBe('MLX');
+    expect(model.architecture.quantisation.method).toBe('mlx');
+    expect(model.architecture.quantisation.bits).toBe(6.5);
+    expect(model.capabilities.use_case.instruct).toBe(true);
+    expect(model.capabilities.use_case.coding).toBe(true);
+    expect(model.capabilities.use_case.mixture_of_experts).toBe(true);
+
+    const patchResponse = await app.inject({
+      method: 'PATCH',
+      url: `/models/${created.inference_server.server_id}/${encodeURIComponent(modelId)}`,
+      headers: AUTH_HEADERS,
+      payload: {
+        model: { base_model_name: 'Manual Name' },
+        identity: { provider: 'custom', quantized_provider: 'manual-provider' },
+        architecture: { format: 'GGUF', parameter_count_label: 'Manual Params' }
+      }
+    });
+    expect(patchResponse.statusCode).toBe(200);
+
+    const refreshAgain = await app.inject({
+      method: 'POST',
+      url: `/inference-servers/${created.inference_server.server_id}/refresh-discovery`,
+      headers: AUTH_HEADERS
+    });
+    expect(refreshAgain.statusCode).toBe(200);
+    const preservedResponse = await app.inject({
+      method: 'GET',
+      url: `/models/${created.inference_server.server_id}/${encodeURIComponent(modelId)}`,
+      headers: AUTH_HEADERS
+    });
+    const preserved = preservedResponse.json();
+    expect(preserved.model.base_model_name).toBe('Manual Name');
+    expect(preserved.identity.provider).toBe('custom');
+    expect(preserved.identity.quantized_provider).toBe('manual-provider');
+    expect(preserved.architecture.format).toBe('GGUF');
+    expect(preserved.architecture.parameter_count_label).toBe('Manual Params');
   });
 
   it('filters malformed remote-prefixed OpenAI discovery model IDs', async () => {

--- a/backend/tests/contract/models.spec.ts
+++ b/backend/tests/contract/models.spec.ts
@@ -80,6 +80,7 @@ describe('models contract', () => {
     });
     expect(createResponse.statusCode).toBe(201);
     const created = createResponse.json();
+    expect(created.model_schema_version).toBe('1.2.0');
     expect(created.model.model_id).toBe('gpt-test');
     expect(created.model.created_at).toBeTruthy();
     expect(created.model.updated_at).toBeTruthy();
@@ -212,7 +213,7 @@ describe('models contract', () => {
     });
     expect(createResponse.statusCode).toBe(201);
     const created = createResponse.json();
-    expect(created.model.base_model_name).toBe('Qwen3-Coder-30B-A3B-Instruct');
+    expect(created.model.base_model_name).toBe('Qwen3-Coder');
   });
 
   it('accepts valid format enum value on POST /models and returns it', async () => {
@@ -491,6 +492,8 @@ describe('models contract', () => {
     expect(listResponse.statusCode).toBe(200);
     const [record] = listResponse.json();
     expect(record.architecture).toHaveProperty('format');
+    expect(record.architecture).toHaveProperty('parameter_count_label');
+    expect(record.architecture).toHaveProperty('active_parameter_label');
     expect(record.architecture.format).toBe('MLX');
     expect(record.identity).toHaveProperty('quantized_provider');
     expect(record.identity.quantized_provider).toBe('lmstudio-community');

--- a/backend/tests/unit/model-name-parser.test.ts
+++ b/backend/tests/unit/model-name-parser.test.ts
@@ -6,11 +6,30 @@ describe('guessModelCharacteristics', () => {
   it('extracts params, quantisation, and provider from an MLX name', () => {
     const result = guessModelCharacteristics('/inferencerlabs/Devstral-Small-2-24B-Instruct-2512-MLX-6.5bit');
     expect(result.provider).toBe('mistral');
+    expect(result.quantized_provider).toBe('inferencerlabs');
     expect(result.parameter_count).toBe(24_000_000_000);
     expect(result.parameter_count_label).toBe('24B');
+    expect(result.active_parameter_label).toBeNull();
+    expect(result.format).toBe('MLX');
     expect(result.quantisation.method).toBe('mlx');
     expect(result.quantisation.bits).toBe(6.5);
+    expect(result.use_case.instruct).toBe(true);
+    expect(result.use_case.coding).toBe(true);
     expect(result.precision).toBeNull();
+  });
+
+  it('extracts Qwen3 Coder MoE metadata from provider-prefixed MLX names', () => {
+    const result = guessModelCharacteristics('inferencerlabs/Qwen3-Coder-30B-A3B-Instruct-MLX-6.5bit');
+    expect(result.quantized_provider).toBe('inferencerlabs');
+    expect(result.parameter_count).toBe(30_000_000_000);
+    expect(result.parameter_count_label).toBe('30B');
+    expect(result.active_parameter_label).toBe('A3B');
+    expect(result.format).toBe('MLX');
+    expect(result.quantisation.method).toBe('mlx');
+    expect(result.quantisation.bits).toBe(6.5);
+    expect(result.use_case.instruct).toBe(true);
+    expect(result.use_case.coding).toBe(true);
+    expect(result.use_case.mixture_of_experts).toBe(true);
   });
 
   it('extracts meta and precision hints', () => {
@@ -36,22 +55,28 @@ describe('guessModelCharacteristics', () => {
 describe('extractBaseModelName', () => {
   it('strips leading /prefix/ and trailing format+bit tokens', () => {
     expect(extractBaseModelName('/lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-6bit')).toBe(
-      'Qwen3-Coder-30B-A3B-Instruct'
+      'Qwen3-Coder'
     );
   });
 
   it('strips leading /prefix/ and trailing MLX, decimal-bit, and revision tokens', () => {
     expect(extractBaseModelName('/inferencerlabs/Devstral-Small-2-24B-Instruct-2512-MLX-6.5bit')).toBe(
-      'Devstral-Small-2-24B-Instruct'
+      'Devstral-Small-2'
     );
   });
 
   it('strips org/ prefix without leading slash and trailing precision label', () => {
-    expect(extractBaseModelName('meta-llama/Llama-3.1-8B-Instruct-fp16')).toBe('Llama-3.1-8B-Instruct');
+    expect(extractBaseModelName('meta-llama/Llama-3.1-8B-Instruct-fp16')).toBe('Llama-3.1');
   });
 
   it('strips trailing AWQ token with no prefix', () => {
-    expect(extractBaseModelName('Qwen2.5-72B-AWQ')).toBe('Qwen2.5-72B');
+    expect(extractBaseModelName('Qwen2.5-72B-AWQ')).toBe('Qwen2.5');
+  });
+
+  it('strips compound GGUF quantization suffixes', () => {
+    expect(extractBaseModelName('/inferencerlabs/Devstral-Small-24B-Instruct-GGUF-Q4_K_M')).toBe(
+      'Devstral-Small'
+    );
   });
 
   it('returns the model name unchanged when there are no strippable tokens', () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Navigate, Route, Routes, useLocation, useSearchParams } from 'react-router-dom';
 
-import packageInfo from '../package.json';
+import packageInfo from '../package.json' with { type: 'json' };
 import { Sidebar } from './components/Sidebar.js';
 import { Catalog } from './pages/Catalog.js';
 import { Evaluate } from './pages/Evaluate.js';

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -82,8 +82,8 @@ export function Sidebar({ version, health, templateCount, runCount, onSettings }
           >
             <span className="sidebar-item__main">
               <span>{item.label}</span>
-              {item.badge === 'templates' && templateCount !== null ? <b>{templateCount}</b> : null}
-              {item.badge === 'runs' && runCount !== null ? <b>{runCount}</b> : null}
+              {'badge' in item && item.badge === 'templates' && templateCount !== null ? <b>{templateCount}</b> : null}
+              {'badge' in item && item.badge === 'runs' && runCount !== null ? <b>{runCount}</b> : null}
             </span>
             <span className="sidebar-item__sub">{item.sub}</span>
           </NavLink>

--- a/frontend/src/pages/Catalog.tsx
+++ b/frontend/src/pages/Catalog.tsx
@@ -20,7 +20,6 @@ import {
   updateInferenceServer
 } from '../services/inference-servers-api.js';
 import { ModelFormat, ModelRecord, listModels } from '../services/models-api.js';
-import { extractBaseModelName, inferModelMetadata } from '../services/model-metadata-inference.js';
 import { DEFAULT_INFERENCE_PARAMS, type InferenceParams } from '../services/inference-param-presets-api.js';
 import { ModelDetails } from './ModelDetails.js';
 
@@ -69,9 +68,7 @@ function formatProvider(provider: string): string {
 }
 
 function modelLabel(record: ModelRecord | undefined, modelId: string, displayName: string): string {
-  return record?.model.base_model_name?.trim()
-    ? extractBaseModelName(record.model.base_model_name) ?? record.model.base_model_name
-    : inferModelMetadata(modelId, displayName).baseModelName ?? extractBaseModelName(displayName) ?? displayName;
+  return record?.model.base_model_name?.trim() ?? record?.model.display_name?.trim() ?? (displayName || modelId);
 }
 
 function statusFor(server: InferenceServerRecord, health?: InferenceServerHealth): ServerStatus {
@@ -130,14 +127,12 @@ function buildCatalogModels(servers: InferenceServerRecord[], modelRecords: Mode
   const entries = new Map<string, CatalogModel>();
   const put = (server: InferenceServerRecord, modelId: string, displayName: string, context: number | null, quantLabel?: string | null) => {
     const record = recordMap.get(`${server.inference_server.server_id}:${modelId}`);
-    const inferred = inferModelMetadata(modelId, displayName);
     const label = modelLabel(record, modelId, displayName);
-    const format = record?.architecture.format ?? inferred.format ?? 'Unknown';
+    const format = record?.architecture.format ?? 'Unknown';
     const quantization =
       record?.architecture.quantisation.weight_format
-      ?? quantLabel
       ?? (record?.architecture.quantisation.bits ? `${record.architecture.quantisation.bits}-bit` : null)
-      ?? (inferred.quantisation.bits ? `${inferred.quantisation.bits}-bit` : null)
+      ?? (record ? quantLabel : null)
       ?? 'Unknown';
     const key = `${server.inference_server.server_id}:${modelId}`;
     entries.set(key, {
@@ -147,7 +142,7 @@ function buildCatalogModels(servers: InferenceServerRecord[], modelRecords: Mode
       serverUrl: server.endpoints.base_url,
       modelId,
       displayName: label,
-      family: formatProvider(record?.identity.provider ?? inferred.provider),
+      family: formatProvider(record?.identity.provider ?? 'unknown'),
       quantization,
       format,
       context: (record?.limits.context_window_tokens ?? context) ? `${record?.limits.context_window_tokens ?? context} ctx` : 'ctx unknown',

--- a/frontend/src/pages/Models.tsx
+++ b/frontend/src/pages/Models.tsx
@@ -12,7 +12,6 @@ import {
   listModels,
   updateModel
 } from '../services/models-api.js';
-import { extractBaseModelName, inferModelMetadata } from '../services/model-metadata-inference.js';
 
 type ModelServerInfo = {
   server_id: string;
@@ -32,11 +31,7 @@ type ModelAggregate = {
 
 function modelLabel(modelId: string, displayName: string, record?: ModelRecord): string {
   const storedBaseName = record?.model.base_model_name?.trim();
-  const normalizedStoredBaseName = storedBaseName ? extractBaseModelName(storedBaseName) : null;
-  return normalizedStoredBaseName
-    ?? inferModelMetadata(modelId, displayName).baseModelName
-    ?? extractBaseModelName(displayName)
-    ?? displayName;
+  return storedBaseName ?? record?.model.display_name?.trim() ?? (displayName || modelId);
 }
 
 function canonicalModelKey(modelId: string, displayName: string, record?: ModelRecord): string {
@@ -77,65 +72,6 @@ function mergeModelAggregate(target: ModelAggregate, source: ModelAggregate): vo
       target.servers.push(server);
     }
   }
-}
-
-function inferredMetadataCandidates(model: ModelAggregate) {
-  return model.model_ids.map((modelId) => inferModelMetadata(modelId, model.display_name));
-}
-
-function firstInferred<T>(model: ModelAggregate, selector: (metadata: ReturnType<typeof inferModelMetadata>) => T | null | undefined): T | null {
-  for (const metadata of inferredMetadataCandidates(model)) {
-    const value = selector(metadata);
-    if (value !== null && value !== undefined && value !== '') {
-      return value;
-    }
-  }
-  return null;
-}
-
-function bestInferredMetadata(model: ModelAggregate) {
-  const candidates = inferredMetadataCandidates(model);
-  return candidates.find((metadata) => metadata.quantizedProvider || metadata.format || metadata.quantisation.bits != null)
-    ?? candidates[0]
-    ?? inferModelMetadata(model.model_id, model.display_name);
-}
-
-function inferProviderKey(model: ModelAggregate): ModelProvider {
-  const raw = `${model.model_id} ${model.display_name}`.toLowerCase();
-  if (raw.includes('mistral') || raw.includes('mixtral')) {
-    return 'mistral';
-  }
-  if (raw.includes('qwen')) {
-    return 'qwen';
-  }
-  if (raw.includes('gemini') || raw.includes('google') || raw.includes('palm') || raw.includes('gemma')) {
-    return 'google';
-  }
-  if (raw.includes('moonshot') || /\bkimi\b/i.test(raw)) {
-    return 'moonshot';
-  }
-  if (raw.includes('gpt') || raw.includes('openai')) {
-    return 'openai';
-  }
-  if (raw.includes('claude') || raw.includes('anthropic')) {
-    return 'anthropic';
-  }
-  if (raw.includes('llama') || raw.includes('meta')) {
-    return 'meta';
-  }
-  if (raw.includes('cohere') || raw.includes('command')) {
-    return 'cohere';
-  }
-  if (raw.includes('deepseek')) {
-    return 'deepseek';
-  }
-  if (raw.includes('nvidia') || raw.includes('nemotron')) {
-    return 'nvidia';
-  }
-  if (raw.includes('zai') || raw.includes('01.ai') || raw.includes('01ai') || raw.includes('yi')) {
-    return 'zai';
-  }
-  return 'custom';
 }
 
 function formatProviderLabel(provider: ModelProvider): string {
@@ -358,16 +294,8 @@ export function Models({ onModelSelect }: ModelsProps = {}) {
         set.add(record.identity.quantized_provider);
       }
     }
-    for (const server of servers) {
-      for (const model of server.discovery.model_list.normalised) {
-        const inferred = inferModelMetadata(model.model_id, model.display_name ?? model.model_id);
-        if (inferred.quantizedProvider) {
-          set.add(inferred.quantizedProvider);
-        }
-      }
-    }
     return Array.from(set).sort();
-  }, [modelRecords, servers]);
+  }, [modelRecords]);
 
   const formats = useMemo(() => {
     const set = new Set<ModelFormat>();
@@ -376,16 +304,8 @@ export function Models({ onModelSelect }: ModelsProps = {}) {
         set.add(record.architecture.format);
       }
     }
-    for (const server of servers) {
-      for (const model of server.discovery.model_list.normalised) {
-        const inferred = inferModelMetadata(model.model_id, model.display_name ?? model.model_id);
-        if (inferred.format) {
-          set.add(inferred.format);
-        }
-      }
-    }
     return Array.from(set).sort();
-  }, [modelRecords, servers]);
+  }, [modelRecords]);
 
   const quantisationBits = useMemo(() => {
     const set = new Set<number>();
@@ -394,16 +314,8 @@ export function Models({ onModelSelect }: ModelsProps = {}) {
         set.add(record.architecture.quantisation.bits);
       }
     }
-    for (const server of servers) {
-      for (const model of server.discovery.model_list.normalised) {
-        const inferred = inferModelMetadata(model.model_id, model.display_name ?? model.model_id);
-        if (inferred.quantisation.bits != null) {
-          set.add(inferred.quantisation.bits);
-        }
-      }
-    }
     return Array.from(set).sort((a, b) => a - b);
-  }, [modelRecords, servers]);
+  }, [modelRecords]);
 
   const models = useMemo<ModelAggregate[]>(() => {
     const map = new Map<string, ModelAggregate>();
@@ -488,12 +400,8 @@ export function Models({ onModelSelect }: ModelsProps = {}) {
     for (const provider of providerByModelId.values()) {
       bucket.add(provider);
     }
-    for (const model of models) {
-      const inferred = inferModelMetadata(model.model_id, model.display_name).provider;
-      bucket.add(providerByModelId.get(model.model_id) ?? (inferred === 'unknown' ? inferProviderKey(model) : inferred));
-    }
     return Array.from(bucket).sort((a, b) => a.localeCompare(b));
-  }, [models, providerByModelId]);
+  }, [providerByModelId]);
 
   const filteredModels = useMemo(() => {
     return models.filter((model) => {
@@ -510,9 +418,7 @@ export function Models({ onModelSelect }: ModelsProps = {}) {
             : undefined;
         const providerKey =
           providerByModelId.get(model.model_id)
-          ?? (recordProvider && recordProvider !== 'unknown' ? recordProvider : undefined)
-          ?? firstInferred(model, (metadata) => metadata.provider !== 'unknown' ? metadata.provider : null)
-          ?? inferProviderKey(model);
+          ?? (recordProvider && recordProvider !== 'unknown' ? recordProvider : undefined);
         if (providerKey !== selectedProvider) {
           return false;
         }
@@ -523,8 +429,7 @@ export function Models({ onModelSelect }: ModelsProps = {}) {
           selectedServerId !== 'all'
             ? (modelRecordMap.get(`${selectedServerId}:${model.model_id}`) ?? modelRecordByModelId.get(model.model_id))
             : modelRecordByModelId.get(model.model_id);
-        const quantizedProvider = record?.identity.quantized_provider
-          ?? firstInferred(model, (metadata) => metadata.quantizedProvider);
+        const quantizedProvider = record?.identity.quantized_provider;
         if (quantizedProvider !== selectedQuantizedProvider) {
           return false;
         }
@@ -535,7 +440,7 @@ export function Models({ onModelSelect }: ModelsProps = {}) {
           selectedServerId !== 'all'
             ? (modelRecordMap.get(`${selectedServerId}:${model.model_id}`) ?? modelRecordByModelId.get(model.model_id))
             : modelRecordByModelId.get(model.model_id);
-        const format = record?.architecture.format ?? firstInferred(model, (metadata) => metadata.format);
+        const format = record?.architecture.format;
         if (format !== selectedFormat) {
           return false;
         }
@@ -546,8 +451,7 @@ export function Models({ onModelSelect }: ModelsProps = {}) {
           selectedServerId !== 'all'
             ? (modelRecordMap.get(`${selectedServerId}:${model.model_id}`) ?? modelRecordByModelId.get(model.model_id))
             : modelRecordByModelId.get(model.model_id);
-        const bits = record?.architecture.quantisation.bits
-          ?? firstInferred(model, (metadata) => metadata.quantisation.bits);
+        const bits = record?.architecture.quantisation.bits;
         if (bits == null || bits.toString() !== selectedQuantBits) {
           return false;
         }
@@ -559,7 +463,7 @@ export function Models({ onModelSelect }: ModelsProps = {}) {
             ? (modelRecordMap.get(`${selectedServerId}:${model.model_id}`) ?? modelRecordByModelId.get(model.model_id))
             : modelRecordByModelId.get(model.model_id);
         for (const cap of selectedCapabilities) {
-          if (!(record?.capabilities.use_case[cap] ?? firstInferred(model, (metadata) => metadata.useCase[cap]))) {
+          if (!record?.capabilities.use_case[cap]) {
             return false;
           }
         }
@@ -631,9 +535,6 @@ export function Models({ onModelSelect }: ModelsProps = {}) {
     selectedModel && effectiveServerId !== 'all'
       ? modelRecordMap.get(`${effectiveServerId}:${selectedModel.model_id}`) ?? null
       : null;
-  const selectedInferred = selectedModel
-    ? bestInferredMetadata(selectedModel)
-    : null;
   const contextLabel = selectedModel?.context_windows.length
     ? selectedModel.context_windows.sort((a, b) => a - b).join(', ')
     : 'N/A';
@@ -641,17 +542,11 @@ export function Models({ onModelSelect }: ModelsProps = {}) {
     ? selectedModel.quantisations.join(', ')
     : 'N/A';
   const providerLabel = selectedModel
-    ? formatProviderLabel(providerByModelId.get(selectedModel.model_id) ?? selectedInferred?.provider ?? inferProviderKey(selectedModel))
+    ? formatProviderLabel(providerByModelId.get(selectedModel.model_id) ?? selectedRecord?.identity.provider ?? 'unknown')
     : 'Unknown';
   const quantisationLabel = selectedRecord
     ? formatQuantisation(selectedRecord.architecture.quantisation)
-    : selectedInferred
-      ? formatQuantisation({
-          method: selectedInferred.quantisation.method,
-          bits: selectedInferred.quantisation.bits,
-          group_size: null,
-        })
-      : quantLabel;
+    : quantLabel;
   const discoveryQuantisation =
     selectedModel && effectiveServerId !== 'all'
       ? servers
@@ -668,15 +563,6 @@ export function Models({ onModelSelect }: ModelsProps = {}) {
         `variant: ${selectedRecord.architecture.quantisation.variant ?? 'none'}`,
         `weight: ${selectedRecord.architecture.quantisation.weight_format ?? 'none'}`
       ]
-    : selectedInferred
-      ? [
-          `method: ${selectedInferred.quantisation.method}`,
-          `bits: ${selectedInferred.quantisation.bits ?? 'none'}`,
-          'group: none',
-          'scheme: none',
-          'variant: none',
-          'weight: none'
-        ]
     : discoveryQuantisation && typeof discoveryQuantisation !== 'string'
       ? [
           `method: ${discoveryQuantisation.method ?? 'unknown'}`,
@@ -702,14 +588,7 @@ export function Models({ onModelSelect }: ModelsProps = {}) {
         `instruct: ${selectedRecord.capabilities.use_case.instruct ? 'yes' : 'none'}`,
         `mixture of experts: ${selectedRecord.capabilities.use_case.mixture_of_experts ? 'yes' : 'none'}`
       ]
-    : selectedInferred
-      ? [
-          `thinking: ${selectedInferred.useCase.thinking ? 'yes' : 'none'}`,
-          `coding: ${selectedInferred.useCase.coding ? 'yes' : 'none'}`,
-          `instruct: ${selectedInferred.useCase.instruct ? 'yes' : 'none'}`,
-          `mixture of experts: ${selectedInferred.useCase.mixture_of_experts ? 'yes' : 'none'}`
-        ]
-      : null;
+    : null;
   const capabilityMultimodalLabel = selectedRecord
     ? [
         `vision: ${selectedRecord.capabilities.multimodal.vision ? 'yes' : 'none'}`,
@@ -730,12 +609,11 @@ export function Models({ onModelSelect }: ModelsProps = {}) {
       return;
     }
     const record = selectedRecord;
-    const inferred = bestInferredMetadata(selectedModel);
-    const provider = providerByModelId.get(selectedModel.model_id) ?? inferred.provider ?? inferProviderKey(selectedModel);
+    const provider = providerByModelId.get(selectedModel.model_id) ?? record?.identity.provider ?? 'unknown';
     setUpdateForm({
       provider,
-      quantMethod: record?.architecture.quantisation.method ?? inferred.quantisation.method,
-      quantBits: record?.architecture.quantisation.bits?.toString() ?? inferred.quantisation.bits?.toString() ?? '',
+      quantMethod: record?.architecture.quantisation.method ?? 'unknown',
+      quantBits: record?.architecture.quantisation.bits?.toString() ?? '',
       quantGroupSize: record?.architecture.quantisation.group_size?.toString() ?? '',
       quantScheme: record?.architecture.quantisation.scheme ?? 'unknown',
       quantVariant: record?.architecture.quantisation.variant ?? '',
@@ -749,12 +627,12 @@ export function Models({ onModelSelect }: ModelsProps = {}) {
       capAudio: record?.capabilities.multimodal.audio ?? false,
       capReasoning: record?.capabilities.reasoning.supported ?? false,
       capExplicit: record?.capabilities.reasoning.explicit_tokens ?? false,
-      quantizedProvider: record?.identity.quantized_provider ?? inferred.quantizedProvider ?? '',
-      capThinking: record?.capabilities.use_case.thinking ?? inferred.useCase.thinking,
-      capCoding: record?.capabilities.use_case.coding ?? inferred.useCase.coding,
-      capInstruct: record?.capabilities.use_case.instruct ?? inferred.useCase.instruct,
-      capMoe: record?.capabilities.use_case.mixture_of_experts ?? inferred.useCase.mixture_of_experts,
-      format: record?.architecture.format ?? inferred.format ?? ''
+      quantizedProvider: record?.identity.quantized_provider ?? '',
+      capThinking: record?.capabilities.use_case.thinking ?? false,
+      capCoding: record?.capabilities.use_case.coding ?? false,
+      capInstruct: record?.capabilities.use_case.instruct ?? false,
+      capMoe: record?.capabilities.use_case.mixture_of_experts ?? false,
+      format: record?.architecture.format ?? ''
     });
     setUpdateError(null);
     setShowUpdateModal(true);
@@ -982,9 +860,7 @@ export function Models({ onModelSelect }: ModelsProps = {}) {
             ) : (
               visibleModels.map((model) => (
                 <option key={model.model_id} value={model.model_id}>
-                  {modelDisplayMap.get(model.model_id)
-                    ?? inferModelMetadata(model.model_id, model.display_name).baseModelName
-                    ?? model.display_name}
+                  {modelDisplayMap.get(model.model_id) ?? model.display_name}
                 </option>
               ))
             )}
@@ -1011,11 +887,11 @@ export function Models({ onModelSelect }: ModelsProps = {}) {
                 </div>
                 <div className="detail-row">
                   <span>Quantized provider</span>
-                  <strong>{selectedRecord?.identity.quantized_provider ?? selectedInferred?.quantizedProvider ?? 'N/A'}</strong>
+                  <strong>{selectedRecord?.identity.quantized_provider ?? 'N/A'}</strong>
                 </div>
                 <div className="detail-row">
                   <span>Format</span>
-                  <strong>{selectedRecord?.architecture.format ?? selectedInferred?.format ?? 'N/A'}</strong>
+                  <strong>{selectedRecord?.architecture.format ?? 'N/A'}</strong>
                 </div>
                 <div className="detail-row">
                   <span>Display name</span>

--- a/frontend/src/services/models-api.ts
+++ b/frontend/src/services/models-api.ts
@@ -41,6 +41,8 @@ export interface ModelRecord {
   architecture: {
     type: string;
     parameter_count: number | null;
+    parameter_count_label: string | null;
+    active_parameter_label: string | null;
     precision: string;
     quantisation: {
       method: ModelQuantisationMethod;

--- a/frontend/src/styles/dashboard-results.css
+++ b/frontend/src/styles/dashboard-results.css
@@ -572,9 +572,12 @@
 }
 
 .results-drawer {
-  width: min(640px, 100vw);
+  box-sizing: border-box;
+  width: min(100vw, clamp(640px, 72vw, 1040px));
+  max-width: 100vw;
   height: 100vh;
-  overflow: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
   background: var(--paper-1);
   box-shadow: -12px 0 30px rgba(0, 0, 0, 0.18);
 }
@@ -602,6 +605,7 @@
   margin: 0;
   font-family: var(--font-mono);
   font-size: 16px;
+  overflow-wrap: anywhere;
 }
 
 .results-drawer__header p {
@@ -613,7 +617,13 @@
 .results-drawer__body {
   display: grid;
   gap: 14px;
+  min-width: 0;
   padding: 18px;
+}
+
+.results-drawer__body > section,
+.results-kv {
+  min-width: 0;
 }
 
 .results-kv {
@@ -624,6 +634,7 @@
 
 .results-kv div,
 .results-detail-block {
+  min-width: 0;
   padding: 10px;
   border: 1px solid var(--paper-7);
   border-radius: 8px;
@@ -638,8 +649,13 @@
 }
 
 .results-drawer pre {
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
   max-height: 320px;
   overflow: auto;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
   padding: 12px;
   border-radius: 8px;
   background: var(--ink-9);

--- a/frontend/tests/e2e/architecture-inspect.spec.ts
+++ b/frontend/tests/e2e/architecture-inspect.spec.ts
@@ -102,6 +102,15 @@ function make1000NodeTree(modelId: string) {
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
+function displayNameForModelId(modelId: string): string {
+  return modelId
+    .replace(/^\/+/, '')
+    .split('/')
+    .filter(Boolean)
+    .pop()
+    ?.replace(/-/g, ' ') ?? modelId;
+}
+
 async function seedHfModel(
   request: import('@playwright/test').APIRequestContext,
   serverId: string,
@@ -125,10 +134,30 @@ async function seedHfModel(
   return response.json();
 }
 
-async function navigateToModelDetail(page: import('@playwright/test').Page, serverId: string, modelId: string) {
+async function catalogLabelForModel(
+  request: import('@playwright/test').APIRequestContext,
+  serverId: string,
+  modelId: string
+) {
+  const response = await request.get(`${API_BASE_URL}/models/${serverId}/${encodeURIComponent(modelId)}`, {
+    headers: authHeaders
+  });
+  if (!response.ok()) {
+    return displayNameForModelId(modelId);
+  }
+  const record = await response.json();
+  return record.model.base_model_name?.trim() || record.model.display_name?.trim() || displayNameForModelId(modelId);
+}
+
+async function navigateToModelDetail(
+  page: import('@playwright/test').Page,
+  request: import('@playwright/test').APIRequestContext,
+  serverId: string,
+  modelId: string
+) {
   await page.goto(`/catalog?tab=models&servers=${encodeURIComponent(serverId)}`);
   await page.waitForLoadState('networkidle');
-  const expectedModelText = modelId.replace(/^\/+/, '').split('/').filter(Boolean).pop() ?? modelId;
+  const expectedModelText = await catalogLabelForModel(request, serverId, modelId);
   const card = page.locator('.catalog-model-card').filter({ hasText: expectedModelText });
   await expect(card).toBeVisible();
   await card.getByRole('button', { name: 'Inspect' }).click();
@@ -157,7 +186,7 @@ test.describe('Architecture Inspection — US1 + US2 + US3', () => {
       }
     });
 
-    await navigateToModelDetail(page, serverId, MODEL_ID);
+    await navigateToModelDetail(page, request, serverId, MODEL_ID);
 
     // Inspect Architecture button should be visible for HF-style model
     await expect(page.getByRole('button', { name: 'Inspect Architecture' })).toBeVisible();
@@ -239,7 +268,7 @@ test.describe('Architecture Inspection — US1 + US2 + US3', () => {
       }
     });
 
-    await navigateToModelDetail(page, serverId, bigModelId);
+    await navigateToModelDetail(page, request, serverId, bigModelId);
     await page.getByRole('button', { name: 'Inspect Architecture' }).click();
     await expect(page.locator('.arch-node-row').first()).toBeVisible();
 
@@ -268,7 +297,7 @@ test.describe('Architecture Inspection — US1 + US2 + US3', () => {
       }
     });
 
-    await navigateToModelDetail(page, serverId, MODEL_ID);
+    await navigateToModelDetail(page, request, serverId, MODEL_ID);
     await page.getByRole('button', { name: 'Inspect Architecture' }).click();
     await expect(page.locator('.arch-node-row').first()).toBeVisible();
 
@@ -320,7 +349,7 @@ test.describe('Architecture Inspection — US1 + US2 + US3', () => {
       headers: authHeaders,
     });
 
-    await navigateToModelDetail(page, serverId, 'plain-local-model');
+    await navigateToModelDetail(page, request, serverId, 'plain-local-model');
 
     // Button should NOT be rendered at all
     await expect(page.getByRole('button', { name: 'Inspect Architecture' })).toHaveCount(0);
@@ -345,7 +374,7 @@ test.describe('Architecture Inspection — US1 + US2 + US3', () => {
       }
     });
 
-    await navigateToModelDetail(page, serverId, MODEL_ID);
+    await navigateToModelDetail(page, request, serverId, MODEL_ID);
     await page.getByRole('button', { name: 'Inspect Architecture' }).click();
 
     await expect(page.locator('.error')).toContainText('Hugging Face API token');

--- a/frontend/tests/e2e/compare.spec.ts
+++ b/frontend/tests/e2e/compare.spec.ts
@@ -3,6 +3,6 @@ import { expect, test } from '@playwright/test';
 test('loads comparison page', async ({ page }) => {
   await page.goto('/run?legacy=compare');
 
-  await expect(page.getByRole('heading', { name: 'Run', exact: true })).toBeVisible();
+  await expect(page.locator('.merged-page-header').getByRole('heading', { name: 'Run', exact: true })).toBeVisible();
   await expect(page.getByRole('heading', { name: 'Pick model(s) to run' })).toBeVisible();
 });

--- a/frontend/tests/e2e/inference-servers-create.spec.ts
+++ b/frontend/tests/e2e/inference-servers-create.spec.ts
@@ -1,9 +1,10 @@
 import { expect, test } from '@playwright/test';
+import crypto from 'node:crypto';
 
 import { archiveInferenceServer, findInferenceServerByName } from './helpers.js';
 
 test('creates a new inference server from the dashboard', async ({ page, request }) => {
-  const displayName = `E2E Server ${Date.now()}`;
+  const displayName = `E2E Server ${Date.now()}-${crypto.randomBytes(4).toString('hex')}`;
   const baseUrl = 'http://localhost:8080';
 
   await page.goto('/');

--- a/frontend/tests/e2e/leaderboard.spec.ts
+++ b/frontend/tests/e2e/leaderboard.spec.ts
@@ -63,6 +63,19 @@ async function getOrCreateServer(request: APIRequestContext): Promise<string> {
   return server.inference_server.server_id;
 }
 
+async function clearResultsRailState(page: import('@playwright/test').Page) {
+  await page.addInitScript(() => {
+    window.localStorage.removeItem('results.funnelCollapsedStages');
+  });
+}
+
+function leaderboardUrl(filters?: { serverId?: string; modelName?: string }) {
+  const params = new URLSearchParams({ tab: 'leaderboard' });
+  if (filters?.serverId) params.set('server', filters.serverId);
+  if (filters?.modelName) params.set('model', filters.modelName);
+  return `/results?${params.toString()}`;
+}
+
 test.describe('Leaderboard page — empty state', () => {
   test('renders the merged Results leaderboard tab and shared filter rail when no evaluations match', async ({ page }) => {
     await page.goto('/results?tab=leaderboard');
@@ -118,11 +131,13 @@ test.describe('Leaderboard filters', () => {
     const modelName = `e2e-filter-rail-${Date.now()}`;
     await seedEvaluation(request, { serverId, modelName });
 
-    await page.goto('/results?tab=leaderboard');
+    await clearResultsRailState(page);
+    await page.goto(leaderboardUrl({ serverId, modelName }));
     await expect(page.locator('.results-leader-row').filter({ hasText: modelName })).toBeVisible();
 
-    await page.getByLabel('From').fill('2030-01-01T00:00');
-    await page.getByLabel('To').fill('2030-12-31T23:59');
+    const filterRail = page.locator('[aria-label="Results filters"]');
+    await filterRail.getByLabel('From').fill('2030-01-01T00:00');
+    await filterRail.getByLabel('To').fill('2030-12-31T23:59');
     await expect(page.getByText('No evaluations match the selected filters.')).toBeVisible({ timeout: 3000 });
   });
 
@@ -131,10 +146,12 @@ test.describe('Leaderboard filters', () => {
     const modelName = `e2e-filter-clear-${Date.now()}`;
     await seedEvaluation(request, { serverId, modelName });
 
-    await page.goto('/results?tab=leaderboard');
+    await clearResultsRailState(page);
+    await page.goto(leaderboardUrl({ serverId, modelName }));
 
-    await page.getByLabel('From').fill('2030-01-01T00:00');
-    await page.getByLabel('To').fill('2030-12-31T23:59');
+    const filterRail = page.locator('[aria-label="Results filters"]');
+    await filterRail.getByLabel('From').fill('2030-01-01T00:00');
+    await filterRail.getByLabel('To').fill('2030-12-31T23:59');
     await expect(page.getByText('No evaluations match the selected filters.')).toBeVisible();
 
     const t0 = Date.now();

--- a/frontend/tests/e2e/models.spec.ts
+++ b/frontend/tests/e2e/models.spec.ts
@@ -38,6 +38,7 @@ async function seedModel(
         server_id: serverId,
         model_id: opts.model_id,
         display_name: opts.display_name,
+        base_model_name: opts.display_name,
         active: true,
         archived: false
       },
@@ -75,7 +76,7 @@ test('models tab requires a selected server before showing model cards', async (
   await expect(page.getByRole('heading', { name: 'Select a server to see its models' })).toBeVisible();
 
   await page.locator('.server-filter-row').filter({ hasText: server.inference_server.display_name }).click();
-  await expect(page.locator('.catalog-model-card').filter({ hasText: 'Qwen3-Coder-30B-A3B-Instruct' })).toBeVisible();
+  await expect(page.locator('.catalog-model-card').filter({ hasText: 'Qwen3 Coder' })).toBeVisible();
 
   await archiveInferenceServer(request, server.inference_server.server_id);
 });
@@ -98,10 +99,33 @@ test('model filter rail narrows visible model cards', async ({ page, request }) 
   await page.waitForLoadState('networkidle');
 
   await page.getByLabel('MLX').check();
-  await expect(page.locator('.catalog-model-card').filter({ hasText: 'Qwen3-Coder' })).toBeVisible();
+  await expect(page.locator('.catalog-model-card').filter({ hasText: 'Qwen3 Coder' })).toBeVisible();
   await expect(page.locator('.catalog-model-card').filter({ hasText: 'Devstral' })).toHaveCount(0);
 
   await expect(page).toHaveURL(/format=MLX/);
+  await archiveInferenceServer(request, serverId);
+});
+
+test('model filter rail uses persisted metadata instead of inferring from model IDs', async ({ page, request }) => {
+  const server = await createInferenceServer(request);
+  const serverId = server.inference_server.server_id;
+  await seedModel(request, serverId, {
+    model_id: '/lmstudio-community/Raw-Name-MLX-6bit',
+    display_name: 'Raw MLX Suffix'
+  });
+  await seedModel(request, serverId, {
+    model_id: 'persisted-mlx',
+    display_name: 'Persisted MLX',
+    format: 'MLX'
+  });
+
+  await page.goto(`/catalog?tab=models&servers=${encodeURIComponent(serverId)}`);
+  await page.waitForLoadState('networkidle');
+
+  await page.getByLabel('MLX').check();
+  await expect(page.locator('.catalog-model-card').filter({ hasText: 'Persisted MLX' })).toBeVisible();
+  await expect(page.locator('.catalog-model-card').filter({ hasText: 'Raw MLX Suffix' })).toHaveCount(0);
+
   await archiveInferenceServer(request, serverId);
 });
 
@@ -116,7 +140,7 @@ test('Inspect opens the catalog model inspector for the selected server/model', 
 
   await page.goto(`/catalog?tab=models&servers=${encodeURIComponent(serverId)}`);
   await page.waitForLoadState('networkidle');
-  await page.locator('.catalog-model-card').filter({ hasText: 'Llama-3.1-8B' }).getByRole('button', { name: 'Inspect' }).click();
+  await page.locator('.catalog-model-card').filter({ hasText: 'Llama 3.1 8B' }).getByRole('button', { name: 'Inspect' }).click();
 
   await expect(page).toHaveURL(new RegExp(`serverId=${serverId}`));
   await expect(page).toHaveURL(/modelId=meta-llama/);

--- a/frontend/tests/e2e/navigation-shell.spec.ts
+++ b/frontend/tests/e2e/navigation-shell.spec.ts
@@ -41,6 +41,52 @@ function catalogServer(serverId: string, name: string, modelId: string) {
   };
 }
 
+function catalogModel(serverId: string, modelId: string, provider: string, format: string) {
+  return {
+    model: {
+      server_id: serverId,
+      model_id: modelId,
+      display_name: modelId,
+      active: true,
+      archived: false,
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+      archived_at: null,
+      base_model_name: modelId
+    },
+    identity: {
+      provider,
+      family: null,
+      version: null,
+      revision: null,
+      checksum: null,
+      quantized_provider: null
+    },
+    architecture: {
+      type: 'unknown',
+      parameter_count: null,
+      parameter_count_label: null,
+      active_parameter_label: null,
+      precision: 'unknown',
+      quantisation: { method: 'mlx', bits: null, group_size: null, weight_format: 'MLX' },
+      format
+    },
+    capabilities: {
+      generation: { text: true, json_schema_output: false, tools: false, embeddings: false },
+      multimodal: { vision: false, audio: false },
+      reasoning: { supported: false, explicit_tokens: false },
+      use_case: { thinking: false, coding: false, instruct: false, mixture_of_experts: false }
+    },
+    limits: {
+      context_window_tokens: 4096,
+      max_output_tokens: null,
+      max_images: null,
+      max_batch_size: null
+    },
+    raw: {}
+  };
+}
+
 test('sidebar exposes five top-level destinations and follows active routes', async ({ page }) => {
   await page.goto('/catalog?tab=servers');
 
@@ -112,6 +158,10 @@ test('catalog models funnel aligns staged rail controls', async ({ page }) => {
     catalogServer('srv-a', 'Inferencer', 'mistral:latest'),
     catalogServer('srv-b', 'InferencerPro', 'qwen:latest')
   ];
+  const models = [
+    catalogModel('srv-a', 'mistral:latest', 'mistral', 'MLX'),
+    catalogModel('srv-b', 'qwen:latest', 'qwen', 'MLX')
+  ];
   await page.addInitScript(() => {
     window.localStorage.removeItem('catalog.serverStageCollapsed');
     window.localStorage.removeItem('catalog.modelFilterStageCollapsed');
@@ -133,7 +183,7 @@ test('catalog models funnel aligns staged rail controls', async ({ page }) => {
     await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(servers) });
   });
   await page.route('**/models', async (route) => {
-    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) });
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(models) });
   });
 
   await page.goto('/catalog?tab=models');

--- a/frontend/tests/e2e/results-dashboard.spec.ts
+++ b/frontend/tests/e2e/results-dashboard.spec.ts
@@ -145,6 +145,10 @@ function resultsViewPayload(empty = false) {
 }
 
 test('merged Results dashboard filter and render flow', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 900 });
+
+  const longRawValue = `raw-payload-${'x'.repeat(3000)}`;
+
   await page.route('**/results-view/query', async (route) => {
     const payload = route.request().postDataJSON() as { date_from?: string };
     const isFutureRange = payload.date_from
@@ -170,10 +174,11 @@ test('merged Results dashboard filter and render flow', async ({ page }) => {
             test_id: 'latency-benchmark',
             template_label: 'latency-benchmark',
             verdict: 'pass',
-            metrics: { latency_ms: 80 }
+            metrics: { latency_ms: 80 },
+            raw_payload: longRawValue
           }
         ],
-        documents: [{ summary: { passed_steps: 1, failed_steps: 0 } }]
+        documents: [{ summary: { passed_steps: 1, failed_steps: 0 }, raw_payload: longRawValue }]
       })
     });
   });
@@ -274,6 +279,34 @@ test('merged Results dashboard filter and render flow', async ({ page }) => {
   await recentRun.click();
   await expect(page.getByText('Run detail')).toBeVisible();
   await expect(page.getByText('run-dashboard-1')).toBeVisible();
+  const drawerSizing = await page.evaluate(() => {
+    const drawer = document.querySelector<HTMLElement>('.results-drawer');
+    const detailBlock = document.querySelector<HTMLElement>('.results-detail-block');
+    const rawPre = detailBlock?.querySelector<HTMLElement>('pre');
+    const scrollingElement = document.scrollingElement;
+    if (!drawer || !detailBlock || !rawPre || !scrollingElement) {
+      return null;
+    }
+    return {
+      viewportWidth: window.innerWidth,
+      drawerWidth: drawer.getBoundingClientRect().width,
+      drawerClientWidth: drawer.clientWidth,
+      drawerScrollWidth: drawer.scrollWidth,
+      detailClientWidth: detailBlock.clientWidth,
+      detailScrollWidth: detailBlock.scrollWidth,
+      preClientWidth: rawPre.clientWidth,
+      preScrollWidth: rawPre.scrollWidth,
+      pageClientWidth: scrollingElement.clientWidth,
+      pageScrollWidth: scrollingElement.scrollWidth
+    };
+  });
+  expect(drawerSizing).not.toBeNull();
+  expect(drawerSizing!.drawerWidth).toBeGreaterThan(640);
+  expect(drawerSizing!.drawerWidth).toBeLessThanOrEqual(drawerSizing!.viewportWidth);
+  expect(drawerSizing!.drawerScrollWidth).toBeLessThanOrEqual(drawerSizing!.drawerClientWidth + 1);
+  expect(drawerSizing!.detailScrollWidth).toBeLessThanOrEqual(drawerSizing!.detailClientWidth + 1);
+  expect(drawerSizing!.preScrollWidth).toBeLessThanOrEqual(drawerSizing!.preClientWidth + 1);
+  expect(drawerSizing!.pageScrollWidth).toBeLessThanOrEqual(drawerSizing!.pageClientWidth + 1);
 
   await page.getByRole('button', { name: 'Close' }).click();
   await page.getByRole('button', { name: 'Reset filters' }).click();

--- a/frontend/tests/e2e/run-single-template-types.spec.ts
+++ b/frontend/tests/e2e/run-single-template-types.spec.ts
@@ -109,7 +109,7 @@ test('supports JSON and Python template types', async ({ page, request }) => {
     );
     await page.goto('/run');
     await serversResponse;
-    await expect(page.getByRole('heading', { name: 'Run', exact: true })).toBeVisible();
+    await expect(page.locator('.merged-page-header').getByRole('heading', { name: 'Run', exact: true })).toBeVisible();
 
     const inferenceServerSelect = page.getByRole('combobox', { name: 'Inference server', exact: true });
     await expect(inferenceServerSelect).toBeVisible();

--- a/frontend/tests/unit/evaluation-queue-api.test.ts
+++ b/frontend/tests/unit/evaluation-queue-api.test.ts
@@ -41,7 +41,7 @@ describe('evaluation queue score helpers', () => {
       json: async () => {
         throw new Error('204 responses do not have JSON bodies');
       }
-    } as Response);
+    } as unknown as Response);
     vi.stubGlobal('fetch', fetchMock);
 
     await expect(skipEvaluationQueueItem('queue-result-1')).resolves.toBeUndefined();


### PR DESCRIPTION
- upsert discovered models during inference-server refresh
- preserve manually edited model metadata on refresh
- store parameter and active MoE labels in model records
- make Catalog and Models read persisted metadata instead of inferring from IDs
- add parser, discovery, and frontend source-of-truth coverage