### PR TITLE
feat(run): editable generation params and decode-aware throughput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,16 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 ### Added
 
 - **Benchmark metrics & aggregation** — new `benchmark-metrics` service computing the full schema-advertised metric set per item (`tokens_per_second`, `output_input_token_ratio`, `exact_match`, `contains_required_terms`, `json_valid`, `schema_valid`, `regex_match`, and tool-call metrics) plus run-level aggregations (`mean`/`median`/`min`/`max`/`sum`/`count`/`p50`/`p90`/`p95`/`p99`/`stddev`/`variance`), with boolean metrics surfaced as `success_rate` and partial-execution sample accounting.
-- Run page right-side metrics panel now shows tokens-per-second, latency `p95` and item count for multi-item runs, and a correctness section (per-metric success rate) when the template requests correctness metrics.
+- Run page right-side metrics panel now shows tokens-per-second, duration `p95` and item count for multi-item runs, and a correctness section (per-metric success rate) when the template requests correctness metrics.
+- Generation parameters (temperature, top_p, max_tokens, stream) editable inline in the Run page Step 4 options grid; previously hardcoded to defaults.
+- Decode-aware throughput metrics `decode_tokens_per_second` (`output_tokens / (elapsed_ms − first_token_ms)`) and `prefill_tokens_per_second` (`input_tokens / first_token_ms`), isolating generation speed from prompt prefill on streaming runs; both null on non-streaming runs. Metrics panel shows decode / overall / prefill tok/s separately.
 
 ### Changed
 
 - Benchmark runner replaces the stub aggregator (`count`/`elapsed_ms_mean`/`output_tokens_sum`) with template-driven metric computation and aggregation; `metric_version` bumped from `basic-v1` to `metrics-v1`.
 - Response normalizer now surfaces `tool_calls` so tool-call metrics can be computed.
-- Run page smoke template requests `tokens_per_second` and `p95`/`count` aggregations.
+- Run page smoke template requests `tokens_per_second`, `decode_tokens_per_second`, `prefill_tokens_per_second`, and `p95`/`count` aggregations.
+- Run page metrics panel labels clarified: `latency` → `duration` (total request time, distinct from `ttft`).
 
 ## [0.5.0] - 2026-06-08
 

--- a/backend/src/schemas/benchmark/test_template.schema.json
+++ b/backend/src/schemas/benchmark/test_template.schema.json
@@ -68,6 +68,8 @@
           "elapsed_ms",
           "first_token_ms",
           "tokens_per_second",
+          "decode_tokens_per_second",
+          "prefill_tokens_per_second",
           "output_input_token_ratio",
           "tool_call_count",
           "tool_selected_correctly",

--- a/backend/src/services/benchmark-metrics.ts
+++ b/backend/src/services/benchmark-metrics.ts
@@ -46,6 +46,24 @@ export function computeItemMetrics(args: ItemMetricInputs): Record<string, numbe
         result.tokens_per_second = out !== null && ms !== null && ms > 0 ? out / (ms / 1000) : null;
         break;
       }
+      case 'decode_tokens_per_second': {
+        const out = timing.output_tokens;
+        const ms = timing.elapsed_ms;
+        const ttft = timing.first_token_ms;
+        const decodeMs = ms !== null && ttft !== null ? ms - ttft : null;
+        result.decode_tokens_per_second = out !== null && decodeMs !== null && decodeMs > 0
+          ? out / (decodeMs / 1000)
+          : null;
+        break;
+      }
+      case 'prefill_tokens_per_second': {
+        const inp = timing.input_tokens;
+        const ttft = timing.first_token_ms;
+        result.prefill_tokens_per_second = inp !== null && ttft !== null && ttft > 0
+          ? inp / (ttft / 1000)
+          : null;
+        break;
+      }
       case 'output_input_token_ratio': {
         const out = timing.output_tokens;
         const inp = timing.input_tokens;

--- a/backend/tests/unit/benchmark-metrics.test.ts
+++ b/backend/tests/unit/benchmark-metrics.test.ts
@@ -85,6 +85,63 @@ describe('computeItemMetrics', () => {
       expect(result.tokens_per_second).toBeNull();
     });
 
+    it('computes decode_tokens_per_second using the post-ttft window', () => {
+      const result = computeItemMetrics({
+        requestedMetrics: ['decode_tokens_per_second'],
+        timing: { ...BASE_TIMING, output_tokens: 90, elapsed_ms: 2000, first_token_ms: 500 },
+        answerText: '',
+        toolCalls: null,
+        item: {}
+      });
+      // 90 tokens over (2000 - 500) = 1500ms => 60 tok/s
+      expect(result.decode_tokens_per_second).toBeCloseTo(60);
+    });
+
+    it('decode_tokens_per_second is null when first_token_ms is missing (non-streaming)', () => {
+      const result = computeItemMetrics({
+        requestedMetrics: ['decode_tokens_per_second'],
+        timing: { ...BASE_TIMING, first_token_ms: null },
+        answerText: '',
+        toolCalls: null,
+        item: {}
+      });
+      expect(result.decode_tokens_per_second).toBeNull();
+    });
+
+    it('decode_tokens_per_second is null when decode window is non-positive', () => {
+      const result = computeItemMetrics({
+        requestedMetrics: ['decode_tokens_per_second'],
+        timing: { ...BASE_TIMING, elapsed_ms: 500, first_token_ms: 500 },
+        answerText: '',
+        toolCalls: null,
+        item: {}
+      });
+      expect(result.decode_tokens_per_second).toBeNull();
+    });
+
+    it('computes prefill_tokens_per_second from input tokens over ttft', () => {
+      const result = computeItemMetrics({
+        requestedMetrics: ['prefill_tokens_per_second'],
+        timing: { ...BASE_TIMING, input_tokens: 100, first_token_ms: 250 },
+        answerText: '',
+        toolCalls: null,
+        item: {}
+      });
+      // 100 tokens over 250ms => 400 tok/s
+      expect(result.prefill_tokens_per_second).toBeCloseTo(400);
+    });
+
+    it('prefill_tokens_per_second is null when first_token_ms is missing', () => {
+      const result = computeItemMetrics({
+        requestedMetrics: ['prefill_tokens_per_second'],
+        timing: { ...BASE_TIMING, first_token_ms: null },
+        answerText: '',
+        toolCalls: null,
+        item: {}
+      });
+      expect(result.prefill_tokens_per_second).toBeNull();
+    });
+
     it('computes output_input_token_ratio', () => {
       const result = computeItemMetrics({
         requestedMetrics: ['output_input_token_ratio'],

--- a/frontend/src/pages/RunUnified.tsx
+++ b/frontend/src/pages/RunUnified.tsx
@@ -13,7 +13,7 @@ import {
   type BenchmarkResultRecord
 } from '../services/benchmark-api.js';
 import type { InferenceServerHealth } from '../services/connectivity-api.js';
-import { DEFAULT_INFERENCE_PARAMS } from '../services/inference-param-presets-api.js';
+import { DEFAULT_INFERENCE_PARAMS, type InferenceParams } from '../services/inference-param-presets-api.js';
 import { InferenceServerRecord, listInferenceServers } from '../services/inference-servers-api.js';
 import { listModels, ModelRecord } from '../services/models-api.js';
 import {
@@ -194,11 +194,13 @@ function ConfigRail({
   datasetId,
   datasetFormat,
   datasetPath,
+  inferenceParams,
   onAddTarget,
   onRemoveTarget,
   onCustomServerChange,
   onTimeoutChange,
   onSeedChange,
+  onInferenceParamsChange,
   onPromptChange,
   onSystemPromptChange,
   onDatasetModeChange,
@@ -221,11 +223,13 @@ function ConfigRail({
   datasetId: string;
   datasetFormat: BenchmarkDatasetFormat;
   datasetPath: string;
+  inferenceParams: InferenceParams;
   onAddTarget: (target: RunTarget) => void;
   onRemoveTarget: (target: RunTarget) => void;
   onCustomServerChange: (value: string) => void;
   onTimeoutChange: (value: string) => void;
   onSeedChange: (value: string) => void;
+  onInferenceParamsChange: (params: InferenceParams) => void;
   onPromptChange: (value: string) => void;
   onSystemPromptChange: (value: string) => void;
   onDatasetModeChange: (value: RunDatasetMode) => void;
@@ -398,6 +402,59 @@ function ConfigRail({
             Seed
             <input value={seed} onChange={(event) => onSeedChange(event.target.value)} />
           </label>
+          <label>
+            Temperature
+            <input
+              type="number"
+              step="0.01"
+              min="0"
+              max="2"
+              value={inferenceParams.temperature ?? ''}
+              onChange={(event) => onInferenceParamsChange({
+                ...inferenceParams,
+                temperature: event.target.value ? Number(event.target.value) : null
+              })}
+            />
+          </label>
+          <label>
+            Top P
+            <input
+              type="number"
+              step="0.01"
+              min="0"
+              max="1"
+              value={inferenceParams.top_p ?? ''}
+              onChange={(event) => onInferenceParamsChange({
+                ...inferenceParams,
+                top_p: event.target.value ? Number(event.target.value) : null
+              })}
+            />
+          </label>
+          <label>
+            Max tokens
+            <input
+              type="number"
+              min="1"
+              value={inferenceParams.max_tokens ?? ''}
+              onChange={(event) => onInferenceParamsChange({
+                ...inferenceParams,
+                max_tokens: event.target.value ? Number(event.target.value) : null
+              })}
+            />
+          </label>
+          <label>
+            Stream
+            <select
+              value={inferenceParams.stream ? 'true' : 'false'}
+              onChange={(event) => onInferenceParamsChange({
+                ...inferenceParams,
+                stream: event.target.value === 'true'
+              })}
+            >
+              <option value="false">false</option>
+              <option value="true">true</option>
+            </select>
+          </label>
         </div>
       </div>
 
@@ -476,6 +533,8 @@ function BenchmarkDetail({
   const responses = normalizedResponseItems(result);
   const itemCount = aggStat(result, 'elapsed_ms', 'count');
   const tokensPerSec = aggStat(result, 'tokens_per_second', 'mean');
+  const decodeTokensPerSec = aggStat(result, 'decode_tokens_per_second', 'mean');
+  const prefillTokensPerSec = aggStat(result, 'prefill_tokens_per_second', 'mean');
   const latencyP95 = aggStat(result, 'elapsed_ms', 'p95');
   const correctness = correctnessMetrics(result);
   return (
@@ -540,17 +599,23 @@ function BenchmarkDetail({
       <aside className="run-side-metrics">
         <h3>Metrics</h3>
         <div className="run-metric-grid">
-          <span><b>latency</b>{formatMetric(metrics.elapsed_ms)}</span>
+          <span><b>duration</b>{formatMetric(metrics.elapsed_ms)}</span>
           <span><b>ttft</b>{formatMetric(metrics.first_token_ms)}</span>
           <span><b>tokens in</b>{formatNumber(metrics.input_tokens)}</span>
           <span><b>tokens out</b>{formatNumber(metrics.output_tokens)}</span>
           <span><b>total tokens</b>{formatNumber(metrics.total_tokens)}</span>
           <span><b>stream</b>{streamSummary(result)}</span>
+          {decodeTokensPerSec !== null && (
+            <span><b>tok / s (decode)</b>{formatMetric(decodeTokensPerSec, 'tok/s')}</span>
+          )}
           {tokensPerSec !== null && (
-            <span><b>tok / s</b>{formatMetric(tokensPerSec, 'tok/s')}</span>
+            <span><b>tok / s (overall)</b>{formatMetric(tokensPerSec, 'tok/s')}</span>
+          )}
+          {prefillTokensPerSec !== null && (
+            <span><b>prefill tok / s</b>{formatMetric(prefillTokensPerSec, 'tok/s')}</span>
           )}
           {latencyP95 !== null && itemCount !== null && itemCount > 1 && (
-            <span><b>latency p95</b>{formatMetric(latencyP95)}</span>
+            <span><b>duration p95</b>{formatMetric(latencyP95)}</span>
           )}
           {itemCount !== null && itemCount > 1 && (
             <span><b>items</b>{String(itemCount)}</span>
@@ -599,7 +664,7 @@ export function RunUnified({ connectivitySnapshot = {} }: { connectivitySnapshot
   const [datasetId, setDatasetId] = useState('codegen-small');
   const [datasetFormat, setDatasetFormat] = useState<BenchmarkDatasetFormat>('jsonl');
   const [datasetPath, setDatasetPath] = useState('codegen-small.jsonl');
-  const inferenceParams = DEFAULT_INFERENCE_PARAMS;
+  const [inferenceParams, setInferenceParams] = useState<InferenceParams>(DEFAULT_INFERENCE_PARAMS);
   const [instantiation, setInstantiation] = useState<BenchmarkInstantiationRecord | null>(null);
   const [result, setResult] = useState<BenchmarkResultRecord | null>(null);
   const [busy, setBusy] = useState(false);
@@ -740,11 +805,13 @@ export function RunUnified({ connectivitySnapshot = {} }: { connectivitySnapshot
             datasetId={datasetId}
             datasetFormat={datasetFormat}
             datasetPath={datasetPath}
+            inferenceParams={inferenceParams}
             onAddTarget={addTarget}
             onRemoveTarget={removeTarget}
             onCustomServerChange={setCustomServerId}
             onTimeoutChange={setTimeoutSec}
             onSeedChange={setSeed}
+            onInferenceParamsChange={setInferenceParams}
             onPromptChange={setPrompt}
             onSystemPromptChange={setSystemPrompt}
             onDatasetModeChange={setDatasetMode}

--- a/frontend/src/services/benchmark-api.ts
+++ b/frontend/src/services/benchmark-api.ts
@@ -158,7 +158,7 @@ export function buildBenchmarkSmokePayload(input: BuildBenchmarkSmokeInput): Cre
           stop_on_error: false
         }
       ],
-      metrics: ['input_tokens', 'output_tokens', 'total_tokens', 'elapsed_ms', 'first_token_ms', 'tokens_per_second'],
+      metrics: ['input_tokens', 'output_tokens', 'total_tokens', 'elapsed_ms', 'first_token_ms', 'tokens_per_second', 'decode_tokens_per_second', 'prefill_tokens_per_second'],
       aggregations: ['mean', 'p95', 'count']
     },
     server_id: input.target.inference_server_id,


### PR DESCRIPTION
Expose temperature, top_p, max_tokens and stream in the Run page Step 4 options grid (previously hardcoded to DEFAULT_INFERENCE_PARAMS), so a user can enable streaming and tune sampling per run.

With first_token_ms now reachable via streaming, add two throughput metrics that split prefill from decode:
- decode_tokens_per_second  = output_tokens / (elapsed_ms - first_token_ms)
- prefill_tokens_per_second = input_tokens / first_token_ms Both are null on non-streaming runs. The spec-defined wall-clock tokens_per_second is retained. Metrics panel shows decode / overall / prefill tok/s separately and relabels latency to duration.