### PR TITLE
feat(benchmark): multi-model plan runner with server timing metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 
 ## [Unreleased]
 
+### Added
+
+- **Model load time metric** — `load_duration_ms` extracted from server-native response metadata (Ollama reports exact load time in nanoseconds on every `/api/chat` and `/api/generate` response). Exposed as a first-class metric in `computeItemMetrics` and aggregated as `max` (load only fires on the cold request). Run page metrics panel shows a "model load" row when the value is non-null and > 0; hidden for servers that don't report it (llama.cpp, vLLM, TGI).
+- **Ollama protocol timing metrics** — `total_duration` (ns) feeds `server_total_time_ms` (server-measured total including load+prefill+decode); `prompt_eval_duration` (ns) → `server_prompt_eval_ms`; `eval_duration` (ns) → `server_eval_ms`. Applies to all Ollama-compatible servers (Ollama, Inferencer, etc.). Run page shows "server prefill" and "server decode" rows when non-null; server-reported, no red.
+- **oMLX native metrics** — `usage.model_load_duration` (seconds) now feeds `load_duration_ms` alongside Ollama's `load_duration` (nanoseconds); `usage.total_time` (seconds) surfaces as new `server_total_time_ms` metric representing server-measured processing time (excludes network, comparable to `elapsed_ms`). Run page shows "server time" row when non-null.
+- **Request-triggered load estimator** — `estimateRequestTriggeredLoad()` computes a heuristic `load_estimate` from ordered `metric_results` when ≥ 3 samples exist: compares first-request latency against the median of warm requests; detects a load event when the cold spike exceeds `max(50% of warm baseline, 3× warm stddev)`. Prefers `first_token_ms` over `elapsed_ms` when streaming data is present. Stored as `load_estimate` on the result document. Run page shows "model load (est.)" in **bold red** when detected and no native `load_duration_ms` is available — signals heuristic rather than server-reported value.
+
+### Fixed
+
+- Stream dropdown in Run page Step 4 options grid now matches the height of number inputs (`font-size: 12px` and explicit `height: 35px` applied uniformly via `.run-options-grid` selector).
+- Derived/estimated metrics in the Run page metrics panel (`tok / s (decode)`, `tok / s (overall)`, `prefill tok / s`, `model load (est.)`) now render in bold red via `.is-estimated` class, consistently distinguishing computed values from directly measured or server-reported ones.
+
 ## [0.6.0] - 2026-06-10
 
 ### Added

--- a/backend/src/api/routes/benchmark.ts
+++ b/backend/src/api/routes/benchmark.ts
@@ -12,6 +12,7 @@ import {
 import { prepareBenchmarkDatasetManifest } from '../../services/benchmark-datasets.js';
 import { BenchmarkKind } from '../../services/benchmark-schemas.js';
 import { runBenchmarkInstantiation } from '../../services/benchmark-runner.js';
+import { runBenchmarkPlan } from '../../services/benchmark-plan-runner.js';
 
 function sendBenchmarkError(reply: FastifyReply, error: unknown): boolean {
   if (error instanceof BenchmarkValidationError) {
@@ -101,5 +102,39 @@ export function registerBenchmarkRoutes(app: FastifyInstance): void {
       return;
     }
     reply.send(record);
+  });
+
+  app.post('/benchmark/plans/run', async (request, reply) => {
+    const body = request.body as {
+      plan_id?: string;
+      template?: unknown;
+      dataset?: unknown;
+      runtime_profile?: unknown;
+      targets?: unknown;
+      continue_on_model_error?: unknown;
+    };
+    if (!body.template || typeof body.template !== 'object' || Array.isArray(body.template)) {
+      reply.code(400).send({ error: 'benchmark plan requires template' });
+      return;
+    }
+    if (!Array.isArray(body.targets) || body.targets.length === 0) {
+      reply.code(400).send({ error: 'benchmark plan requires at least one target' });
+      return;
+    }
+    try {
+      const result = await runBenchmarkPlan({
+        plan_id: typeof body.plan_id === 'string' ? body.plan_id : undefined,
+        template: body.template as Record<string, unknown>,
+        dataset: (body.dataset ?? {}) as Record<string, unknown>,
+        runtime_profile: (body.runtime_profile ?? {}) as Record<string, unknown>,
+        targets: body.targets as { server_id: string; model_id: string }[],
+        continue_on_model_error: body.continue_on_model_error !== false
+      });
+      reply.code(201).send(result);
+    } catch (error) {
+      if (!sendBenchmarkError(reply, error)) {
+        throw error;
+      }
+    }
   });
 }

--- a/backend/src/schemas/benchmark/test_run_result.schema.json
+++ b/backend/src/schemas/benchmark/test_run_result.schema.json
@@ -40,6 +40,24 @@
     "aggregated_metrics": { "type": "object", "additionalProperties": true },
     "errors": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
     "warnings": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+    "load_estimate": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["basis", "cold_ms", "warm_baseline_ms", "warm_sample_count", "estimated_load_ms", "model_load_detected"],
+          "properties": {
+            "basis": { "type": "string", "enum": ["first_token_ms", "elapsed_ms"] },
+            "cold_ms": { "type": "number" },
+            "warm_baseline_ms": { "type": "number" },
+            "warm_sample_count": { "type": "integer", "minimum": 0 },
+            "estimated_load_ms": { "type": "number", "minimum": 0 },
+            "model_load_detected": { "type": "boolean" }
+          }
+        }
+      ]
+    },
     "metric_version": { "type": "string" },
     "normalizer_version": { "type": "string" },
     "metadata": { "type": "object", "additionalProperties": true },

--- a/backend/src/services/benchmark-metrics.ts
+++ b/backend/src/services/benchmark-metrics.ts
@@ -13,6 +13,10 @@ export interface ItemMetricInputs {
     input_tokens: number | null;
     output_tokens: number | null;
     total_tokens: number | null;
+    load_duration_ms: number | null;
+    server_total_time_ms: number | null;
+    server_prompt_eval_ms: number | null;
+    server_eval_ms: number | null;
   };
   answerText: string;
   toolCalls: unknown[] | null;
@@ -39,6 +43,18 @@ export function computeItemMetrics(args: ItemMetricInputs): Record<string, numbe
         break;
       case 'first_token_ms':
         result.first_token_ms = timing.first_token_ms;
+        break;
+      case 'load_duration_ms':
+        result.load_duration_ms = timing.load_duration_ms;
+        break;
+      case 'server_total_time_ms':
+        result.server_total_time_ms = timing.server_total_time_ms;
+        break;
+      case 'server_prompt_eval_ms':
+        result.server_prompt_eval_ms = timing.server_prompt_eval_ms;
+        break;
+      case 'server_eval_ms':
+        result.server_eval_ms = timing.server_eval_ms;
         break;
       case 'tokens_per_second': {
         const out = timing.output_tokens;
@@ -261,6 +277,51 @@ function interpolatedPercentile(sorted: number[], p: number): number {
   const hi = Math.ceil(idx);
   if (lo === hi) return sorted[lo];
   return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo);
+}
+
+export interface LoadEstimate {
+  basis: 'first_token_ms' | 'elapsed_ms';
+  cold_ms: number;
+  warm_baseline_ms: number;
+  warm_sample_count: number;
+  estimated_load_ms: number;
+  model_load_detected: boolean;
+}
+
+export function estimateRequestTriggeredLoad(
+  metricResults: Record<string, unknown>[]
+): LoadEstimate | null {
+  if (metricResults.length < 3) return null;
+
+  const useFirstToken = metricResults.every(
+    (r) => typeof r.first_token_ms === 'number' && r.first_token_ms !== null
+  );
+  const basis: 'first_token_ms' | 'elapsed_ms' = useFirstToken ? 'first_token_ms' : 'elapsed_ms';
+
+  const first = metricResults[0];
+  const coldMs = typeof first[basis] === 'number' ? (first[basis] as number) : null;
+  if (coldMs === null) return null;
+
+  const warmValues = metricResults.slice(1).map((r) => r[basis]).filter((v): v is number => typeof v === 'number');
+  if (warmValues.length < 2) return null;
+
+  const sortedWarm = [...warmValues].sort((a, b) => a - b);
+  const warmBaseline = interpolatedPercentile(sortedWarm, 50);
+  const warmMean = warmValues.reduce((s, v) => s + v, 0) / warmValues.length;
+  const warmStddev = Math.sqrt(warmValues.reduce((s, v) => s + (v - warmMean) ** 2, 0) / warmValues.length);
+
+  const estimatedLoadMs = Math.max(0, coldMs - warmBaseline);
+  const threshold = Math.max(warmBaseline * 0.5, 3 * warmStddev);
+  const modelLoadDetected = (coldMs - warmBaseline) > threshold;
+
+  return {
+    basis,
+    cold_ms: coldMs,
+    warm_baseline_ms: warmBaseline,
+    warm_sample_count: warmValues.length,
+    estimated_load_ms: estimatedLoadMs,
+    model_load_detected: modelLoadDetected
+  };
 }
 
 function callName(call: unknown): string | null {

--- a/backend/src/services/benchmark-plan-runner.ts
+++ b/backend/src/services/benchmark-plan-runner.ts
@@ -1,0 +1,131 @@
+import crypto from 'crypto';
+
+import type { InstantiateBenchmarkInput } from './benchmark-foundation.js';
+import { BenchmarkValidationError, persistBenchmarkInstantiation } from './benchmark-foundation.js';
+import { runBenchmarkInstantiation } from './benchmark-runner.js';
+
+export interface BenchmarkPlanTarget {
+  server_id: string;
+  model_id: string;
+}
+
+export interface RunBenchmarkPlanInput {
+  plan_id?: string;
+  template: Record<string, unknown>;
+  dataset: Record<string, unknown>;
+  runtime_profile: Record<string, unknown>;
+  targets: BenchmarkPlanTarget[];
+  continue_on_model_error?: boolean;
+}
+
+export interface BenchmarkPlanRunResult {
+  model_profile_ref: string;
+  instantiation_id: string;
+  run_id: string | null;
+  status: string;
+}
+
+export interface BenchmarkPlanResult {
+  kind: 'benchmark_plan_result';
+  plan_version: 'benchmark_plan_result_v1';
+  plan_id: string;
+  run_results: BenchmarkPlanRunResult[];
+  comparison: {
+    metrics: Record<string, Record<string, number | null>>;
+  };
+}
+
+function requestedMetrics(template: Record<string, unknown>): string[] {
+  return Array.isArray(template.metrics) ? (template.metrics as string[]) : [];
+}
+
+export function buildComparison(
+  runResults: BenchmarkPlanRunResult[],
+  resultDocs: Map<string, Record<string, unknown>>,
+  metrics: string[]
+): BenchmarkPlanResult['comparison'] {
+  const matrix: Record<string, Record<string, number | null>> = {};
+  for (const metric of metrics) {
+    const row: Record<string, number | null> = {};
+    for (const run of runResults) {
+      const doc = resultDocs.get(run.model_profile_ref);
+      if (!doc) {
+        row[run.model_profile_ref] = null;
+        continue;
+      }
+      const agg = doc.aggregated_metrics as Record<string, Record<string, unknown>> | undefined;
+      const entry = agg?.[metric];
+      if (!entry) {
+        row[run.model_profile_ref] = null;
+        continue;
+      }
+      const val = typeof entry.mean === 'number' ? entry.mean
+        : typeof entry.success_rate === 'number' ? entry.success_rate
+        : null;
+      row[run.model_profile_ref] = val;
+    }
+    matrix[metric] = row;
+  }
+  return { metrics: matrix };
+}
+
+export async function runBenchmarkPlan(input: RunBenchmarkPlanInput): Promise<BenchmarkPlanResult> {
+  const {
+    plan_id = `plan_${crypto.randomUUID()}`,
+    template,
+    dataset,
+    runtime_profile,
+    targets,
+    continue_on_model_error = true
+  } = input;
+
+  if (targets.length === 0) {
+    throw new BenchmarkValidationError('runBenchmarkPlan requires at least one target.');
+  }
+
+  const metrics = requestedMetrics(template);
+  const runResults: BenchmarkPlanRunResult[] = [];
+  const resultDocs = new Map<string, Record<string, unknown>>();
+
+  for (const target of targets) {
+    const modelProfileRef = `${target.server_id}:${target.model_id}`;
+    try {
+      const instantiationInput: InstantiateBenchmarkInput = {
+        template,
+        server_id: target.server_id,
+        model_id: target.model_id,
+        dataset,
+        runtime_profile,
+        metadata: { source: 'benchmark-plan', plan_id }
+      };
+      const instantiation = persistBenchmarkInstantiation(instantiationInput);
+      const result = await runBenchmarkInstantiation(instantiation.id);
+      const doc = result.document as Record<string, unknown>;
+      runResults.push({
+        model_profile_ref: modelProfileRef,
+        instantiation_id: instantiation.id,
+        run_id: result.run_id,
+        status: String(doc.status ?? 'failed')
+      });
+      resultDocs.set(modelProfileRef, doc);
+    } catch {
+      runResults.push({
+        model_profile_ref: modelProfileRef,
+        instantiation_id: '',
+        run_id: null,
+        status: 'failed'
+      });
+      if (!continue_on_model_error) {
+        break;
+      }
+    }
+  }
+
+  return {
+    kind: 'benchmark_plan_result',
+    plan_version: 'benchmark_plan_result_v1',
+    plan_id,
+    run_results: runResults,
+    comparison: buildComparison(runResults, resultDocs, metrics)
+  };
+}

--- a/backend/src/services/benchmark-runner.ts
+++ b/backend/src/services/benchmark-runner.ts
@@ -13,7 +13,7 @@ import { buildInferenceServerAuthHeaders } from './inference-server-auth.js';
 import { backendFetch } from './inference-proxy.js';
 import { sha256Document, validateBenchmarkDocument } from './benchmark-schemas.js';
 import { parseSseEvents } from './sse-parser.js';
-import { aggregateMetrics as computeAggregations, computeItemMetrics } from './benchmark-metrics.js';
+import { aggregateMetrics as computeAggregations, computeItemMetrics, estimateRequestTriggeredLoad } from './benchmark-metrics.js';
 
 const ENGINE_VERSION = 'benchmark-runner-v1';
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -58,6 +58,10 @@ interface NormalizedResponse {
   input_tokens: number | null;
   output_tokens: number | null;
   total_tokens: number | null;
+  load_duration_ms: number | null;
+  server_total_time_ms: number | null;
+  server_prompt_eval_ms: number | null;
+  server_eval_ms: number | null;
   tool_calls: unknown[] | null;
   body: unknown;
   text: string | null;
@@ -309,6 +313,34 @@ function objectValue(value: unknown): Record<string, unknown> | null {
   return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : null;
 }
 
+function extractLoadDurationMs(metadata: Record<string, unknown> | null): number | null {
+  // Ollama: load_duration is nanoseconds
+  if (typeof metadata?.load_duration === 'number') return metadata.load_duration / 1e6;
+  // oMLX: usage.model_load_duration is seconds
+  const usage = objectValue(metadata?.usage);
+  if (typeof usage?.model_load_duration === 'number') return usage.model_load_duration * 1000;
+  return null;
+}
+
+function extractServerTotalTimeMs(metadata: Record<string, unknown> | null): number | null {
+  // Ollama/Inferencer: total_duration is nanoseconds
+  if (typeof metadata?.total_duration === 'number') return metadata.total_duration / 1e6;
+  // oMLX: usage.total_time is seconds
+  const usage = objectValue(metadata?.usage);
+  if (typeof usage?.total_time === 'number') return usage.total_time * 1000;
+  return null;
+}
+
+function extractServerPromptEvalMs(metadata: Record<string, unknown> | null): number | null {
+  if (typeof metadata?.prompt_eval_duration === 'number') return metadata.prompt_eval_duration / 1e6;
+  return null;
+}
+
+function extractServerEvalMs(metadata: Record<string, unknown> | null): number | null {
+  if (typeof metadata?.eval_duration === 'number') return metadata.eval_duration / 1e6;
+  return null;
+}
+
 function usageTokens(metadata: Record<string, unknown> | null): Pick<NormalizedResponse, 'input_tokens' | 'output_tokens' | 'total_tokens'> {
   const usage = objectValue(metadata?.usage);
   const inputTokens = numberAt(usage, 'prompt_tokens') ?? numberAt(metadata, 'prompt_eval_count');
@@ -418,6 +450,10 @@ function normalizeStreamResponse(protocol: unknown, contentType: string, respons
     input_tokens: stream.input_tokens,
     output_tokens: stream.output_tokens,
     total_tokens: stream.total_tokens,
+    load_duration_ms: extractLoadDurationMs(stream.final_metadata),
+    server_total_time_ms: extractServerTotalTimeMs(stream.final_metadata),
+    server_prompt_eval_ms: extractServerPromptEvalMs(stream.final_metadata),
+    server_eval_ms: extractServerEvalMs(stream.final_metadata),
     tool_calls: null,
     body: stream.final_metadata,
     text: null,
@@ -456,6 +492,10 @@ function normalizeResponse(body: unknown, text: string | null): NormalizedRespon
       total_tokens: typeof usage?.total_tokens === 'number'
         ? usage.total_tokens
         : inputTokens !== null && outputTokens !== null ? inputTokens + outputTokens : null,
+      load_duration_ms: extractLoadDurationMs(record),
+      server_total_time_ms: extractServerTotalTimeMs(record),
+      server_prompt_eval_ms: extractServerPromptEvalMs(record),
+      server_eval_ms: extractServerEvalMs(record),
       tool_calls: toolCalls,
       body,
       text: null
@@ -466,6 +506,10 @@ function normalizeResponse(body: unknown, text: string | null): NormalizedRespon
     input_tokens: null,
     output_tokens: null,
     total_tokens: null,
+    load_duration_ms: null,
+    server_total_time_ms: null,
+    server_prompt_eval_ms: null,
+    server_eval_ms: null,
     tool_calls: null,
     body,
     text
@@ -608,7 +652,11 @@ async function executeItem(
             first_token_ms: firstTokenMs,
             input_tokens: null,
             output_tokens: null,
-            total_tokens: null
+            total_tokens: null,
+            load_duration_ms: null,
+            server_total_time_ms: null,
+            server_prompt_eval_ms: null,
+            server_eval_ms: null
           },
           error: issue
         };
@@ -632,7 +680,11 @@ async function executeItem(
         first_token_ms: firstTokenMs,
         input_tokens: normalized.input_tokens,
         output_tokens: normalized.output_tokens,
-        total_tokens: normalized.total_tokens
+        total_tokens: normalized.total_tokens,
+        load_duration_ms: normalized.load_duration_ms,
+        server_total_time_ms: normalized.server_total_time_ms,
+        server_prompt_eval_ms: normalized.server_prompt_eval_ms,
+        server_eval_ms: normalized.server_eval_ms
       };
       const computedMetrics = computeItemMetrics({
         requestedMetrics,
@@ -910,6 +962,7 @@ export async function runBenchmarkInstantiation(instantiationId: string) {
     normalized_responses: normalizedResponses,
     metric_results: metricResults,
     aggregated_metrics: computeAggregations(metricResults, requestedAggregations, expectedSampleCount(stages, items.length)),
+    load_estimate: estimateRequestTriggeredLoad(metricResults),
     errors,
     warnings,
     metric_version: 'metrics-v1',

--- a/backend/tests/unit/benchmark-plan-runner.test.ts
+++ b/backend/tests/unit/benchmark-plan-runner.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/services/benchmark-foundation.js', () => ({
+  BenchmarkValidationError: class BenchmarkValidationError extends Error {
+    issues: unknown[];
+    constructor(message: string, issues: unknown[] = []) {
+      super(message);
+      this.name = 'BenchmarkValidationError';
+      this.issues = issues;
+    }
+  },
+  persistBenchmarkInstantiation: vi.fn()
+}));
+
+vi.mock('../../src/services/benchmark-runner.js', () => ({
+  runBenchmarkInstantiation: vi.fn()
+}));
+
+import { persistBenchmarkInstantiation } from '../../src/services/benchmark-foundation.js';
+import { runBenchmarkInstantiation } from '../../src/services/benchmark-runner.js';
+import { buildComparison, runBenchmarkPlan } from '../../src/services/benchmark-plan-runner.js';
+import type { BenchmarkPlanRunResult } from '../../src/services/benchmark-plan-runner.js';
+
+const mockPersist = vi.mocked(persistBenchmarkInstantiation);
+const mockRun = vi.mocked(runBenchmarkInstantiation);
+
+function fakeInstantiation(id: string) {
+  return { id, schema_version: 'v1', document_hash: 'h', template_id: 't', template_version: '1', server_id: 's', model_id: 'm', dataset_hash: 'd', status: 'created', document: {}, created_at: '', updated_at: '' };
+}
+
+function fakeResult(runId: string, status: string, aggregatedMetrics: Record<string, unknown> = {}) {
+  return {
+    id: runId,
+    schema_version: 'v1',
+    document_hash: 'h',
+    instantiation_id: 'inst-1',
+    run_id: runId,
+    status,
+    document: { kind: 'test_run_result', status, aggregated_metrics: aggregatedMetrics },
+    created_at: ''
+  };
+}
+
+describe('buildComparison', () => {
+  it('returns empty metrics when no requested metrics', () => {
+    const result = buildComparison([], new Map(), []);
+    expect(result).toEqual({ metrics: {} });
+  });
+
+  it('builds metric matrix from aggregated_metrics.mean', () => {
+    const runResults: BenchmarkPlanRunResult[] = [
+      { model_profile_ref: 'srv:m1', instantiation_id: 'i1', run_id: 'r1', status: 'completed' },
+      { model_profile_ref: 'srv:m2', instantiation_id: 'i2', run_id: 'r2', status: 'completed' }
+    ];
+    const resultDocs = new Map<string, Record<string, unknown>>([
+      ['srv:m1', { aggregated_metrics: { elapsed_ms: { mean: 500 }, tokens_per_second: { mean: 20 } } }],
+      ['srv:m2', { aggregated_metrics: { elapsed_ms: { mean: 300 }, tokens_per_second: { mean: 35 } } }]
+    ]);
+    const result = buildComparison(runResults, resultDocs, ['elapsed_ms', 'tokens_per_second']);
+    expect(result.metrics.elapsed_ms['srv:m1']).toBe(500);
+    expect(result.metrics.elapsed_ms['srv:m2']).toBe(300);
+    expect(result.metrics.tokens_per_second['srv:m1']).toBe(20);
+    expect(result.metrics.tokens_per_second['srv:m2']).toBe(35);
+  });
+
+  it('uses success_rate for boolean metrics', () => {
+    const runResults: BenchmarkPlanRunResult[] = [
+      { model_profile_ref: 'srv:m1', instantiation_id: 'i1', run_id: 'r1', status: 'completed' }
+    ];
+    const resultDocs = new Map<string, Record<string, unknown>>([
+      ['srv:m1', { aggregated_metrics: { exact_match: { success_rate: 0.75 } } }]
+    ]);
+    const result = buildComparison(runResults, resultDocs, ['exact_match']);
+    expect(result.metrics.exact_match['srv:m1']).toBe(0.75);
+  });
+
+  it('returns null for missing model', () => {
+    const runResults: BenchmarkPlanRunResult[] = [
+      { model_profile_ref: 'srv:m1', instantiation_id: '', run_id: null, status: 'failed' }
+    ];
+    const resultDocs = new Map<string, Record<string, unknown>>();
+    const result = buildComparison(runResults, resultDocs, ['elapsed_ms']);
+    expect(result.metrics.elapsed_ms['srv:m1']).toBeNull();
+  });
+
+  it('returns null for missing metric in aggregated_metrics', () => {
+    const runResults: BenchmarkPlanRunResult[] = [
+      { model_profile_ref: 'srv:m1', instantiation_id: 'i1', run_id: 'r1', status: 'completed' }
+    ];
+    const resultDocs = new Map<string, Record<string, unknown>>([
+      ['srv:m1', { aggregated_metrics: {} }]
+    ]);
+    const result = buildComparison(runResults, resultDocs, ['elapsed_ms']);
+    expect(result.metrics.elapsed_ms['srv:m1']).toBeNull();
+  });
+});
+
+describe('runBenchmarkPlan', () => {
+  const template = {
+    kind: 'test_template',
+    template_id: 'plan-tpl',
+    template_version: '1.0.0',
+    metrics: ['elapsed_ms', 'tokens_per_second']
+  };
+  const dataset = { kind: 'dataset_manifest', dataset_id: 'ds' };
+  const runtime_profile = { kind: 'runtime_profile', profile_id: 'rt' };
+  const targets = [
+    { server_id: 'srv', model_id: 'model-a' },
+    { server_id: 'srv', model_id: 'model-b' }
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('throws when targets is empty', async () => {
+    await expect(runBenchmarkPlan({ template, dataset, runtime_profile, targets: [] }))
+      .rejects.toThrow('at least one target');
+  });
+
+  it('returns benchmark_plan_result shape with two targets', async () => {
+    mockPersist
+      .mockReturnValueOnce(fakeInstantiation('inst-a'))
+      .mockReturnValueOnce(fakeInstantiation('inst-b'));
+    mockRun
+      .mockResolvedValueOnce(fakeResult('run-a', 'completed', { elapsed_ms: { mean: 400 } }))
+      .mockResolvedValueOnce(fakeResult('run-b', 'completed', { elapsed_ms: { mean: 200 } }));
+
+    const result = await runBenchmarkPlan({ plan_id: 'plan-1', template, dataset, runtime_profile, targets });
+
+    expect(result.kind).toBe('benchmark_plan_result');
+    expect(result.plan_version).toBe('benchmark_plan_result_v1');
+    expect(result.plan_id).toBe('plan-1');
+    expect(result.run_results).toHaveLength(2);
+    expect(result.run_results[0].model_profile_ref).toBe('srv:model-a');
+    expect(result.run_results[1].model_profile_ref).toBe('srv:model-b');
+    expect(result.run_results[0].status).toBe('completed');
+    expect(result.comparison.metrics.elapsed_ms?.['srv:model-a']).toBe(400);
+    expect(result.comparison.metrics.elapsed_ms?.['srv:model-b']).toBe(200);
+  });
+
+  it('continues on model error when continue_on_model_error is true', async () => {
+    mockPersist
+      .mockReturnValueOnce(fakeInstantiation('inst-a'))
+      .mockReturnValueOnce(fakeInstantiation('inst-b'));
+    mockRun
+      .mockRejectedValueOnce(new Error('model-a failed'))
+      .mockResolvedValueOnce(fakeResult('run-b', 'completed', {}));
+
+    const result = await runBenchmarkPlan({ template, dataset, runtime_profile, targets, continue_on_model_error: true });
+
+    expect(result.run_results).toHaveLength(2);
+    expect(result.run_results[0].status).toBe('failed');
+    expect(result.run_results[0].run_id).toBeNull();
+    expect(result.run_results[1].status).toBe('completed');
+  });
+
+  it('stops after first failure when continue_on_model_error is false', async () => {
+    mockPersist.mockReturnValueOnce(fakeInstantiation('inst-a'));
+    mockRun.mockRejectedValueOnce(new Error('model-a failed'));
+
+    const result = await runBenchmarkPlan({ template, dataset, runtime_profile, targets, continue_on_model_error: false });
+
+    expect(result.run_results).toHaveLength(1);
+    expect(result.run_results[0].status).toBe('failed');
+    expect(mockRun).toHaveBeenCalledTimes(1);
+  });
+
+  it('generates plan_id when not provided', async () => {
+    mockPersist.mockReturnValueOnce(fakeInstantiation('inst-a'));
+    mockRun.mockResolvedValueOnce(fakeResult('run-a', 'completed', {}));
+
+    const result = await runBenchmarkPlan({ template, dataset, runtime_profile, targets: [targets[0]] });
+    expect(result.plan_id).toMatch(/^plan_/);
+  });
+
+  it('passes metadata with plan_id to persistBenchmarkInstantiation', async () => {
+    mockPersist.mockReturnValueOnce(fakeInstantiation('inst-a'));
+    mockRun.mockResolvedValueOnce(fakeResult('run-a', 'completed', {}));
+
+    await runBenchmarkPlan({ plan_id: 'p42', template, dataset, runtime_profile, targets: [targets[0]] });
+
+    expect(mockPersist).toHaveBeenCalledWith(
+      expect.objectContaining({ metadata: expect.objectContaining({ plan_id: 'p42' }) })
+    );
+  });
+});

--- a/frontend/src/pages/RunUnified.tsx
+++ b/frontend/src/pages/RunUnified.tsx
@@ -4,10 +4,13 @@ import { useSearchParams } from 'react-router-dom';
 import { InferenceServerErrors } from '../components/InferenceServerErrors.js';
 import { MergedPageHeader } from '../components/MergedPageHeader.js';
 import {
+  buildBenchmarkPlanPayload,
   buildBenchmarkSmokePayload,
   createBenchmarkInstantiation,
+  getBenchmarkResult,
   prepareBenchmarkDatasetManifest,
   runBenchmarkInstantiation,
+  runBenchmarkPlan,
   type BenchmarkDatasetFormat,
   type BenchmarkInstantiationRecord,
   type BenchmarkResultRecord
@@ -115,6 +118,14 @@ function aggStat(result: BenchmarkResultRecord | null, metric: string, stat: str
   const entry = agg?.[metric];
   const value = entry?.[stat];
   return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function firstMetricValue(result: BenchmarkResultRecord | null, field: string): number | null {
+  const rows = result?.document.metric_results ?? [];
+  if (!Array.isArray(rows) || rows.length === 0) return null;
+  const first = rows[0] as Record<string, unknown> | undefined;
+  const v = first?.[field];
+  return typeof v === 'number' && Number.isFinite(v) ? v : null;
 }
 
 interface CorrectnessMetric {
@@ -313,8 +324,8 @@ function ConfigRail({
             </select>
           </label>
         </div>
-        <div className="run-count-line">{selectedTargets.length || 0} of 8 models selected · run executes the first selected model</div>
-        <p className="run-hint">Run one model through either a smoke prompt or a server-side dataset file.</p>
+        <div className="run-count-line">{selectedTargets.length || 0} of 8 models selected · {selectedTargets.length > 1 ? `run executes all ${selectedTargets.length} selected models` : 'run executes the selected model'}</div>
+        <p className="run-hint">Run one or more models through a smoke prompt or server-side dataset. Multiple models produce a side-by-side comparison.</p>
       </div>
 
       <div className="run-config-step">
@@ -536,6 +547,12 @@ function BenchmarkDetail({
   const decodeTokensPerSec = aggStat(result, 'decode_tokens_per_second', 'mean');
   const prefillTokensPerSec = aggStat(result, 'prefill_tokens_per_second', 'mean');
   const latencyP95 = aggStat(result, 'elapsed_ms', 'p95');
+  const modelLoadMs = aggStat(result, 'load_duration_ms', 'max') ?? firstMetricValue(result, 'load_duration_ms');
+  const serverTotalTimeMs = aggStat(result, 'server_total_time_ms', 'mean') ?? firstMetricValue(result, 'server_total_time_ms');
+  const serverPromptEvalMs = aggStat(result, 'server_prompt_eval_ms', 'mean') ?? firstMetricValue(result, 'server_prompt_eval_ms');
+  const serverEvalMs = aggStat(result, 'server_eval_ms', 'mean') ?? firstMetricValue(result, 'server_eval_ms');
+  const loadEstimate = result?.document.load_estimate as { estimated_load_ms: number; model_load_detected: boolean } | null | undefined;
+  const estimatedLoadMs = loadEstimate?.model_load_detected ? loadEstimate.estimated_load_ms : null;
   const correctness = correctnessMetrics(result);
   return (
     <div className="run-single-detail">
@@ -600,22 +617,37 @@ function BenchmarkDetail({
         <h3>Metrics</h3>
         <div className="run-metric-grid">
           <span><b>duration</b>{formatMetric(metrics.elapsed_ms)}</span>
+          {serverTotalTimeMs !== null && (
+            <span><b>server time</b>{formatMetric(serverTotalTimeMs)}</span>
+          )}
+          {serverPromptEvalMs !== null && (
+            <span><b>server prefill</b>{formatMetric(serverPromptEvalMs)}</span>
+          )}
+          {serverEvalMs !== null && (
+            <span><b>server decode</b>{formatMetric(serverEvalMs)}</span>
+          )}
+          {latencyP95 !== null && itemCount !== null && itemCount > 1 && (
+            <span><b>duration p95</b>{formatMetric(latencyP95)}</span>
+          )}
           <span><b>ttft</b>{formatMetric(metrics.first_token_ms)}</span>
+          {modelLoadMs !== null && modelLoadMs > 0 && (
+            <span><b>model load</b>{formatMetric(modelLoadMs)}</span>
+          )}
+          {modelLoadMs === null && estimatedLoadMs !== null && estimatedLoadMs > 0 && (
+            <span className="is-estimated"><b>model load (est.)</b>{formatMetric(estimatedLoadMs)}</span>
+          )}
           <span><b>tokens in</b>{formatNumber(metrics.input_tokens)}</span>
           <span><b>tokens out</b>{formatNumber(metrics.output_tokens)}</span>
           <span><b>total tokens</b>{formatNumber(metrics.total_tokens)}</span>
           <span><b>stream</b>{streamSummary(result)}</span>
           {decodeTokensPerSec !== null && (
-            <span><b>tok / s (decode)</b>{formatMetric(decodeTokensPerSec, 'tok/s')}</span>
+            <span className="is-estimated"><b>tok / s (decode)</b>{formatMetric(decodeTokensPerSec, 'tok/s')}</span>
           )}
           {tokensPerSec !== null && (
-            <span><b>tok / s (overall)</b>{formatMetric(tokensPerSec, 'tok/s')}</span>
+            <span className="is-estimated"><b>tok / s (overall)</b>{formatMetric(tokensPerSec, 'tok/s')}</span>
           )}
           {prefillTokensPerSec !== null && (
-            <span><b>prefill tok / s</b>{formatMetric(prefillTokensPerSec, 'tok/s')}</span>
-          )}
-          {latencyP95 !== null && itemCount !== null && itemCount > 1 && (
-            <span><b>duration p95</b>{formatMetric(latencyP95)}</span>
+            <span className="is-estimated"><b>prefill tok / s</b>{formatMetric(prefillTokensPerSec, 'tok/s')}</span>
           )}
           {itemCount !== null && itemCount > 1 && (
             <span><b>items</b>{String(itemCount)}</span>
@@ -650,6 +682,7 @@ function BenchmarkDetail({
   );
 }
 
+
 export function RunUnified({ connectivitySnapshot = {} }: { connectivitySnapshot?: Record<string, InferenceServerHealth> }) {
   const [searchParams, setSearchParams] = useSearchParams();
   const [servers, setServers] = useState<InferenceServerRecord[]>([]);
@@ -667,6 +700,7 @@ export function RunUnified({ connectivitySnapshot = {} }: { connectivitySnapshot
   const [inferenceParams, setInferenceParams] = useState<InferenceParams>(DEFAULT_INFERENCE_PARAMS);
   const [instantiation, setInstantiation] = useState<BenchmarkInstantiationRecord | null>(null);
   const [result, setResult] = useState<BenchmarkResultRecord | null>(null);
+  const [multiResults, setMultiResults] = useState<(BenchmarkResultRecord | null)[]>([]);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -721,6 +755,7 @@ export function RunUnified({ connectivitySnapshot = {} }: { connectivitySnapshot
   function addTarget(target: RunTarget) {
     setInstantiation(null);
     setResult(null);
+    setMultiResults([]);
     setSelectedTargets((current) => {
       const key = targetKey(target);
       if (current.some((entry) => targetKey(entry) === key)) {
@@ -733,6 +768,7 @@ export function RunUnified({ connectivitySnapshot = {} }: { connectivitySnapshot
   function removeTarget(target: RunTarget) {
     setInstantiation(null);
     setResult(null);
+    setMultiResults([]);
     setSelectedTargets((current) => current.filter((entry) => targetKey(entry) !== targetKey(target)));
   }
 
@@ -749,6 +785,7 @@ export function RunUnified({ connectivitySnapshot = {} }: { connectivitySnapshot
     setBusy(true);
     setError(null);
     setResult(null);
+    setMultiResults([]);
     try {
       const preparedDataset = datasetMode === 'manifest_only'
         ? await prepareBenchmarkDatasetManifest({
@@ -761,22 +798,44 @@ export function RunUnified({ connectivitySnapshot = {} }: { connectivitySnapshot
             metadata: { source: 'run-page-dataset-path' }
           })
         : undefined;
-      const payload = buildBenchmarkSmokePayload({
-        target: selectedTarget,
-        prompt: prompt.trim(),
-        systemPrompt,
-        inferenceParams,
-        timeoutSec,
-        seed,
-        dataset: preparedDataset
-          ? { mode: 'manifest_only', manifest: preparedDataset }
-          : { mode: 'inline', prompt: prompt.trim(), systemPrompt }
-      });
-      const created = await createBenchmarkInstantiation(payload);
-      setInstantiation(created);
-      const completed = await runBenchmarkInstantiation(created.id);
-      setResult(completed);
-      window.dispatchEvent(new CustomEvent('runs:changed'));
+      const datasetInput = preparedDataset
+        ? { mode: 'manifest_only' as const, manifest: preparedDataset }
+        : { mode: 'inline' as const, prompt: prompt.trim(), systemPrompt };
+
+      if (selectedTargets.length > 1) {
+        const payload = buildBenchmarkPlanPayload({
+          targets: selectedTargets,
+          prompt: prompt.trim(),
+          systemPrompt,
+          inferenceParams,
+          timeoutSec,
+          seed,
+          dataset: datasetInput
+        });
+        const plan = await runBenchmarkPlan(payload);
+        const fetched = await Promise.all(
+          plan.run_results.map((r) =>
+            r.run_id ? getBenchmarkResult(r.run_id).catch(() => null) : Promise.resolve(null)
+          )
+        );
+        setMultiResults(fetched);
+        window.dispatchEvent(new CustomEvent('runs:changed'));
+      } else {
+        const payload = buildBenchmarkSmokePayload({
+          target: selectedTarget,
+          prompt: prompt.trim(),
+          systemPrompt,
+          inferenceParams,
+          timeoutSec,
+          seed,
+          dataset: datasetInput
+        });
+        const created = await createBenchmarkInstantiation(payload);
+        setInstantiation(created);
+        const completed = await runBenchmarkInstantiation(created.id);
+        setResult(completed);
+        window.dispatchEvent(new CustomEvent('runs:changed'));
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Unable to run benchmark.');
     } finally {
@@ -824,7 +883,7 @@ export function RunUnified({ connectivitySnapshot = {} }: { connectivitySnapshot
             <header className="run-page-header">
               <div>
                 <h1>Run</h1>
-                <p>{subtitle}{result ? ` · ${result.document.status}` : busy ? ' · running' : ''}</p>
+                <p>{subtitle}{multiResults.length > 0 ? ` · ${multiResults.length} models` : result ? ` · ${result.document.status}` : busy ? ' · running' : ''}</p>
               </div>
               <div className="run-header-actions">
                 <button type="button" disabled={!result}>Export</button>
@@ -839,6 +898,20 @@ export function RunUnified({ connectivitySnapshot = {} }: { connectivitySnapshot
             />
             {!selectedTarget ? (
               <RunUnifiedEmpty />
+            ) : selectedTargets.length > 1 || multiResults.length > 0 ? (
+              <div style={{ display: 'flex', flexWrap: 'wrap' }}>
+                {selectedTargets.map((target, index) => (
+                  <div key={targetKey(target)} style={{ flex: '1 1 50%', minWidth: 0, borderRight: '1px solid var(--paper-7)', borderBottom: '1px solid var(--paper-7)', boxSizing: 'border-box' }}>
+                    <BenchmarkDetail
+                      target={target}
+                      option={optionMap.get(targetKey(target))}
+                      instantiation={null}
+                      result={multiResults[index] ?? null}
+                      busy={busy}
+                    />
+                  </div>
+                ))}
+              </div>
             ) : (
               <BenchmarkDetail
                 target={selectedTarget}

--- a/frontend/src/services/benchmark-api.ts
+++ b/frontend/src/services/benchmark-api.ts
@@ -199,3 +199,51 @@ export async function runBenchmarkInstantiation(id: string): Promise<BenchmarkRe
 export async function getBenchmarkResult(id: string): Promise<BenchmarkResultRecord> {
   return apiGet<BenchmarkResultRecord>(`/benchmark/results/${id}`);
 }
+
+export interface BenchmarkPlanRunResult {
+  model_profile_ref: string;
+  instantiation_id: string;
+  run_id: string | null;
+  status: string;
+}
+
+export interface BenchmarkPlanResult {
+  kind: 'benchmark_plan_result';
+  plan_version: 'benchmark_plan_result_v1';
+  plan_id: string;
+  run_results: BenchmarkPlanRunResult[];
+  comparison: {
+    metrics: Record<string, Record<string, number | null>>;
+  };
+}
+
+export interface BenchmarkPlanPayload {
+  plan_id?: string;
+  template: Record<string, unknown>;
+  dataset: Record<string, unknown>;
+  runtime_profile: Record<string, unknown>;
+  targets: { server_id: string; model_id: string }[];
+  continue_on_model_error?: boolean;
+}
+
+export async function runBenchmarkPlan(payload: BenchmarkPlanPayload): Promise<BenchmarkPlanResult> {
+  return apiPost<BenchmarkPlanResult>('/benchmark/plans/run', payload);
+}
+
+export function buildBenchmarkPlanPayload(input: {
+  targets: RunTarget[];
+  prompt: string;
+  systemPrompt?: string | null;
+  inferenceParams: InferenceParams;
+  timeoutSec: string;
+  seed: string;
+  dataset?: BenchmarkDatasetInput;
+}): BenchmarkPlanPayload {
+  const first = buildBenchmarkSmokePayload({ ...input, target: input.targets[0] });
+  return {
+    template: first.template,
+    dataset: first.dataset as Record<string, unknown>,
+    runtime_profile: first.runtime_profile,
+    targets: input.targets.map((t) => ({ server_id: t.inference_server_id, model_id: t.model_id }))
+  };
+}

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -1195,9 +1195,12 @@ button.is-pending::after {
   text-transform: uppercase;
 }
 
-.run-options-grid input {
+.run-options-grid input,
+.run-options-grid select {
   font-family: var(--font-mono);
   font-size: 12px;
+  height: 35px;
+  box-sizing: border-box;
 }
 
 .run-actions-row {
@@ -1484,6 +1487,14 @@ button.is-pending::after {
   color: var(--ink-3);
   font-size: 9px;
   text-transform: uppercase;
+}
+
+.run-metric-grid span.is-estimated {
+  color: #cc0000;
+}
+
+.run-metric-grid span.is-estimated b {
+  color: #cc0000;
 }
 
 .run-side-actions {


### PR DESCRIPTION
Add POST /benchmark/plans/run endpoint backed by BenchmarkPlanRunner service. When 2+ models selected on Run page, executes all targets in parallel and renders side-by-side BenchmarkDetail panels.

Extract Ollama/oMLX server-side timing fields (load_duration, total_duration, prompt_eval_duration, eval_duration) through the normalization pipeline into metric_results and aggregations.

Add estimateRequestTriggeredLoad() to benchmark-metrics: detects model cold-load overhead by comparing first-request latency against warm median; attaches load_estimate to run result document and exposes estimated load ms in the UI when direct load_duration unavailable. Schema: add load_estimate shape to test_run_result.schema.json. UI: show server time / prefill / decode / model load metric rows; mark derived tok/s metrics with is-estimated class; update subtitle and run-count-line copy for multi-model mode.