### PR TITLE
fix(frontend): align catalog server header actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 ### Changed
 
 - Catalog and Models metadata filters/details now use persisted `/models` records as their source of truth instead of inferring provider, format, quantized provider, or use cases from raw model IDs.
-- Catalog now places `+ Add server` in the Servers/Models sub-tab row and removes the visible Health/Grid header toggle while keeping the health view URL-compatible.
+- Catalog Servers now keeps `Filter`, `Archived`, and `+ Add server` in the section header, opens the filter rail only on demand, defaults to active servers, and starts server cards unselected with click-to-toggle detail rails.
 
 
 ## [0.4.0] - 2026-05-10

--- a/frontend/src/pages/Catalog.tsx
+++ b/frontend/src/pages/Catalog.tsx
@@ -17,6 +17,7 @@ import {
   deleteInferenceServer,
   listInferenceServers,
   refreshInferenceServerDiscovery,
+  unarchiveInferenceServer,
   updateInferenceServer
 } from '../services/inference-servers-api.js';
 import { ModelFormat, ModelRecord, listModels } from '../services/models-api.js';
@@ -201,6 +202,8 @@ export function Catalog({
   const [error, setError] = useState<string | null>(null);
   const [drawer, setDrawer] = useState<DrawerMode | null>(null);
   const [selectedDetailId, setSelectedDetailId] = useState<string | null>(null);
+  const [serverFiltersOpen, setServerFiltersOpen] = useState(false);
+  const [showArchivedOnly, setShowArchivedOnly] = useState(false);
   const [serverStageCollapsed, setServerStageCollapsed] = useState(() => localStorage.getItem(SERVER_STAGE_STORAGE_KEY) === 'true');
   const [serverFilters, setServerFilters] = useState({ status: new Set<string>(), runtime: new Set<string>(), gpu: new Set<string>() });
   const [inferenceParams, setInferenceParams] = useState<InferenceParams>(DEFAULT_INFERENCE_PARAMS);
@@ -228,7 +231,7 @@ export function Catalog({
       setConnectivity(nextHealth);
       setSelectedDetailId((current) => current && serverRows.some((server) => server.inference_server.server_id === current)
         ? current
-        : serverRows[0]?.inference_server.server_id ?? null);
+        : null);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Unable to load catalog');
     } finally {
@@ -272,7 +275,6 @@ export function Catalog({
   const catalogModels = useMemo(() => buildCatalogModels(servers, models), [servers, models]);
   const reachable = servers.filter((server) => connectivity[server.inference_server.server_id]?.ok).length;
   const selectedServerRows = servers.filter((server) => selectedServers.has(server.inference_server.server_id));
-  const selectedDetail = servers.find((server) => server.inference_server.server_id === selectedDetailId) ?? null;
 
   const runtimeOptions = useMemo(() => Array.from(new Set(servers.map(runtimeLabel))).sort(), [servers]);
   const gpuOptions = useMemo(() => Array.from(new Set(servers.map(gpuLabel))).sort(), [servers]);
@@ -282,13 +284,21 @@ export function Catalog({
 
   const filteredServers = useMemo(() => {
     return servers.filter((server) => {
+      if (server.inference_server.archived !== showArchivedOnly) return false;
       const status = statusFor(server, connectivity[server.inference_server.server_id]);
       if (serverFilters.status.size && !serverFilters.status.has(status)) return false;
       if (serverFilters.runtime.size && !serverFilters.runtime.has(runtimeLabel(server))) return false;
       if (serverFilters.gpu.size && !serverFilters.gpu.has(gpuLabel(server))) return false;
       return true;
     });
-  }, [connectivity, serverFilters, servers]);
+  }, [connectivity, serverFilters, servers, showArchivedOnly]);
+  const selectedDetail = filteredServers.find((server) => server.inference_server.server_id === selectedDetailId) ?? null;
+
+  useEffect(() => {
+    if (!selectedDetailId || activeTab !== 'servers') return;
+    if (filteredServers.some((server) => server.inference_server.server_id === selectedDetailId)) return;
+    setSelectedDetailId(null);
+  }, [activeTab, filteredServers, selectedDetailId]);
 
   const visibleModels = useMemo(() => {
     if (selectedServers.size === 0) return [];
@@ -342,12 +352,6 @@ export function Catalog({
     await refreshData();
   }
 
-  const headerTabAction = activeTab === 'servers' ? (
-    <div className="catalog-header-actions">
-      <button type="button" onClick={() => setDrawer({ kind: 'create' })}>+ Add server</button>
-    </div>
-  ) : null;
-
   if (activeTab === 'models' && inspectorServerId && inspectorModelId) {
     return (
       <>
@@ -382,7 +386,6 @@ export function Catalog({
         ]}
         activeTab={activeTab}
         onTabChange={changeTab}
-        tabAction={headerTabAction}
       />
       <InferenceContextBar params={inferenceParams} onChange={setInferenceParams} />
       {error ? <div className="catalog-error error">{error}</div> : null}
@@ -400,11 +403,19 @@ export function Catalog({
             runtimeOptions={runtimeOptions}
             gpuOptions={gpuOptions}
             serverFilters={serverFilters}
+            serverFiltersOpen={serverFiltersOpen}
+            showArchivedOnly={showArchivedOnly}
             setServerFilters={setServerFilters}
+            onToggleServerFilters={() => setServerFiltersOpen((current) => !current)}
+            onToggleArchivedOnly={() => setShowArchivedOnly((current) => !current)}
             onSelectDetail={setSelectedDetailId}
             onEdit={(server) => setDrawer({ kind: 'edit', server })}
             onArchive={async (server) => {
-              await archiveInferenceServer(server.inference_server.server_id);
+              if (server.inference_server.archived) {
+                await unarchiveInferenceServer(server.inference_server.server_id);
+              } else {
+                await archiveInferenceServer(server.inference_server.server_id);
+              }
               notifyServersUpdated();
               await refreshData();
             }}
@@ -492,8 +503,12 @@ function ServersCatalog(props: {
   runtimeOptions: string[];
   gpuOptions: string[];
   serverFilters: { status: Set<string>; runtime: Set<string>; gpu: Set<string> };
+  serverFiltersOpen: boolean;
+  showArchivedOnly: boolean;
   setServerFilters: (filters: { status: Set<string>; runtime: Set<string>; gpu: Set<string> }) => void;
-  onSelectDetail: (serverId: string) => void;
+  onToggleServerFilters: () => void;
+  onToggleArchivedOnly: () => void;
+  onSelectDetail: (serverId: string | null) => void;
   onEdit: (server: InferenceServerRecord) => void;
   onArchive: (server: InferenceServerRecord) => void;
   onAdd: () => void;
@@ -502,69 +517,86 @@ function ServersCatalog(props: {
     return <NoServersState onAdd={props.onAdd} />;
   }
   return (
-    <section className={`catalog-page catalog-servers ${props.selectedDetail ? 'has-detail' : ''}`}>
-      <aside className="catalog-rail">
-        <FilterGroup
-          title="Status"
-          options={['healthy', 'degraded', 'down', 'unknown']}
-          selected={props.serverFilters.status}
-          onToggle={(value) => props.setServerFilters({ ...props.serverFilters, status: toggleSetValue(props.serverFilters.status, value) })}
-        />
-        <FilterGroup
-          title="Runtime"
-          options={props.runtimeOptions}
-          selected={props.serverFilters.runtime}
-          onToggle={(value) => props.setServerFilters({ ...props.serverFilters, runtime: toggleSetValue(props.serverFilters.runtime, value) })}
-        />
-        <FilterGroup
-          title="GPU"
-          options={props.gpuOptions}
-          selected={props.serverFilters.gpu}
-          onToggle={(value) => props.setServerFilters({ ...props.serverFilters, gpu: toggleSetValue(props.serverFilters.gpu, value) })}
-        />
-      </aside>
+    <section className={`catalog-page catalog-servers ${props.serverFiltersOpen ? 'has-filters' : ''} ${props.selectedDetail ? 'has-detail' : ''}`}>
+      {props.serverFiltersOpen ? (
+        <aside className="catalog-rail">
+          <FilterGroup
+            title="Status"
+            options={['healthy', 'degraded', 'down', 'unknown']}
+            selected={props.serverFilters.status}
+            onToggle={(value) => props.setServerFilters({ ...props.serverFilters, status: toggleSetValue(props.serverFilters.status, value) })}
+          />
+          <FilterGroup
+            title="Runtime"
+            options={props.runtimeOptions}
+            selected={props.serverFilters.runtime}
+            onToggle={(value) => props.setServerFilters({ ...props.serverFilters, runtime: toggleSetValue(props.serverFilters.runtime, value) })}
+          />
+          <FilterGroup
+            title="GPU"
+            options={props.gpuOptions}
+            selected={props.serverFilters.gpu}
+            onToggle={(value) => props.setServerFilters({ ...props.serverFilters, gpu: toggleSetValue(props.serverFilters.gpu, value) })}
+          />
+        </aside>
+      ) : null}
       <main className="catalog-main">
         <div className="catalog-section-title">
           <div>
             <h2>Inference servers</h2>
-            <p>{props.servers.length} shown · {props.allServers.filter((server) => server.inference_server.archived).length} archived</p>
+            <p>{props.servers.length} shown · {props.allServers.filter((server) => !server.inference_server.archived).length} active · {props.allServers.filter((server) => server.inference_server.archived).length} archived</p>
+          </div>
+          <div className="catalog-section-actions">
+            <button type="button" className={`btn btn--ghost btn--sm ${props.serverFiltersOpen ? 'is-active' : ''}`} onClick={props.onToggleServerFilters}>Filter</button>
+            <button type="button" className={`btn btn--ghost btn--sm ${props.showArchivedOnly ? 'is-active' : ''}`} onClick={props.onToggleArchivedOnly}>Archived</button>
+            <button type="button" className="btn btn--sm" onClick={props.onAdd}>+ Add server</button>
           </div>
         </div>
-        <div className="catalog-server-grid">
-          {props.servers.map((server) => {
-            const status = statusFor(server, props.connectivity[server.inference_server.server_id]);
-            return (
-              <button
-                type="button"
-                key={server.inference_server.server_id}
-                className={`catalog-server-card ${props.selectedDetailId === server.inference_server.server_id ? 'is-selected' : ''}`}
-                onClick={() => props.onSelectDetail(server.inference_server.server_id)}
-              >
-                <span className="catalog-card-top">
-                  <strong>{server.inference_server.display_name}</strong>
-                  <RegLight
-                    state={statusToRegLight(status)}
-                    label={statusLabel(status)}
-                    latencyMs={props.connectivity[server.inference_server.server_id]?.response_time_ms}
-                    lastProbe={props.connectivity[server.inference_server.server_id]?.checked_at ?? server.discovery.retrieved_at}
-                    statusCode={props.connectivity[server.inference_server.server_id]?.status_code}
-                    error={props.connectivity[server.inference_server.server_id]?.error}
-                  />
-                </span>
-                <span className="catalog-url">{server.endpoints.base_url}</span>
-                <span className="catalog-card-meta">
-                  <span>{runtimeLabel(server)}</span>
-                  <span className="catalog-pill">{gpuLabel(server)}</span>
-                </span>
-                <span className="catalog-card-footer">
-                  <span>{server.discovery.model_list.normalised.length} models</span>
-                  <span>{relativeTime(server.discovery.retrieved_at)}</span>
-                  <span aria-hidden="true">...</span>
-                </span>
-              </button>
-            );
-          })}
-        </div>
+        {props.servers.length === 0 ? (
+          <div className="catalog-empty">
+            <EmptyState
+              title={props.showArchivedOnly ? 'No archived servers' : 'No matching servers'}
+              body={props.showArchivedOnly ? 'Archived servers appear here when they are available.' : 'Adjust the server filters to show more entries.'}
+            />
+          </div>
+        ) : (
+          <div className="catalog-server-grid">
+            {props.servers.map((server) => {
+              const status = statusFor(server, props.connectivity[server.inference_server.server_id]);
+              return (
+                <button
+                  type="button"
+                  key={server.inference_server.server_id}
+                  className={`catalog-server-card ${props.selectedDetailId === server.inference_server.server_id ? 'is-selected' : ''}`}
+                  aria-pressed={props.selectedDetailId === server.inference_server.server_id}
+                  onClick={() => props.onSelectDetail(props.selectedDetailId === server.inference_server.server_id ? null : server.inference_server.server_id)}
+                >
+                  <span className="catalog-card-top">
+                    <strong>{server.inference_server.display_name}</strong>
+                    <RegLight
+                      state={statusToRegLight(status)}
+                      label={statusLabel(status)}
+                      latencyMs={props.connectivity[server.inference_server.server_id]?.response_time_ms}
+                      lastProbe={props.connectivity[server.inference_server.server_id]?.checked_at ?? server.discovery.retrieved_at}
+                      statusCode={props.connectivity[server.inference_server.server_id]?.status_code}
+                      error={props.connectivity[server.inference_server.server_id]?.error}
+                    />
+                  </span>
+                  <span className="catalog-url">{server.endpoints.base_url}</span>
+                  <span className="catalog-card-meta">
+                    <span>{runtimeLabel(server)}</span>
+                    <span className="catalog-pill">{gpuLabel(server)}</span>
+                  </span>
+                  <span className="catalog-card-footer">
+                    <span>{server.discovery.model_list.normalised.length} models</span>
+                    <span>{relativeTime(server.discovery.retrieved_at)}</span>
+                    <span aria-hidden="true">...</span>
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        )}
       </main>
       {props.selectedDetail ? (
         <aside className="catalog-detail-rail">
@@ -832,8 +864,7 @@ function ServersHealthPanel({ servers, connectivity }: { servers: InferenceServe
 
 function NoServersState({ onAdd }: { onAdd?: () => void }) {
   return (
-    <section className="catalog-page">
-      <aside className="catalog-rail catalog-placeholder">Status<br />Runtime<br />GPU</aside>
+    <section className="catalog-page catalog-servers">
       <main className="catalog-main catalog-empty catalog-empty-large">
         <EmptyState
           title="No servers yet"

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -2300,7 +2300,8 @@ pre.code-block {
   color: var(--ink-8);
 }
 
-.catalog-header-actions {
+.catalog-header-actions,
+.catalog-section-actions {
   display: flex;
   gap: 8px;
   align-items: center;
@@ -2318,7 +2319,19 @@ pre.code-block {
   background: var(--paper-2);
 }
 
+.catalog-servers {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.catalog-servers.has-filters {
+  grid-template-columns: 240px minmax(0, 1fr);
+}
+
 .catalog-servers.has-detail {
+  grid-template-columns: minmax(0, 1fr) 320px;
+}
+
+.catalog-servers.has-filters.has-detail {
   grid-template-columns: 240px minmax(0, 1fr) 320px;
 }
 
@@ -2363,7 +2376,19 @@ pre.code-block {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
+  gap: 16px;
   margin-bottom: 16px;
+}
+
+.catalog-section-actions {
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.catalog-section-actions .is-active {
+  border-color: var(--gold-9);
+  background: var(--bg-selected);
+  color: var(--ink-9);
 }
 
 .catalog-section-title h2 {
@@ -2404,6 +2429,11 @@ pre.code-block {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
   gap: 14px;
+}
+
+.catalog-server-grid {
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 280px), 320px));
+  justify-content: start;
 }
 
 .catalog-server-card,
@@ -3077,7 +3107,9 @@ pre.code-block {
   }
 
   .catalog-page,
+  .catalog-servers.has-filters,
   .catalog-servers.has-detail,
+  .catalog-servers.has-filters.has-detail,
   .catalog-models,
   .catalog-models.stage-collapsed {
     grid-template-columns: 1fr;

--- a/frontend/tests/e2e/inference-servers-create.spec.ts
+++ b/frontend/tests/e2e/inference-servers-create.spec.ts
@@ -9,7 +9,7 @@ test('creates a new inference server from the dashboard', async ({ page, request
 
   await page.goto('/catalog?tab=servers');
 
-  await page.locator('.merged-page-header').getByRole('button', { name: '+ Add server' }).click();
+  await page.locator('.catalog-section-title').filter({ hasText: 'Inference servers' }).getByRole('button', { name: '+ Add server' }).click();
 
   const createDrawer = page
     .getByRole('dialog')

--- a/frontend/tests/e2e/navigation-shell.spec.ts
+++ b/frontend/tests/e2e/navigation-shell.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 
 function catalogServer(serverId: string, name: string, modelId: string) {
   return {
@@ -87,6 +87,31 @@ function catalogModel(serverId: string, modelId: string, provider: string, forma
   };
 }
 
+type CatalogServerFixture = ReturnType<typeof catalogServer>;
+type CatalogModelFixture = ReturnType<typeof catalogModel>;
+
+async function mockCatalogRoutes(page: Page, servers: CatalogServerFixture[], models: CatalogModelFixture[]) {
+  await page.route('**/system/connectivity-config', async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ poll_interval_ms: 60000 }) });
+  });
+  await page.route('**/inference-servers/health', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ results: servers.map((server) => ({ server_id: server.inference_server.server_id, ok: true, status_code: 200, response_time_ms: 12, checked_at: '2026-01-01T00:00:00.000Z' })) })
+    });
+  });
+  await page.route('**/inference-servers?*', async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(servers) });
+  });
+  await page.route('**/inference-servers', async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(servers) });
+  });
+  await page.route('**/models', async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(models) });
+  });
+}
+
 test('sidebar exposes five top-level destinations and follows active routes', async ({ page }) => {
   await page.goto('/catalog?tab=servers');
 
@@ -125,15 +150,45 @@ test('merged page sub-tabs preserve route state', async ({ page }) => {
   await expect(page).toHaveURL(/\/results\?tab=history/);
 });
 
-test('catalog header keeps server actions in the tab row', async ({ page }) => {
+test('catalog servers header owns actions and conditional filter rail', async ({ page }) => {
+  const activeServer = catalogServer('srv-a', 'Inferencer', 'mistral:latest');
+  const archivedServer = catalogServer('srv-archived', 'LegacyProd', 'legacy:latest');
+  archivedServer.inference_server.active = false;
+  archivedServer.inference_server.archived = true;
+  archivedServer.inference_server.archived_at = '2026-01-02T00:00:00.000Z';
+  const servers = [activeServer, archivedServer];
+  const models = [
+    catalogModel('srv-a', 'mistral:latest', 'mistral', 'MLX'),
+    catalogModel('srv-archived', 'legacy:latest', 'mistral', 'GGUF')
+  ];
+  await mockCatalogRoutes(page, servers, models);
+
   await page.goto('/catalog?tab=servers');
   const catalogHeader = page.locator('.merged-page-header');
+  const sectionHeader = page.locator('.catalog-section-title').filter({ hasText: 'Inference servers' });
 
-  await expect(catalogHeader.getByRole('button', { name: '+ Add server' })).toBeVisible();
+  await expect(catalogHeader.getByRole('button', { name: '+ Add server' })).toHaveCount(0);
+  await expect(sectionHeader.getByRole('button', { name: 'Filter' })).toBeVisible();
+  await expect(sectionHeader.getByRole('button', { name: 'Archived' })).toBeVisible();
+  await expect(sectionHeader.getByRole('button', { name: '+ Add server' })).toBeVisible();
   await expect(catalogHeader.getByRole('button', { name: 'Health' })).toHaveCount(0);
   await expect(catalogHeader.getByRole('button', { name: 'Grid' })).toHaveCount(0);
+  await expect(page.locator('.catalog-rail')).toHaveCount(0);
+  await expect(page.locator('.catalog-server-card').filter({ hasText: 'Inferencer' })).toBeVisible();
+  await expect(page.locator('.catalog-server-card').filter({ hasText: 'LegacyProd' })).toHaveCount(0);
 
-  await catalogHeader.getByRole('button', { name: '+ Add server' }).click();
+  await sectionHeader.getByRole('button', { name: 'Filter' }).click();
+  await expect(page.locator('.catalog-rail')).toBeVisible();
+  await expect(sectionHeader.getByRole('button', { name: 'Filter' })).toHaveClass(/is-active/);
+  await sectionHeader.getByRole('button', { name: 'Filter' }).click();
+  await expect(page.locator('.catalog-rail')).toHaveCount(0);
+
+  await sectionHeader.getByRole('button', { name: 'Archived' }).click();
+  await expect(sectionHeader.getByRole('button', { name: 'Archived' })).toHaveClass(/is-active/);
+  await expect(page.locator('.catalog-server-card').filter({ hasText: 'Inferencer' })).toHaveCount(0);
+  await expect(page.locator('.catalog-server-card').filter({ hasText: 'LegacyProd' })).toBeVisible();
+
+  await sectionHeader.getByRole('button', { name: '+ Add server' }).click();
   const createDrawer = page
     .getByRole('dialog')
     .filter({ has: page.getByRole('heading', { name: 'Add inference server' }) });
@@ -142,6 +197,48 @@ test('catalog header keeps server actions in the tab row', async ({ page }) => {
 
   await page.goto('/catalog?tab=models');
   await expect(page.locator('.merged-page-header').getByRole('button', { name: '+ Add server' })).toHaveCount(0);
+});
+
+test('catalog server cards toggle the detail rail', async ({ page }) => {
+  const servers = [
+    catalogServer('srv-a', 'Inferencer', 'mistral:latest'),
+    catalogServer('srv-b', 'InferencerPro', 'qwen:latest')
+  ];
+  const models = [
+    catalogModel('srv-a', 'mistral:latest', 'mistral', 'MLX'),
+    catalogModel('srv-b', 'qwen:latest', 'qwen', 'MLX')
+  ];
+  await mockCatalogRoutes(page, servers, models);
+
+  await page.goto('/catalog?tab=servers');
+  const serverCard = page.locator('.catalog-server-card').filter({ hasText: 'Inferencer' }).first();
+  const sectionHeader = page.locator('.catalog-section-title').filter({ hasText: 'Inference servers' });
+
+  await expect(page.locator('.catalog-server-card.is-selected')).toHaveCount(0);
+  await expect(page.locator('.catalog-detail-rail')).toHaveCount(0);
+  const initialBox = await serverCard.boundingBox();
+  expect(initialBox).not.toBeNull();
+
+  await serverCard.click();
+  await expect(serverCard).toHaveClass(/is-selected/);
+  await expect(page.locator('.catalog-detail-rail').filter({ hasText: 'Inferencer' })).toBeVisible();
+  const selectedBox = await serverCard.boundingBox();
+  expect(selectedBox).not.toBeNull();
+
+  await serverCard.click();
+  await expect(page.locator('.catalog-server-card.is-selected')).toHaveCount(0);
+  await expect(page.locator('.catalog-detail-rail')).toHaveCount(0);
+  const unselectedBox = await serverCard.boundingBox();
+  expect(unselectedBox).not.toBeNull();
+
+  expect(selectedBox!.width).toBeCloseTo(initialBox!.width, 1);
+  expect(unselectedBox!.width).toBeCloseTo(initialBox!.width, 1);
+
+  await sectionHeader.getByRole('button', { name: 'Filter' }).click();
+  await expect(page.locator('.catalog-rail')).toBeVisible();
+  const filteredBox = await serverCard.boundingBox();
+  expect(filteredBox).not.toBeNull();
+  expect(filteredBox!.width).toBeCloseTo(initialBox!.width, 1);
 });
 
 test('legacy routes redirect to the new IA contract', async ({ page }) => {
@@ -185,25 +282,7 @@ test('catalog models funnel aligns staged rail controls', async ({ page }) => {
     window.localStorage.removeItem('catalog.serverStageCollapsed');
     window.localStorage.removeItem('catalog.modelFilterStageCollapsed');
   });
-  await page.route('**/system/connectivity-config', async (route) => {
-    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ poll_interval_ms: 60000 }) });
-  });
-  await page.route('**/inference-servers/health', async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ results: servers.map((server) => ({ server_id: server.inference_server.server_id, ok: true, status_code: 200, response_time_ms: 12, checked_at: '2026-01-01T00:00:00.000Z' })) })
-    });
-  });
-  await page.route('**/inference-servers?*', async (route) => {
-    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(servers) });
-  });
-  await page.route('**/inference-servers', async (route) => {
-    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(servers) });
-  });
-  await page.route('**/models', async (route) => {
-    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(models) });
-  });
+  await mockCatalogRoutes(page, servers, models);
 
   await page.goto('/catalog?tab=models');
   const catalogPage = page.locator('.catalog-models');


### PR DESCRIPTION
Move Catalog server actions into the section header, make the filter rail conditional, add archived-only mode, and keep server card selection/detail behavior stable.