### PR TITLE
feat(benchmark): compute full metric set and aggregations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 
 ## [Unreleased]
 
+### Added
+
+- **Benchmark metrics & aggregation** — new `benchmark-metrics` service computing the full schema-advertised metric set per item (`tokens_per_second`, `output_input_token_ratio`, `exact_match`, `contains_required_terms`, `json_valid`, `schema_valid`, `regex_match`, and tool-call metrics) plus run-level aggregations (`mean`/`median`/`min`/`max`/`sum`/`count`/`p50`/`p90`/`p95`/`p99`/`stddev`/`variance`), with boolean metrics surfaced as `success_rate` and partial-execution sample accounting.
+- Run page right-side metrics panel now shows tokens-per-second, latency `p95` and item count for multi-item runs, and a correctness section (per-metric success rate) when the template requests correctness metrics.
+
+### Changed
+
+- Benchmark runner replaces the stub aggregator (`count`/`elapsed_ms_mean`/`output_tokens_sum`) with template-driven metric computation and aggregation; `metric_version` bumped from `basic-v1` to `metrics-v1`.
+- Response normalizer now surfaces `tool_calls` so tool-call metrics can be computed.
+- Run page smoke template requests `tokens_per_second` and `p95`/`count` aggregations.
+
 ## [0.5.0] - 2026-06-08
 
 ### Added

--- a/backend/src/services/benchmark-metrics.ts
+++ b/backend/src/services/benchmark-metrics.ts
@@ -1,0 +1,305 @@
+import { Ajv2020 } from 'ajv/dist/2020.js';
+
+const ajv = new Ajv2020({ allErrors: false, strict: false });
+ajv.addFormat('date-time', true);
+
+const META_FIELDS = new Set(['stage_id', 'item_index', 'iteration']);
+
+export interface ItemMetricInputs {
+  requestedMetrics: string[];
+  timing: {
+    elapsed_ms: number | null;
+    first_token_ms: number | null;
+    input_tokens: number | null;
+    output_tokens: number | null;
+    total_tokens: number | null;
+  };
+  answerText: string;
+  toolCalls: unknown[] | null;
+  item: Record<string, unknown>;
+}
+
+export function computeItemMetrics(args: ItemMetricInputs): Record<string, number | boolean | null> {
+  const { requestedMetrics, timing, answerText, toolCalls, item } = args;
+  const result: Record<string, number | boolean | null> = {};
+
+  for (const metric of requestedMetrics) {
+    switch (metric) {
+      case 'input_tokens':
+        result.input_tokens = timing.input_tokens;
+        break;
+      case 'output_tokens':
+        result.output_tokens = timing.output_tokens;
+        break;
+      case 'total_tokens':
+        result.total_tokens = timing.total_tokens;
+        break;
+      case 'elapsed_ms':
+        result.elapsed_ms = timing.elapsed_ms;
+        break;
+      case 'first_token_ms':
+        result.first_token_ms = timing.first_token_ms;
+        break;
+      case 'tokens_per_second': {
+        const out = timing.output_tokens;
+        const ms = timing.elapsed_ms;
+        result.tokens_per_second = out !== null && ms !== null && ms > 0 ? out / (ms / 1000) : null;
+        break;
+      }
+      case 'output_input_token_ratio': {
+        const out = timing.output_tokens;
+        const inp = timing.input_tokens;
+        result.output_input_token_ratio = out !== null && inp !== null && inp > 0 ? out / inp : null;
+        break;
+      }
+      case 'exact_match': {
+        const expected = item.expected_answer;
+        result.exact_match = typeof expected === 'string'
+          ? answerText.trim() === expected.trim()
+          : null;
+        break;
+      }
+      case 'contains_required_terms': {
+        const expected = item.expected_answer;
+        if (Array.isArray(expected)) {
+          result.contains_required_terms = (expected as unknown[]).every(
+            (term) => typeof term === 'string' && answerText.toLowerCase().includes(term.toLowerCase())
+          );
+        } else if (typeof expected === 'string') {
+          result.contains_required_terms = answerText.toLowerCase().includes(expected.toLowerCase());
+        } else {
+          result.contains_required_terms = null;
+        }
+        break;
+      }
+      case 'json_valid': {
+        if (answerText.trim().length === 0) {
+          result.json_valid = null;
+        } else {
+          try {
+            JSON.parse(answerText);
+            result.json_valid = true;
+          } catch {
+            result.json_valid = false;
+          }
+        }
+        break;
+      }
+      case 'schema_valid': {
+        const schema = item.expected_schema;
+        if (schema && typeof schema === 'object' && !Array.isArray(schema)) {
+          try {
+            const parsed = JSON.parse(answerText);
+            const validate = ajv.compile(schema as Record<string, unknown>);
+            result.schema_valid = validate(parsed) as boolean;
+          } catch {
+            result.schema_valid = false;
+          }
+        } else {
+          result.schema_valid = null;
+        }
+        break;
+      }
+      case 'regex_match': {
+        const fmt = item.expected_format;
+        const pattern = item.expected_answer;
+        if (fmt === 'regex' && typeof pattern === 'string') {
+          try {
+            result.regex_match = new RegExp(pattern).test(answerText);
+          } catch {
+            result.regex_match = null;
+          }
+        } else {
+          result.regex_match = null;
+        }
+        break;
+      }
+      case 'tool_call_count':
+        result.tool_call_count = toolCalls !== null ? toolCalls.length : null;
+        break;
+      case 'tool_selected_correctly':
+        result.tool_selected_correctly = computeToolSelectedCorrectly(toolCalls, item.expected_tool_calls);
+        break;
+      case 'tool_arguments_valid':
+        result.tool_arguments_valid = computeToolArgumentsValid(toolCalls, item.expected_tool_calls);
+        break;
+      case 'missing_tool_call':
+        result.missing_tool_call = computeMissingToolCall(toolCalls, item.expected_tool_calls);
+        break;
+      case 'hallucinated_tool_call':
+        result.hallucinated_tool_call = computeHallucinatedToolCall(toolCalls, item.expected_tool_calls);
+        break;
+    }
+  }
+
+  return result;
+}
+
+export function aggregateMetrics(
+  metricResults: Record<string, unknown>[],
+  requestedAggregations: string[],
+  expectedSampleCount: number
+): Record<string, Record<string, unknown>> {
+  const numericValues = new Map<string, number[]>();
+  const booleanValues = new Map<string, boolean[]>();
+  const totalSamples = metricResults.length;
+
+  for (const m of metricResults) {
+    for (const [key, val] of Object.entries(m)) {
+      if (META_FIELDS.has(key)) continue;
+      if (typeof val === 'number') {
+        const list = numericValues.get(key) ?? [];
+        list.push(val);
+        numericValues.set(key, list);
+      } else if (typeof val === 'boolean') {
+        const list = booleanValues.get(key) ?? [];
+        list.push(val);
+        booleanValues.set(key, list);
+      }
+    }
+  }
+
+  const result: Record<string, Record<string, unknown>> = {};
+
+  for (const [key, values] of numericValues) {
+    const agg: Record<string, unknown> = {};
+    for (const stat of requestedAggregations) {
+      const v = computeStat(stat, values);
+      if (v !== null) agg[stat] = v;
+    }
+    const validCount = values.length;
+    agg.count = totalSamples;
+    agg.valid_sample_count = validCount;
+    if (validCount < expectedSampleCount) {
+      agg.expected_sample_count = expectedSampleCount;
+      agg.missing_sample_count = expectedSampleCount - validCount;
+      agg.partial_execution = true;
+    }
+    result[key] = agg;
+  }
+
+  for (const [key, values] of booleanValues) {
+    const validCount = values.length;
+    const trueCount = values.filter(Boolean).length;
+    const agg: Record<string, unknown> = {
+      success_rate: validCount > 0 ? trueCount / validCount : null,
+      count: totalSamples,
+      valid_sample_count: validCount
+    };
+    if (validCount < expectedSampleCount) {
+      agg.expected_sample_count = expectedSampleCount;
+      agg.missing_sample_count = expectedSampleCount - validCount;
+      agg.partial_execution = true;
+    }
+    result[key] = agg;
+  }
+
+  return result;
+}
+
+function computeStat(stat: string, values: number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const n = values.length;
+
+  switch (stat) {
+    case 'mean':
+      return values.reduce((s, v) => s + v, 0) / n;
+    case 'min':
+      return sorted[0];
+    case 'max':
+      return sorted[n - 1];
+    case 'sum':
+      return values.reduce((s, v) => s + v, 0);
+    case 'count':
+      return n;
+    case 'median':
+      return interpolatedPercentile(sorted, 50);
+    case 'p50':
+      return interpolatedPercentile(sorted, 50);
+    case 'p90':
+      return interpolatedPercentile(sorted, 90);
+    case 'p95':
+      return interpolatedPercentile(sorted, 95);
+    case 'p99':
+      return interpolatedPercentile(sorted, 99);
+    case 'stddev': {
+      const mean = values.reduce((s, v) => s + v, 0) / n;
+      return Math.sqrt(values.reduce((s, v) => s + (v - mean) ** 2, 0) / n);
+    }
+    case 'variance': {
+      const mean = values.reduce((s, v) => s + v, 0) / n;
+      return values.reduce((s, v) => s + (v - mean) ** 2, 0) / n;
+    }
+    default:
+      return null;
+  }
+}
+
+function interpolatedPercentile(sorted: number[], p: number): number {
+  if (sorted.length === 1) return sorted[0];
+  const idx = (p / 100) * (sorted.length - 1);
+  const lo = Math.floor(idx);
+  const hi = Math.ceil(idx);
+  if (lo === hi) return sorted[lo];
+  return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo);
+}
+
+function callName(call: unknown): string | null {
+  if (!call || typeof call !== 'object') return null;
+  const r = call as Record<string, unknown>;
+  const fn = r.function as Record<string, unknown> | undefined;
+  const name = typeof fn?.name === 'string' ? fn.name : typeof r.name === 'string' ? r.name : null;
+  return name;
+}
+
+function expectedCallNames(expected: unknown): string[] {
+  if (!Array.isArray(expected)) return [];
+  return (expected as unknown[]).flatMap((e) => {
+    const name = callName(e);
+    return name ? [name] : [];
+  });
+}
+
+function computeToolSelectedCorrectly(actual: unknown[] | null, expected: unknown): boolean | null {
+  if (!Array.isArray(expected) || expected.length === 0) return null;
+  const actualNames = (actual ?? []).flatMap((c) => { const n = callName(c); return n ? [n] : []; });
+  return expectedCallNames(expected).every((name) => actualNames.includes(name));
+}
+
+function computeToolArgumentsValid(actual: unknown[] | null, expected: unknown): boolean | null {
+  if (!Array.isArray(expected) || expected.length === 0 || actual === null) return null;
+  return (expected as unknown[]).every((exp) => {
+    if (!exp || typeof exp !== 'object') return false;
+    const e = exp as Record<string, unknown>;
+    const name = callName(e);
+    if (!name) return false;
+    const match = actual.find((a) => callName(a) === name);
+    if (!match) return false;
+    if (e.arguments === undefined) return true;
+    const r = match as Record<string, unknown>;
+    const fn = r.function as Record<string, unknown> | undefined;
+    const actualArgs = fn?.arguments ?? r.arguments;
+    if (typeof actualArgs === 'string' && typeof e.arguments === 'object') {
+      try {
+        return JSON.stringify(JSON.parse(actualArgs)) === JSON.stringify(e.arguments);
+      } catch {
+        return false;
+      }
+    }
+    return JSON.stringify(actualArgs) === JSON.stringify(e.arguments);
+  });
+}
+
+function computeMissingToolCall(actual: unknown[] | null, expected: unknown): boolean | null {
+  if (!Array.isArray(expected) || expected.length === 0) return null;
+  const actualNames = (actual ?? []).flatMap((c) => { const n = callName(c); return n ? [n] : []; });
+  return expectedCallNames(expected).some((name) => !actualNames.includes(name));
+}
+
+function computeHallucinatedToolCall(actual: unknown[] | null, expected: unknown): boolean | null {
+  if (!Array.isArray(expected) || actual === null) return null;
+  const actualNames = actual.flatMap((c) => { const n = callName(c); return n ? [n] : []; });
+  const expectedNames = expectedCallNames(expected);
+  return actualNames.some((name) => !expectedNames.includes(name));
+}

--- a/backend/src/services/benchmark-runner.ts
+++ b/backend/src/services/benchmark-runner.ts
@@ -13,6 +13,7 @@ import { buildInferenceServerAuthHeaders } from './inference-server-auth.js';
 import { backendFetch } from './inference-proxy.js';
 import { sha256Document, validateBenchmarkDocument } from './benchmark-schemas.js';
 import { parseSseEvents } from './sse-parser.js';
+import { aggregateMetrics as computeAggregations, computeItemMetrics } from './benchmark-metrics.js';
 
 const ENGINE_VERSION = 'benchmark-runner-v1';
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -57,6 +58,7 @@ interface NormalizedResponse {
   input_tokens: number | null;
   output_tokens: number | null;
   total_tokens: number | null;
+  tool_calls: unknown[] | null;
   body: unknown;
   text: string | null;
   stream?: Record<string, unknown> | null;
@@ -132,6 +134,27 @@ function stagesFromInstantiation(instantiation: Record<string, unknown>): Benchm
       stop_on_error: typeof record.stop_on_error === 'boolean' ? record.stop_on_error : false
     };
   });
+}
+
+function templateMetricsFromInstantiation(instantiation: Record<string, unknown>): string[] {
+  const snapshot = objectAt(objectAt(instantiation, 'template'), 'snapshot');
+  const metrics = snapshot?.metrics;
+  return Array.isArray(metrics) ? (metrics as string[]) : ['elapsed_ms', 'input_tokens', 'output_tokens', 'total_tokens'];
+}
+
+function templateAggregationsFromInstantiation(instantiation: Record<string, unknown>): string[] {
+  const snapshot = objectAt(objectAt(instantiation, 'template'), 'snapshot');
+  const aggs = snapshot?.aggregations;
+  return Array.isArray(aggs) ? (aggs as string[]) : ['mean', 'count'];
+}
+
+function expectedSampleCount(stages: BenchmarkStage[], itemCount: number): number {
+  return stages
+    .filter((s) => s.record_metrics !== false)
+    .reduce((sum, s) => {
+      const itemsForStage = s.type === 'single_request' ? 1 : itemCount;
+      return sum + itemsForStage * (s.iterations_per_item ?? 1);
+    }, 0);
 }
 
 function modelIdFromInstantiation(instantiation: Record<string, unknown>): string {
@@ -395,6 +418,7 @@ function normalizeStreamResponse(protocol: unknown, contentType: string, respons
     input_tokens: stream.input_tokens,
     output_tokens: stream.output_tokens,
     total_tokens: stream.total_tokens,
+    tool_calls: null,
     body: stream.final_metadata,
     text: null,
     stream: {
@@ -424,6 +448,7 @@ function normalizeResponse(body: unknown, text: string | null): NormalizedRespon
     const evalCount = typeof record.eval_count === 'number' ? record.eval_count : null;
     const inputTokens = typeof usage?.prompt_tokens === 'number' ? usage.prompt_tokens : promptEvalCount;
     const outputTokens = typeof usage?.completion_tokens === 'number' ? usage.completion_tokens : evalCount;
+    const toolCalls = Array.isArray(message?.tool_calls) ? (message.tool_calls as unknown[]) : null;
     return {
       answer_text: textFromValue(message?.content) ?? textFromValue(ollamaMessage?.content) ?? textFromValue(record.response) ?? '',
       input_tokens: inputTokens,
@@ -431,6 +456,7 @@ function normalizeResponse(body: unknown, text: string | null): NormalizedRespon
       total_tokens: typeof usage?.total_tokens === 'number'
         ? usage.total_tokens
         : inputTokens !== null && outputTokens !== null ? inputTokens + outputTokens : null,
+      tool_calls: toolCalls,
       body,
       text: null
     };
@@ -440,6 +466,7 @@ function normalizeResponse(body: unknown, text: string | null): NormalizedRespon
     input_tokens: null,
     output_tokens: null,
     total_tokens: null,
+    tool_calls: null,
     body,
     text
   };
@@ -450,7 +477,8 @@ async function executeItem(
   stage: BenchmarkStage,
   executable: ExecutableItem,
   policy: ExecutionPolicy,
-  authHeaders: Record<string, string>
+  authHeaders: Record<string, string>,
+  requestedMetrics: string[]
 ): Promise<{
   result: Record<string, unknown>;
   rawResponse: Record<string, unknown> | null;
@@ -596,7 +624,7 @@ async function executeItem(
         text: responseBody === null ? responseText : null,
         stream: normalized.stream ?? null
       };
-      const metrics = {
+      const baseMetrics = {
         stage_id: stage.id,
         item_index: executable.itemIndex,
         iteration: executable.iteration,
@@ -606,6 +634,14 @@ async function executeItem(
         output_tokens: normalized.output_tokens,
         total_tokens: normalized.total_tokens
       };
+      const computedMetrics = computeItemMetrics({
+        requestedMetrics,
+        timing: baseMetrics,
+        answerText: normalized.answer_text,
+        toolCalls: normalized.tool_calls,
+        item: executable.item
+      });
+      const metrics = { ...baseMetrics, ...computedMetrics };
       const errorCode = response.ok ? null : `http_${response.status}`;
       if (!errorCode) {
         return {
@@ -784,6 +820,8 @@ export async function runBenchmarkInstantiation(instantiationId: string) {
   const items = resolveBenchmarkDatasetItems(record.document);
   const stages = stagesFromInstantiation(record.document);
   const policy = parseExecutionPolicy(record.document);
+  const requestedMetrics = templateMetricsFromInstantiation(record.document);
+  const requestedAggregations = templateAggregationsFromInstantiation(record.document);
   const server = getInferenceServerById(record.server_id);
   if (!server) {
     throw new BenchmarkNotFoundError(`Inference server not found: ${record.server_id}`);
@@ -811,11 +849,11 @@ export async function runBenchmarkInstantiation(instantiationId: string) {
         results.push(skippedResult(item, cancellation));
         continue;
       }
-      const execution = await executeItem(record.document, stage, item, policy, authHeaders);
+      const execution = await executeItem(record.document, stage, item, policy, authHeaders, requestedMetrics);
       results.push(execution.result);
       if (execution.rawResponse) rawResponses.push(execution.rawResponse);
       if (execution.normalizedResponse) normalizedResponses.push(execution.normalizedResponse);
-      if (execution.metrics) metricResults.push(execution.metrics);
+      if (execution.metrics && (stage.record_metrics !== false)) metricResults.push(execution.metrics);
       if (execution.error) {
         stageErrors.push(execution.error);
         errors.push(execution.error);
@@ -871,10 +909,10 @@ export async function runBenchmarkInstantiation(instantiationId: string) {
     raw_responses: rawResponses,
     normalized_responses: normalizedResponses,
     metric_results: metricResults,
-    aggregated_metrics: aggregateMetrics(metricResults),
+    aggregated_metrics: computeAggregations(metricResults, requestedAggregations, expectedSampleCount(stages, items.length)),
     errors,
     warnings,
-    metric_version: 'basic-v1',
+    metric_version: 'metrics-v1',
     normalizer_version: 'chat-v1',
     metadata: runCancelled ? { cancellation_reason: cancellation } : {}
   };
@@ -884,14 +922,4 @@ export async function runBenchmarkInstantiation(instantiationId: string) {
 
 function cryptoRandomId(): string {
   return crypto.randomUUID();
-}
-
-function aggregateMetrics(metrics: Record<string, unknown>[]): Record<string, unknown> {
-  const elapsed = metrics.map((metric) => metric.elapsed_ms).filter((value): value is number => typeof value === 'number');
-  const outputTokens = metrics.map((metric) => metric.output_tokens).filter((value): value is number => typeof value === 'number');
-  return {
-    count: metrics.length,
-    elapsed_ms_mean: elapsed.length > 0 ? elapsed.reduce((sum, value) => sum + value, 0) / elapsed.length : null,
-    output_tokens_sum: outputTokens.length > 0 ? outputTokens.reduce((sum, value) => sum + value, 0) : null
-  };
 }

--- a/backend/tests/integration/benchmark-runner.test.ts
+++ b/backend/tests/integration/benchmark-runner.test.ts
@@ -348,7 +348,8 @@ describe('benchmark runner API', () => {
     expect(result.document.raw_responses).toHaveLength(1);
     expect(result.document.normalized_responses[0].answer_text).toBe('benchmark answer');
     expect(result.document.metric_results[0].total_tokens).toBe(7);
-    expect(result.document.aggregated_metrics.count).toBe(1);
+    expect(result.document.metric_version).toBe('metrics-v1');
+    expect(result.document.aggregated_metrics.elapsed_ms.valid_sample_count).toBe(1);
     expect(mockServer.requests).toHaveLength(1);
     expect((mockServer.requests[0] as Record<string, unknown>).model).toBe('mock-chat');
 
@@ -673,7 +674,7 @@ describe('benchmark runner API', () => {
     const result = runResponse.json();
     expect(result.document.status).toBe('completed');
     expect(result.document.metric_results).toHaveLength(2);
-    expect(result.document.aggregated_metrics.count).toBe(2);
+    expect(result.document.aggregated_metrics.elapsed_ms.valid_sample_count).toBe(2);
     expect(mockServer.requests).toHaveLength(2);
     await app.close();
   });

--- a/backend/tests/unit/benchmark-metrics.test.ts
+++ b/backend/tests/unit/benchmark-metrics.test.ts
@@ -1,0 +1,512 @@
+import { describe, expect, it } from 'vitest';
+
+import { aggregateMetrics, computeItemMetrics } from '../../src/services/benchmark-metrics.js';
+
+const BASE_TIMING = {
+  elapsed_ms: 1000,
+  first_token_ms: 100,
+  input_tokens: 10,
+  output_tokens: 20,
+  total_tokens: 30
+};
+
+describe('computeItemMetrics', () => {
+  describe('timing metrics — passthrough', () => {
+    it('returns timing values when requested', () => {
+      const result = computeItemMetrics({
+        requestedMetrics: ['elapsed_ms', 'first_token_ms', 'input_tokens', 'output_tokens', 'total_tokens'],
+        timing: BASE_TIMING,
+        answerText: 'hello',
+        toolCalls: null,
+        item: {}
+      });
+      expect(result.elapsed_ms).toBe(1000);
+      expect(result.first_token_ms).toBe(100);
+      expect(result.input_tokens).toBe(10);
+      expect(result.output_tokens).toBe(20);
+      expect(result.total_tokens).toBe(30);
+    });
+
+    it('returns null when timing values are null', () => {
+      const result = computeItemMetrics({
+        requestedMetrics: ['first_token_ms'],
+        timing: { ...BASE_TIMING, first_token_ms: null },
+        answerText: '',
+        toolCalls: null,
+        item: {}
+      });
+      expect(result.first_token_ms).toBeNull();
+    });
+
+    it('only computes requested metrics', () => {
+      const result = computeItemMetrics({
+        requestedMetrics: ['elapsed_ms'],
+        timing: BASE_TIMING,
+        answerText: '',
+        toolCalls: null,
+        item: {}
+      });
+      expect(result.elapsed_ms).toBe(1000);
+      expect(result.input_tokens).toBeUndefined();
+    });
+  });
+
+  describe('derived numeric metrics', () => {
+    it('computes tokens_per_second', () => {
+      const result = computeItemMetrics({
+        requestedMetrics: ['tokens_per_second'],
+        timing: { ...BASE_TIMING, output_tokens: 60, elapsed_ms: 2000 },
+        answerText: '',
+        toolCalls: null,
+        item: {}
+      });
+      expect(result.tokens_per_second).toBeCloseTo(30);
+    });
+
+    it('tokens_per_second is null when elapsed_ms is 0', () => {
+      const result = computeItemMetrics({
+        requestedMetrics: ['tokens_per_second'],
+        timing: { ...BASE_TIMING, elapsed_ms: 0 },
+        answerText: '',
+        toolCalls: null,
+        item: {}
+      });
+      expect(result.tokens_per_second).toBeNull();
+    });
+
+    it('tokens_per_second is null when output_tokens is null', () => {
+      const result = computeItemMetrics({
+        requestedMetrics: ['tokens_per_second'],
+        timing: { ...BASE_TIMING, output_tokens: null },
+        answerText: '',
+        toolCalls: null,
+        item: {}
+      });
+      expect(result.tokens_per_second).toBeNull();
+    });
+
+    it('computes output_input_token_ratio', () => {
+      const result = computeItemMetrics({
+        requestedMetrics: ['output_input_token_ratio'],
+        timing: { ...BASE_TIMING, output_tokens: 20, input_tokens: 10 },
+        answerText: '',
+        toolCalls: null,
+        item: {}
+      });
+      expect(result.output_input_token_ratio).toBeCloseTo(2);
+    });
+
+    it('output_input_token_ratio is null when input_tokens is 0', () => {
+      const result = computeItemMetrics({
+        requestedMetrics: ['output_input_token_ratio'],
+        timing: { ...BASE_TIMING, input_tokens: 0 },
+        answerText: '',
+        toolCalls: null,
+        item: {}
+      });
+      expect(result.output_input_token_ratio).toBeNull();
+    });
+  });
+
+  describe('correctness metrics', () => {
+    it('exact_match: true when trimmed strings match', () => {
+      const result = computeItemMetrics({
+        requestedMetrics: ['exact_match'],
+        timing: BASE_TIMING,
+        answerText: '  hello  ',
+        toolCalls: null,
+        item: { expected_answer: 'hello' }
+      });
+      expect(result.exact_match).toBe(true);
+    });
+
+    it('exact_match: false when strings differ', () => {
+      const result = computeItemMetrics({
+        requestedMetrics: ['exact_match'],
+        timing: BASE_TIMING,
+        answerText: 'hello',
+        toolCalls: null,
+        item: { expected_answer: 'world' }
+      });
+      expect(result.exact_match).toBe(false);
+    });
+
+    it('exact_match: null when expected_answer is not a string', () => {
+      const result = computeItemMetrics({
+        requestedMetrics: ['exact_match'],
+        timing: BASE_TIMING,
+        answerText: 'hello',
+        toolCalls: null,
+        item: {}
+      });
+      expect(result.exact_match).toBeNull();
+    });
+
+    it('contains_required_terms: true for string substring match', () => {
+      const result = computeItemMetrics({
+        requestedMetrics: ['contains_required_terms'],
+        timing: BASE_TIMING,
+        answerText: 'The quick brown fox',
+        toolCalls: null,
+        item: { expected_answer: 'brown' }
+      });
+      expect(result.contains_required_terms).toBe(true);
+    });
+
+    it('contains_required_terms: case-insensitive', () => {
+      const result = computeItemMetrics({
+        requestedMetrics: ['contains_required_terms'],
+        timing: BASE_TIMING,
+        answerText: 'The Quick Brown Fox',
+        toolCalls: null,
+        item: { expected_answer: 'quick brown' }
+      });
+      expect(result.contains_required_terms).toBe(true);
+    });
+
+    it('contains_required_terms: all array terms must be present', () => {
+      const result = computeItemMetrics({
+        requestedMetrics: ['contains_required_terms'],
+        timing: BASE_TIMING,
+        answerText: 'alpha beta gamma',
+        toolCalls: null,
+        item: { expected_answer: ['alpha', 'beta', 'delta'] }
+      });
+      expect(result.contains_required_terms).toBe(false);
+    });
+
+    it('contains_required_terms: null when expected_answer absent', () => {
+      const result = computeItemMetrics({
+        requestedMetrics: ['contains_required_terms'],
+        timing: BASE_TIMING,
+        answerText: 'hello',
+        toolCalls: null,
+        item: {}
+      });
+      expect(result.contains_required_terms).toBeNull();
+    });
+
+    it('json_valid: true for valid JSON', () => {
+      const result = computeItemMetrics({
+        requestedMetrics: ['json_valid'],
+        timing: BASE_TIMING,
+        answerText: '{"key": "value"}',
+        toolCalls: null,
+        item: {}
+      });
+      expect(result.json_valid).toBe(true);
+    });
+
+    it('json_valid: false for invalid JSON', () => {
+      const result = computeItemMetrics({
+        requestedMetrics: ['json_valid'],
+        timing: BASE_TIMING,
+        answerText: 'not json',
+        toolCalls: null,
+        item: {}
+      });
+      expect(result.json_valid).toBe(false);
+    });
+
+    it('json_valid: null for empty answer', () => {
+      const result = computeItemMetrics({
+        requestedMetrics: ['json_valid'],
+        timing: BASE_TIMING,
+        answerText: '',
+        toolCalls: null,
+        item: {}
+      });
+      expect(result.json_valid).toBeNull();
+    });
+
+    it('schema_valid: true when answer matches expected_schema', () => {
+      const result = computeItemMetrics({
+        requestedMetrics: ['schema_valid'],
+        timing: BASE_TIMING,
+        answerText: '{"name": "Alice", "age": 30}',
+        toolCalls: null,
+        item: {
+          expected_schema: {
+            type: 'object',
+            properties: { name: { type: 'string' }, age: { type: 'number' } },
+            required: ['name', 'age']
+          }
+        }
+      });
+      expect(result.schema_valid).toBe(true);
+    });
+
+    it('schema_valid: false when answer fails schema', () => {
+      const result = computeItemMetrics({
+        requestedMetrics: ['schema_valid'],
+        timing: BASE_TIMING,
+        answerText: '{"name": "Alice"}',
+        toolCalls: null,
+        item: {
+          expected_schema: {
+            type: 'object',
+            required: ['name', 'age']
+          }
+        }
+      });
+      expect(result.schema_valid).toBe(false);
+    });
+
+    it('schema_valid: null when no expected_schema', () => {
+      const result = computeItemMetrics({
+        requestedMetrics: ['schema_valid'],
+        timing: BASE_TIMING,
+        answerText: '{}',
+        toolCalls: null,
+        item: {}
+      });
+      expect(result.schema_valid).toBeNull();
+    });
+
+    it('regex_match: true when answer matches regex', () => {
+      const result = computeItemMetrics({
+        requestedMetrics: ['regex_match'],
+        timing: BASE_TIMING,
+        answerText: 'hello world',
+        toolCalls: null,
+        item: { expected_format: 'regex', expected_answer: '^hello' }
+      });
+      expect(result.regex_match).toBe(true);
+    });
+
+    it('regex_match: false when answer does not match regex', () => {
+      const result = computeItemMetrics({
+        requestedMetrics: ['regex_match'],
+        timing: BASE_TIMING,
+        answerText: 'goodbye world',
+        toolCalls: null,
+        item: { expected_format: 'regex', expected_answer: '^hello' }
+      });
+      expect(result.regex_match).toBe(false);
+    });
+
+    it('regex_match: null when expected_format is not regex', () => {
+      const result = computeItemMetrics({
+        requestedMetrics: ['regex_match'],
+        timing: BASE_TIMING,
+        answerText: 'hello',
+        toolCalls: null,
+        item: { expected_format: 'free_text', expected_answer: 'hello' }
+      });
+      expect(result.regex_match).toBeNull();
+    });
+  });
+
+  describe('tool-call metrics', () => {
+    const toolCalls = [
+      { function: { name: 'get_weather', arguments: '{"city": "Paris"}' } }
+    ];
+    const expectedCalls = [{ name: 'get_weather', arguments: { city: 'Paris' } }];
+
+    it('tool_call_count', () => {
+      const result = computeItemMetrics({
+        requestedMetrics: ['tool_call_count'],
+        timing: BASE_TIMING,
+        answerText: '',
+        toolCalls,
+        item: {}
+      });
+      expect(result.tool_call_count).toBe(1);
+    });
+
+    it('tool_call_count is null when tool_calls is null', () => {
+      const result = computeItemMetrics({
+        requestedMetrics: ['tool_call_count'],
+        timing: BASE_TIMING,
+        answerText: '',
+        toolCalls: null,
+        item: {}
+      });
+      expect(result.tool_call_count).toBeNull();
+    });
+
+    it('tool_selected_correctly: true when expected name is in actual calls', () => {
+      const result = computeItemMetrics({
+        requestedMetrics: ['tool_selected_correctly'],
+        timing: BASE_TIMING,
+        answerText: '',
+        toolCalls,
+        item: { expected_tool_calls: expectedCalls }
+      });
+      expect(result.tool_selected_correctly).toBe(true);
+    });
+
+    it('tool_selected_correctly: false when wrong tool called', () => {
+      const result = computeItemMetrics({
+        requestedMetrics: ['tool_selected_correctly'],
+        timing: BASE_TIMING,
+        answerText: '',
+        toolCalls: [{ function: { name: 'wrong_tool', arguments: '{}' } }],
+        item: { expected_tool_calls: expectedCalls }
+      });
+      expect(result.tool_selected_correctly).toBe(false);
+    });
+
+    it('tool_selected_correctly: null when no expected_tool_calls', () => {
+      const result = computeItemMetrics({
+        requestedMetrics: ['tool_selected_correctly'],
+        timing: BASE_TIMING,
+        answerText: '',
+        toolCalls,
+        item: {}
+      });
+      expect(result.tool_selected_correctly).toBeNull();
+    });
+
+    it('missing_tool_call: true when expected call not made', () => {
+      const result = computeItemMetrics({
+        requestedMetrics: ['missing_tool_call'],
+        timing: BASE_TIMING,
+        answerText: '',
+        toolCalls: [],
+        item: { expected_tool_calls: expectedCalls }
+      });
+      expect(result.missing_tool_call).toBe(true);
+    });
+
+    it('missing_tool_call: false when all expected calls made', () => {
+      const result = computeItemMetrics({
+        requestedMetrics: ['missing_tool_call'],
+        timing: BASE_TIMING,
+        answerText: '',
+        toolCalls,
+        item: { expected_tool_calls: expectedCalls }
+      });
+      expect(result.missing_tool_call).toBe(false);
+    });
+
+    it('hallucinated_tool_call: true when extra call not in expected', () => {
+      const result = computeItemMetrics({
+        requestedMetrics: ['hallucinated_tool_call'],
+        timing: BASE_TIMING,
+        answerText: '',
+        toolCalls: [
+          { function: { name: 'get_weather', arguments: '{}' } },
+          { function: { name: 'extra_tool', arguments: '{}' } }
+        ],
+        item: { expected_tool_calls: expectedCalls }
+      });
+      expect(result.hallucinated_tool_call).toBe(true);
+    });
+
+    it('hallucinated_tool_call: false when all calls are expected', () => {
+      const result = computeItemMetrics({
+        requestedMetrics: ['hallucinated_tool_call'],
+        timing: BASE_TIMING,
+        answerText: '',
+        toolCalls,
+        item: { expected_tool_calls: expectedCalls }
+      });
+      expect(result.hallucinated_tool_call).toBe(false);
+    });
+  });
+});
+
+describe('aggregateMetrics', () => {
+  it('computes all numeric stats for a single metric', () => {
+    const results = [
+      { elapsed_ms: 100 },
+      { elapsed_ms: 200 },
+      { elapsed_ms: 300 }
+    ];
+    const agg = aggregateMetrics(results, ['mean', 'min', 'max', 'sum', 'count', 'stddev'], 3);
+    expect(agg.elapsed_ms.mean).toBeCloseTo(200);
+    expect(agg.elapsed_ms.min).toBe(100);
+    expect(agg.elapsed_ms.max).toBe(300);
+    expect(agg.elapsed_ms.sum).toBe(600);
+    expect(agg.elapsed_ms.count).toBe(3);
+    expect(agg.elapsed_ms.valid_sample_count).toBe(3);
+  });
+
+  it('computes percentiles via linear interpolation', () => {
+    const values = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    const results = values.map((v) => ({ elapsed_ms: v }));
+    const agg = aggregateMetrics(results, ['p50', 'p90', 'p95', 'p99', 'median'], 10);
+    expect(agg.elapsed_ms.p50).toBeCloseTo(5.5);
+    expect(agg.elapsed_ms.p90).toBeCloseTo(9.1);
+    expect(agg.elapsed_ms.p95).toBeCloseTo(9.55);
+    expect(agg.elapsed_ms.p99).toBeCloseTo(9.91);
+    expect(agg.elapsed_ms.median).toBeCloseTo(5.5);
+  });
+
+  it('p50 on single value returns that value', () => {
+    const agg = aggregateMetrics([{ elapsed_ms: 42 }], ['p50'], 1);
+    expect(agg.elapsed_ms.p50).toBe(42);
+  });
+
+  it('computes variance', () => {
+    const results = [{ v: 2 }, { v: 4 }, { v: 4 }, { v: 4 }, { v: 5 }, { v: 5 }, { v: 7 }, { v: 9 }];
+    const agg = aggregateMetrics(results, ['variance', 'stddev'], 8);
+    expect(agg.v.variance).toBeCloseTo(4);
+    expect(agg.v.stddev).toBeCloseTo(2);
+  });
+
+  it('converts boolean metrics to success_rate', () => {
+    const results = [
+      { exact_match: true },
+      { exact_match: true },
+      { exact_match: false }
+    ];
+    const agg = aggregateMetrics(results, ['mean'], 3);
+    expect(agg.exact_match.success_rate).toBeCloseTo(2 / 3);
+    expect(agg.exact_match.count).toBe(3);
+    expect(agg.exact_match.valid_sample_count).toBe(3);
+  });
+
+  it('excludes meta fields (stage_id, item_index, iteration)', () => {
+    const results = [
+      { stage_id: 'chat', item_index: 0, iteration: 0, elapsed_ms: 100 }
+    ];
+    const agg = aggregateMetrics(results, ['mean'], 1);
+    expect(agg.stage_id).toBeUndefined();
+    expect(agg.item_index).toBeUndefined();
+    expect(agg.iteration).toBeUndefined();
+    expect(agg.elapsed_ms).toBeDefined();
+  });
+
+  it('adds partial_execution fields when valid_sample_count < expectedSampleCount', () => {
+    const results = [{ elapsed_ms: 100 }];
+    const agg = aggregateMetrics(results, ['mean'], 5);
+    expect(agg.elapsed_ms.partial_execution).toBe(true);
+    expect(agg.elapsed_ms.expected_sample_count).toBe(5);
+    expect(agg.elapsed_ms.missing_sample_count).toBe(4);
+  });
+
+  it('no partial_execution fields when counts match', () => {
+    const results = [{ elapsed_ms: 100 }, { elapsed_ms: 200 }];
+    const agg = aggregateMetrics(results, ['mean'], 2);
+    expect(agg.elapsed_ms.partial_execution).toBeUndefined();
+  });
+
+  it('null metric values are excluded from valid_sample_count', () => {
+    const results = [
+      { tokens_per_second: 50 },
+      { tokens_per_second: null as unknown as number },
+      { tokens_per_second: 100 }
+    ];
+    const agg = aggregateMetrics(results, ['mean'], 3);
+    expect(agg.tokens_per_second.valid_sample_count).toBe(2);
+    expect(agg.tokens_per_second.count).toBe(3);
+    expect(agg.tokens_per_second.mean).toBeCloseTo(75);
+  });
+
+  it('returns empty object for empty metric results', () => {
+    const agg = aggregateMetrics([], ['mean'], 0);
+    expect(Object.keys(agg)).toHaveLength(0);
+  });
+
+  it('handles multiple metrics in same result set', () => {
+    const results = [
+      { elapsed_ms: 100, output_tokens: 10 },
+      { elapsed_ms: 200, output_tokens: 20 }
+    ];
+    const agg = aggregateMetrics(results, ['mean', 'sum'], 2);
+    expect(agg.elapsed_ms.mean).toBeCloseTo(150);
+    expect(agg.output_tokens.sum).toBe(30);
+  });
+});

--- a/frontend/src/pages/RunUnified.tsx
+++ b/frontend/src/pages/RunUnified.tsx
@@ -110,6 +110,43 @@ function benchmarkMetrics(result: BenchmarkResultRecord | null): Record<string, 
   };
 }
 
+function aggStat(result: BenchmarkResultRecord | null, metric: string, stat: string): number | null {
+  const agg = result?.document.aggregated_metrics as Record<string, Record<string, unknown>> | undefined;
+  const entry = agg?.[metric];
+  const value = entry?.[stat];
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+interface CorrectnessMetric {
+  label: string;
+  successRate: number;
+  count: number;
+}
+
+const CORRECTNESS_METRIC_LABELS: Record<string, string> = {
+  exact_match: 'exact match',
+  json_valid: 'JSON valid',
+  schema_valid: 'schema valid',
+  regex_match: 'regex match',
+  contains_required_terms: 'terms found',
+  tool_selected_correctly: 'tool selected',
+  tool_arguments_valid: 'tool args valid',
+  missing_tool_call: 'missing tool',
+  hallucinated_tool_call: 'hallucinated tool'
+};
+
+function correctnessMetrics(result: BenchmarkResultRecord | null): CorrectnessMetric[] {
+  const agg = result?.document.aggregated_metrics as Record<string, Record<string, unknown>> | undefined;
+  if (!agg) return [];
+  return Object.entries(agg)
+    .filter(([key, entry]) => key in CORRECTNESS_METRIC_LABELS && typeof entry?.success_rate === 'number')
+    .map(([key, entry]) => ({
+      label: CORRECTNESS_METRIC_LABELS[key] ?? key,
+      successRate: entry.success_rate as number,
+      count: typeof entry.count === 'number' ? entry.count : 0
+    }));
+}
+
 function streamSummary(result: BenchmarkResultRecord | null): string {
   const responses = normalizedResponseItems(result);
   const streams = responses
@@ -437,6 +474,10 @@ function BenchmarkDetail({
   const status = resultStatus(result, busy);
   const manifest = datasetManifest(instantiation);
   const responses = normalizedResponseItems(result);
+  const itemCount = aggStat(result, 'elapsed_ms', 'count');
+  const tokensPerSec = aggStat(result, 'tokens_per_second', 'mean');
+  const latencyP95 = aggStat(result, 'elapsed_ms', 'p95');
+  const correctness = correctnessMetrics(result);
   return (
     <div className="run-single-detail">
       <main className="run-transcript">
@@ -505,7 +546,32 @@ function BenchmarkDetail({
           <span><b>tokens out</b>{formatNumber(metrics.output_tokens)}</span>
           <span><b>total tokens</b>{formatNumber(metrics.total_tokens)}</span>
           <span><b>stream</b>{streamSummary(result)}</span>
+          {tokensPerSec !== null && (
+            <span><b>tok / s</b>{formatMetric(tokensPerSec, 'tok/s')}</span>
+          )}
+          {latencyP95 !== null && itemCount !== null && itemCount > 1 && (
+            <span><b>latency p95</b>{formatMetric(latencyP95)}</span>
+          )}
+          {itemCount !== null && itemCount > 1 && (
+            <span><b>items</b>{String(itemCount)}</span>
+          )}
         </div>
+        {correctness.length > 0 && (
+          <>
+            <h3 style={{ marginTop: '16px' }}>Correctness</h3>
+            <div className="run-metric-grid">
+              {correctness.map(({ label, successRate, count }) => (
+                <span key={label}>
+                  <b>{label}</b>
+                  {`${(successRate * 100).toFixed(0)}%`}
+                  <span style={{ display: 'block', color: 'var(--ink-3)', fontSize: '9px' }}>
+                    {`${Math.round(successRate * count)} / ${count}`}
+                  </span>
+                </span>
+              ))}
+            </div>
+          </>
+        )}
         <details>
           <summary>Raw benchmark result</summary>
           <pre>{JSON.stringify(result ?? instantiation ?? {}, null, 2)}</pre>

--- a/frontend/src/services/benchmark-api.ts
+++ b/frontend/src/services/benchmark-api.ts
@@ -158,8 +158,8 @@ export function buildBenchmarkSmokePayload(input: BuildBenchmarkSmokeInput): Cre
           stop_on_error: false
         }
       ],
-      metrics: ['input_tokens', 'output_tokens', 'total_tokens', 'elapsed_ms', 'first_token_ms'],
-      aggregations: ['mean']
+      metrics: ['input_tokens', 'output_tokens', 'total_tokens', 'elapsed_ms', 'first_token_ms', 'tokens_per_second'],
+      aggregations: ['mean', 'p95', 'count']
     },
     server_id: input.target.inference_server_id,
     model_id: input.target.model_id,


### PR DESCRIPTION
Replace the stub aggregator (count/elapsed_ms_mean/output_tokens_sum) with a template-driven metrics layer.

New benchmark-metrics service computes per-item metrics (tokens_per_second, ratios, exact_match, json/schema/regex validity, tool-call metrics) and run-level aggregations (mean/median/min/max/sum/ count/p50-p99/stddev/variance), with boolean metrics surfaced as success_rate and partial-execution sample accounting. Normalizer now surfaces tool_calls. metric_version bumped to metrics-v1.

Run page metrics panel shows tokens/s, latency p95 and item count for multi-item runs, plus a correctness section when requested.