### PR TITLE
feat(results): add adaptive performance views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 
 ### Added
 
+- **Adaptive Results performance views** — the Results dashboard now has an Auto performance view with manual modes for cold-start comparison, latency trend, pass-rate trend, latency histogram, and model-summary table comparisons backed by filtered model aggregates.
 - **Project workflow guardrails** — `AGENTS.md` now combines the main branch workflow, Node 25 rules, challenge-and-skill behavior instructions, and a static-data rule that keeps prompts, schemas, fixtures, and examples out of application code.
 - **Benchmark template agent** — Templates now includes a review-first benchmark-template agent that uses a database-persisted Settings model, challenges underspecified requests, loads its prompt from Markdown with the full `test_template` schema and example injected, validates generated drafts server-side, and applies drafts to the existing editor without auto-saving.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 
 ### Fixed
 
+- **Benchmark foundation stress test timeout** — the indexed lookup stress test now has an explicit timeout that matches its own 10-second performance budget, avoiding Vitest preemption on slower CI runners.
 - Restored tracked `AGENTS.md` project workflow rules while keeping the Node 25.x native-module guidance, restored `CLAUDE.md` tracking, and aligned Claude-specific project guidance with the enforced Node 25.x runtime.
 - **Template agent settings rate limiting** — `/system/settings` and `/system/settings/template-agent-model` now use an in-memory per-client rate limit before reading or updating app settings.
 

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Model formats supported in the catalog include `GGUF`, `MLX`, `GPTQ`, `AWQ`, and
   <tr>
     <td align="center">
       <img src=".github/assets/5-Results-page.png" width="100%" alt="Results" /><br>
-      <b>Results</b> · Dashboard, history, and leaderboard
+      <b>Results</b> · Adaptive performance charts, history, and leaderboard
     </td>
     <td align="center">
       <img src=".github/assets/Evaluate-page.png" width="100%" alt="Evaluate" /><br>

--- a/backend/src/services/results-view-service.ts
+++ b/backend/src/services/results-view-service.ts
@@ -95,6 +95,13 @@ export interface ResultsDashboardView {
   };
   pass_rate_series: Array<{ label: string; points: Array<{ x: string; y: number | null }> }>;
   latency_series: Array<{ label: string; points: Array<{ x: string; y: number | null }> }>;
+  model_summary: Array<{
+    model_name: string;
+    run_count: number;
+    pass_rate: number | null;
+    median_latency_ms: number | null;
+    median_cost: number | null;
+  }>;
   performance_comparison: ResultsPerformanceComparisonView;
   recent_runs: ResultsHistoryRow[];
 }
@@ -691,6 +698,27 @@ function dayBucket(iso: string): string {
   return iso.slice(0, 10);
 }
 
+function modelSummary(rows: ResultsHistoryRow[]): ResultsDashboardView['model_summary'] {
+  const byModel = new Map<string, ResultsHistoryRow[]>();
+  for (const row of rows) {
+    const modelRows = byModel.get(row.model_name) ?? [];
+    modelRows.push(row);
+    byModel.set(row.model_name, modelRows);
+  }
+  return Array.from(byModel.entries())
+    .map(([modelName, modelRows]) => {
+      const passCount = modelRows.filter((row) => row.status === 'pass').length;
+      return {
+        model_name: modelName,
+        run_count: modelRows.length,
+        pass_rate: modelRows.length > 0 ? (passCount / modelRows.length) * 100 : null,
+        median_latency_ms: median(modelRows.map((row) => row.latency_ms)),
+        median_cost: median(modelRows.map((row) => row.cost))
+      };
+    })
+    .sort((a, b) => (b.pass_rate ?? -1) - (a.pass_rate ?? -1) || (a.median_latency_ms ?? Number.MAX_SAFE_INTEGER) - (b.median_latency_ms ?? Number.MAX_SAFE_INTEGER));
+}
+
 function dashboard(rows: ResultsHistoryRow[]): ResultsDashboardView {
   const total = rows.length;
   const passRate = total > 0 ? (rows.filter((row) => row.status === 'pass').length / total) * 100 : null;
@@ -727,6 +755,7 @@ function dashboard(rows: ResultsHistoryRow[]): ResultsDashboardView {
     },
     pass_rate_series: Array.from(passSeries.entries()).map(([label, points]) => ({ label, points: points.sort((a, b) => a.x.localeCompare(b.x)) })),
     latency_series: Array.from(latencySeries.entries()).map(([label, points]) => ({ label, points: points.sort((a, b) => a.x.localeCompare(b.x)) })),
+    model_summary: modelSummary(rows),
     performance_comparison: emptyPerformanceComparison(),
     recent_runs: rows.slice().sort((a, b) => b.started_at.localeCompare(a.started_at)).slice(0, 8)
   };

--- a/backend/tests/integration/benchmark-foundation.test.ts
+++ b/backend/tests/integration/benchmark-foundation.test.ts
@@ -331,5 +331,5 @@ describe('benchmark foundation API', () => {
     expect(lookupMs).toBeLessThan(50);
     expect(performance.now() - started).toBeLessThan(10000);
     await app.close();
-  });
+  }, 15000);
 });

--- a/backend/tests/integration/results-view.integration.test.ts
+++ b/backend/tests/integration/results-view.integration.test.ts
@@ -191,6 +191,43 @@ describe('results-view routes', () => {
     });
   });
 
+  it('returns model summaries for all filtered rows, independent of history pagination', async () => {
+    const app = createServer();
+    seedRun({ runId: 'run-a1', model: 'model-a', verdict: 'pass', startedAt: '2026-05-01T10:00:00.000Z', latency: 100 });
+    seedRun({ runId: 'run-a2', model: 'model-a', verdict: 'fail', startedAt: '2026-05-01T11:00:00.000Z', latency: 200 });
+    seedRun({ runId: 'run-b1', model: 'model-b', verdict: 'pass', startedAt: '2026-05-01T12:00:00.000Z', latency: 80 });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/results-view/query',
+      headers: AUTH_HEADERS,
+      payload: {
+        date_from: '2026-05-01T00:00:00.000Z',
+        date_to: '2026-05-02T00:00:00.000Z',
+        page_size: 1
+      }
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().history.rows).toHaveLength(1);
+    expect(response.json().dashboard.model_summary).toEqual([
+      {
+        model_name: 'model-b',
+        run_count: 1,
+        pass_rate: 100,
+        median_latency_ms: 80,
+        median_cost: 0.001
+      },
+      {
+        model_name: 'model-a',
+        run_count: 2,
+        pass_rate: 50,
+        median_latency_ms: 150,
+        median_cost: 0.001
+      }
+    ]);
+  });
+
   it('returns cold-start sample comparisons grouped by server, model, and template', async () => {
     const app = createServer();
     seedServer('srv-other', 'Other Server');

--- a/frontend/src/components/results-adaptive-chart-panel.tsx
+++ b/frontend/src/components/results-adaptive-chart-panel.tsx
@@ -1,0 +1,195 @@
+import { useMemo, useState } from 'react';
+import type { ComponentType } from 'react';
+import _ReactECharts from 'echarts-for-react';
+import type { EChartsReactProps } from 'echarts-for-react';
+import type { EChartsOption } from 'echarts/types/dist/shared';
+
+import {
+  buildLatencyHistogram,
+  resolveResultsChartMode,
+  type ResolvedResultsChartMode,
+  type ResultsChartMode
+} from '../services/results-adaptive-chart.js';
+import type { ResultsDashboardView, ResultsFilterState, ResultsHistoryRow } from '../services/results-view-api.js';
+import type { ResultsPanel } from '../services/results-panels.js';
+import { ResultsGraphPanel } from './results-graph-panel.js';
+import { ResultsPerformanceComparisonPanel } from './results-performance-comparison-panel.js';
+
+const ReactECharts = _ReactECharts as unknown as ComponentType<EChartsReactProps>;
+
+interface ResultsAdaptiveChartPanelProps {
+  dashboard: ResultsDashboardView;
+  filters: ResultsFilterState;
+  focusedRun: ResultsHistoryRow | null;
+}
+
+const CHART_MODE_OPTIONS: Array<{ mode: ResultsChartMode; label: string }> = [
+  { mode: 'auto', label: 'Auto' },
+  { mode: 'cold-start', label: 'Cold-start comparison' },
+  { mode: 'latency-trend', label: 'Latency trend' },
+  { mode: 'pass-rate-trend', label: 'Pass-rate trend' },
+  { mode: 'latency-histogram', label: 'Latency histogram' },
+  { mode: 'model-summary', label: 'Model summary' }
+];
+
+function seriesPanel(title: string, metric: string, series: ResultsDashboardView['latency_series']): ResultsPanel {
+  return {
+    panel_id: `results:${metric}`,
+    presentation_type: 'performance_graph',
+    title,
+    runtime_key: 'selected',
+    server_version: null,
+    model_id: 'selected',
+    test_ids: [],
+    metric_keys: [metric],
+    unit_keys: metric === 'pass_rate' ? ['%'] : ['ms'],
+    grouped: true,
+    series,
+    missing_fields: []
+  };
+}
+
+function formatNumber(value: number | null, suffix = ''): string {
+  if (value == null || !Number.isFinite(value)) {
+    return 'N/A';
+  }
+  return `${Number(value.toFixed(value >= 100 ? 0 : 2)).toLocaleString()}${suffix}`;
+}
+
+function modeLabel(mode: ResolvedResultsChartMode | null): string {
+  switch (mode) {
+    case 'cold-start':
+      return 'Cold-start comparison';
+    case 'latency-trend':
+      return 'Latency trend';
+    case 'pass-rate-trend':
+      return 'Pass-rate trend';
+    case 'latency-histogram':
+      return 'Latency histogram';
+    case 'model-summary':
+      return 'Model summary';
+    default:
+      return 'Results chart';
+  }
+}
+
+function LatencyHistogram({ dashboard, focusedRun }: { dashboard: ResultsDashboardView; focusedRun: ResultsHistoryRow | null }) {
+  const buckets = useMemo(() => buildLatencyHistogram(dashboard.latency_series), [dashboard.latency_series]);
+  const labels = dashboard.latency_series.map((entry) => entry.label);
+  const option = useMemo<EChartsOption>(() => ({
+    animation: false,
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: { type: 'shadow' }
+    },
+    legend: { type: 'scroll' },
+    grid: {
+      left: 56,
+      right: 20,
+      top: 36,
+      bottom: 72
+    },
+    xAxis: {
+      type: 'category',
+      data: buckets.map((bucket) => bucket.label),
+      name: 'Latency bucket',
+      nameLocation: 'middle',
+      nameGap: 48,
+      axisLabel: { rotate: buckets.length > 5 ? 28 : 0, hideOverlap: true }
+    },
+    yAxis: {
+      type: 'value',
+      minInterval: 1,
+      name: 'Runs'
+    },
+    series: labels.map((label) => ({
+      name: label,
+      type: 'bar',
+      stack: 'latency',
+      emphasis: { focus: 'series' },
+      itemStyle: {
+        opacity: focusedRun && focusedRun.model_name !== label ? 0.32 : 1
+      },
+      data: buckets.map((bucket) => bucket.series.find((entry) => entry.label === label)?.count ?? 0)
+    }))
+  }), [buckets, focusedRun, labels]);
+
+  if (buckets.length === 0) {
+    return <p className="muted">No latency samples available.</p>;
+  }
+
+  return <ReactECharts option={option} className="results-chart" notMerge lazyUpdate />;
+}
+
+function ModelSummaryTable({ dashboard }: { dashboard: ResultsDashboardView }) {
+  const summaryRows = dashboard.model_summary;
+  if (summaryRows.length === 0) {
+    return <p className="muted">No model summary rows available.</p>;
+  }
+
+  return (
+    <div className="table-scroll">
+      <table className="results-comparison-table">
+        <thead>
+          <tr>
+            <th>Model</th>
+            <th>Runs</th>
+            <th>Pass rate</th>
+            <th>Median latency</th>
+            <th>Median cost</th>
+          </tr>
+        </thead>
+        <tbody>
+          {summaryRows.map((row) => (
+            <tr key={row.model_name}>
+              <td>{row.model_name}</td>
+              <td>{row.run_count}</td>
+              <td>{formatNumber(row.pass_rate, '%')}</td>
+              <td>{formatNumber(row.median_latency_ms, ' ms')}</td>
+              <td>{row.median_cost == null ? 'N/A' : `$${row.median_cost.toFixed(6)}`}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function ResultsAdaptiveChartPanel({ dashboard, filters, focusedRun }: ResultsAdaptiveChartPanelProps) {
+  const [selectedMode, setSelectedMode] = useState<ResultsChartMode>('auto');
+  const resolvedMode = resolveResultsChartMode(selectedMode, dashboard, filters, focusedRun);
+  const focusedLabel = focusedRun?.model_name ?? null;
+
+  return (
+    <section className="results-panel results-adaptive-chart" data-panel-type="adaptive-chart">
+      <header className="results-panel__header">
+        <div>
+          <h2>Performance view</h2>
+          <p className="muted">{selectedMode === 'auto' ? `Auto selected: ${modeLabel(resolvedMode)}` : modeLabel(resolvedMode)}</p>
+        </div>
+        <label className="results-comparison-metric">
+          <span>View</span>
+          <select value={selectedMode} onChange={(event) => setSelectedMode(event.target.value as ResultsChartMode)}>
+            {CHART_MODE_OPTIONS.map((option) => (
+              <option key={option.mode} value={option.mode}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      </header>
+      {resolvedMode === 'cold-start' ? (
+        <ResultsPerformanceComparisonPanel comparison={dashboard.performance_comparison} embedded />
+      ) : null}
+      {resolvedMode === 'latency-trend' ? (
+        <ResultsGraphPanel panel={seriesPanel('Latency trend', 'latency_ms', dashboard.latency_series)} focusedLabel={focusedLabel} embedded />
+      ) : null}
+      {resolvedMode === 'pass-rate-trend' ? (
+        <ResultsGraphPanel panel={seriesPanel('Pass-rate trend', 'pass_rate', dashboard.pass_rate_series)} focusedLabel={focusedLabel} embedded />
+      ) : null}
+      {resolvedMode === 'latency-histogram' ? <LatencyHistogram dashboard={dashboard} focusedRun={focusedRun} /> : null}
+      {resolvedMode === 'model-summary' ? <ModelSummaryTable dashboard={dashboard} /> : null}
+      {resolvedMode === null ? <p className="muted">No chart data available.</p> : null}
+    </section>
+  );
+}

--- a/frontend/src/components/results-graph-panel.tsx
+++ b/frontend/src/components/results-graph-panel.tsx
@@ -10,6 +10,8 @@ import { ResultsPanel } from '../services/results-panels.js';
 
 interface ResultsGraphPanelProps {
   panel: ResultsPanel;
+  focusedLabel?: string | null;
+  embedded?: boolean;
 }
 
 function inferUnit(metricKey: string, panel: ResultsPanel): string {
@@ -59,7 +61,7 @@ function normalizeSeriesData(
   });
 }
 
-export function ResultsGraphPanel({ panel }: ResultsGraphPanelProps) {
+export function ResultsGraphPanel({ panel, focusedLabel = null, embedded = false }: ResultsGraphPanelProps) {
   const series = useMemo(() => panel.series ?? [], [panel.series]);
   const metricKey = panel.metric_keys[0] ?? panel.title;
   const unit = inferUnit(metricKey, panel);
@@ -136,13 +138,22 @@ export function ResultsGraphPanel({ panel }: ResultsGraphPanelProps) {
         symbolSize: 8,
         connectNulls: false,
         emphasis: { focus: 'series' },
+        lineStyle: {
+          opacity: focusedLabel && entry.name !== focusedLabel ? 0.28 : 1,
+          width: focusedLabel && entry.name === focusedLabel ? 3 : 2
+        },
+        itemStyle: {
+          opacity: focusedLabel && entry.name !== focusedLabel ? 0.32 : 1
+        },
         data: entry.data
       }))
     };
-  }, [logScale, metricKey, series, unit]);
+  }, [focusedLabel, logScale, metricKey, series, unit]);
+
+  const Wrapper = embedded ? 'div' : 'article';
 
   return (
-    <article className="card dashboard-panel" data-panel-type="graph">
+    <Wrapper className={embedded ? 'dashboard-panel dashboard-panel--embedded' : 'card dashboard-panel'} data-panel-type="graph">
       <header>
         <h3>{panel.title}</h3>
         <p className="muted">
@@ -161,6 +172,6 @@ export function ResultsGraphPanel({ panel }: ResultsGraphPanelProps) {
           <ReactECharts option={option} className="results-chart" notMerge lazyUpdate />
         </>
       )}
-    </article>
+    </Wrapper>
   );
 }

--- a/frontend/src/components/results-performance-comparison-panel.tsx
+++ b/frontend/src/components/results-performance-comparison-panel.tsx
@@ -13,6 +13,7 @@ const ReactECharts = _ReactECharts as unknown as ComponentType<EChartsReactProps
 
 interface ResultsPerformanceComparisonPanelProps {
   comparison: ResultsPerformanceComparisonView;
+  embedded?: boolean;
 }
 
 function formatValue(value: number | null | undefined, unit = ''): string {
@@ -27,7 +28,7 @@ function groupLabel(group: ResultsPerformanceComparisonView['groups'][number]): 
   return `${group.server_name} / ${group.model_name}`;
 }
 
-export function ResultsPerformanceComparisonPanel({ comparison }: ResultsPerformanceComparisonPanelProps) {
+export function ResultsPerformanceComparisonPanel({ comparison, embedded = false }: ResultsPerformanceComparisonPanelProps) {
   const metricOptions = comparison.metrics.filter((metric) =>
     comparison.groups.some((group) => group.metrics[metric.metric_key])
   );
@@ -112,8 +113,10 @@ export function ResultsPerformanceComparisonPanel({ comparison }: ResultsPerform
     return null;
   }
 
+  const Wrapper = embedded ? 'div' : 'section';
+
   return (
-    <section className="results-panel results-comparison-panel" data-panel-type="performance-comparison">
+    <Wrapper className={embedded ? 'results-comparison-panel' : 'results-panel results-comparison-panel'} data-panel-type="performance-comparison">
       <header className="results-panel__header">
         <div>
           <h2>Cold-start comparison</h2>
@@ -166,6 +169,6 @@ export function ResultsPerformanceComparisonPanel({ comparison }: ResultsPerform
         </table>
       </div>
       <ReactECharts option={option} className="results-comparison-chart" notMerge lazyUpdate />
-    </section>
+    </Wrapper>
   );
 }

--- a/frontend/src/pages/ResultsUnified.tsx
+++ b/frontend/src/pages/ResultsUnified.tsx
@@ -3,8 +3,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { MergedPageHeader } from '../components/MergedPageHeader.js';
 import { FirstRunCompleteHero } from '../components/Onboarding.js';
-import { ResultsGraphPanel } from '../components/results-graph-panel.js';
-import { ResultsPerformanceComparisonPanel } from '../components/results-performance-comparison-panel.js';
+import { ResultsAdaptiveChartPanel } from '../components/results-adaptive-chart-panel.js';
 import { normalizeResultsTab } from '../navigation.js';
 import { useOnboardingContext } from '../onboarding-context.js';
 import { getLeaderboard, type LeaderboardEntry } from '../services/leaderboard-api.js';
@@ -21,7 +20,6 @@ import {
   type ResultsStatus,
   type ResultsTab
 } from '../services/results-view-api.js';
-import type { ResultsPanel } from '../services/results-panels.js';
 import { toLocalInputValue } from '../services/results-panels.js';
 import '../styles/dashboard-results.css';
 
@@ -179,23 +177,6 @@ function templatesForFunnel(options: ResultsFilterOptions | null, serverIds: str
     optionMatchesSelected(serverIds, option.server_ids) &&
     optionMatchesSelected(modelNames, option.model_names)
   ));
-}
-
-function seriesPanel(title: string, metric: string, series: Array<{ label: string; points: Array<{ x: string; y: number | null }> }>): ResultsPanel {
-  return {
-    panel_id: `results:${metric}`,
-    presentation_type: 'performance_graph',
-    title,
-    runtime_key: 'selected',
-    server_version: null,
-    model_id: 'selected',
-    test_ids: [],
-    metric_keys: [metric],
-    unit_keys: metric === 'pass_rate' ? ['%'] : ['ms'],
-    grouped: true,
-    series,
-    missing_fields: []
-  };
 }
 
 function ResultsFilterRail({
@@ -632,9 +613,19 @@ function FilterCheckGroup({
   );
 }
 
-function DashboardTab({ rows, dashboard, onOpenRun }: { rows: ResultsHistoryRow[]; dashboard: Awaited<ReturnType<typeof queryResultsView>>['dashboard']; onOpenRun: (id: string) => void }) {
+function DashboardTab({
+  rows,
+  dashboard,
+  filters,
+  onOpenRun
+}: {
+  rows: ResultsHistoryRow[];
+  dashboard: Awaited<ReturnType<typeof queryResultsView>>['dashboard'];
+  filters: ResultsFilterState;
+  onOpenRun: (id: string) => void;
+}) {
   const cards = dashboard.scorecards;
-  const hasPerformanceComparison = (dashboard.performance_comparison?.groups.length ?? 0) > 0;
+  const [focusedRun, setFocusedRun] = useState<ResultsHistoryRow | null>(null);
   return (
     <div className="results-main-stack">
       <div className="results-scorecards">
@@ -643,14 +634,7 @@ function DashboardTab({ rows, dashboard, onOpenRun }: { rows: ResultsHistoryRow[
         <div className="results-scorecard"><span>Median latency</span><strong>{formatNumber(cards.median_latency_ms, ' ms')}</strong></div>
         <div className="results-scorecard"><span>Median cost</span><strong>{cards.median_cost == null ? 'N/A' : `$${cards.median_cost.toFixed(6)}`}</strong></div>
       </div>
-      {hasPerformanceComparison ? (
-        <ResultsPerformanceComparisonPanel comparison={dashboard.performance_comparison} />
-      ) : (
-        <>
-          <ResultsGraphPanel panel={seriesPanel('Pass-rate over time', 'pass_rate', dashboard.pass_rate_series)} />
-          <ResultsGraphPanel panel={seriesPanel('Latency distribution', 'latency_ms', dashboard.latency_series)} />
-        </>
-      )}
+      <ResultsAdaptiveChartPanel dashboard={dashboard} filters={filters} focusedRun={focusedRun} />
       <section className="results-panel">
         <header className="results-panel__header">
           <h2>Recent runs</h2>
@@ -659,7 +643,16 @@ function DashboardTab({ rows, dashboard, onOpenRun }: { rows: ResultsHistoryRow[
         <div className="results-mini-list">
           {dashboard.recent_runs.length === 0 ? <p className="muted">No runs match the current filters.</p> : null}
           {dashboard.recent_runs.map((run) => (
-            <button key={run.run_id} type="button" className="results-run-row" onClick={() => onOpenRun(run.run_id)}>
+            <button
+              key={run.run_id}
+              type="button"
+              className="results-run-row"
+              onBlur={() => setFocusedRun(null)}
+              onClick={() => onOpenRun(run.run_id)}
+              onFocus={() => setFocusedRun(run)}
+              onMouseEnter={() => setFocusedRun(run)}
+              onMouseLeave={() => setFocusedRun(null)}
+            >
               <StatusPill status={run.status} />
               <span>{run.template_label}</span>
               <strong>{run.model_name}</strong>
@@ -1207,7 +1200,7 @@ export function ResultsUnified({ runCount }: { runCount: number | null }) {
           {showDashboardEmpty ? (
             <DashboardEmptyState onExpandRange={() => expandRange(90)} onGoToRun={() => navigate('/run')} />
           ) : data && activeTab === 'dashboard' ? (
-            <DashboardTab rows={data.history.rows} dashboard={data.dashboard} onOpenRun={openRun} />
+            <DashboardTab rows={data.history.rows} dashboard={data.dashboard} filters={filters} onOpenRun={openRun} />
           ) : null}
           {data && activeTab === 'leaderboard' ? (
             <LeaderboardTab

--- a/frontend/src/services/results-adaptive-chart.ts
+++ b/frontend/src/services/results-adaptive-chart.ts
@@ -1,0 +1,98 @@
+import type {
+  ResultsDashboardView,
+  ResultsFilterState,
+  ResultsHistoryRow,
+  ResultsPerformanceComparisonView
+} from './results-view-api.js';
+
+export type ResultsChartMode = 'auto' | 'cold-start' | 'latency-trend' | 'pass-rate-trend' | 'latency-histogram' | 'model-summary';
+export type ResolvedResultsChartMode = Exclude<ResultsChartMode, 'auto'>;
+
+export interface HistogramBucket {
+  label: string;
+  min: number;
+  max: number;
+  series: Array<{ label: string; count: number }>;
+}
+
+function finitePointCount(series: Array<{ points: Array<{ y: number | null }> }>): number {
+  return series.reduce(
+    (total, entry) => total + entry.points.filter((point) => typeof point.y === 'number' && Number.isFinite(point.y)).length,
+    0
+  );
+}
+
+export function hasPerformanceComparison(comparison: ResultsPerformanceComparisonView | null | undefined): boolean {
+  return Boolean(comparison?.groups.some((group) => Object.keys(group.metrics).length > 0));
+}
+
+export function resolveResultsChartMode(
+  mode: ResultsChartMode,
+  dashboard: ResultsDashboardView,
+  filters: ResultsFilterState,
+  focusedRun: ResultsHistoryRow | null = null
+): ResolvedResultsChartMode | null {
+  if (mode !== 'auto') {
+    return mode;
+  }
+
+  const latencyPoints = finitePointCount(dashboard.latency_series);
+  const passRatePoints = finitePointCount(dashboard.pass_rate_series);
+
+  if (focusedRun && latencyPoints > 0) {
+    return 'latency-trend';
+  }
+  if (hasPerformanceComparison(dashboard.performance_comparison)) {
+    return 'cold-start';
+  }
+  if (latencyPoints >= 6) {
+    return 'latency-histogram';
+  }
+  if (latencyPoints > 0) {
+    return 'latency-trend';
+  }
+  if (passRatePoints > 0) {
+    return 'pass-rate-trend';
+  }
+  return dashboard.scorecards.total_runs > 0 ? 'model-summary' : null;
+}
+
+export function buildLatencyHistogram(series: ResultsDashboardView['latency_series'], bucketCount = 8): HistogramBucket[] {
+  const values = series.flatMap((entry) =>
+    entry.points
+      .map((point) => point.y)
+      .filter((value): value is number => typeof value === 'number' && Number.isFinite(value))
+  );
+  if (values.length === 0) {
+    return [];
+  }
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const width = max === min ? 1 : (max - min) / Math.max(1, bucketCount);
+  const buckets = Array.from({ length: Math.max(1, bucketCount) }, (_, index) => {
+    const bucketMin = min + width * index;
+    const bucketMax = index === bucketCount - 1 ? max : min + width * (index + 1);
+    return {
+      label: max === min ? `${Math.round(min)} ms` : `${Math.round(bucketMin)}-${Math.round(bucketMax)} ms`,
+      min: bucketMin,
+      max: bucketMax,
+      series: [] as Array<{ label: string; count: number }>
+    };
+  });
+
+  for (const entry of series) {
+    const counts = new Array(buckets.length).fill(0) as number[];
+    for (const point of entry.points) {
+      if (typeof point.y !== 'number' || !Number.isFinite(point.y)) {
+        continue;
+      }
+      const index = max === min ? 0 : Math.min(buckets.length - 1, Math.floor((point.y - min) / width));
+      counts[index] += 1;
+    }
+    counts.forEach((count, index) => {
+      buckets[index].series.push({ label: entry.label, count });
+    });
+  }
+
+  return buckets;
+}

--- a/frontend/src/services/results-view-api.ts
+++ b/frontend/src/services/results-view-api.ts
@@ -48,6 +48,13 @@ export interface ResultsDashboardView {
   };
   pass_rate_series: Array<{ label: string; points: Array<{ x: string; y: number | null }> }>;
   latency_series: Array<{ label: string; points: Array<{ x: string; y: number | null }> }>;
+  model_summary: Array<{
+    model_name: string;
+    run_count: number;
+    pass_rate: number | null;
+    median_latency_ms: number | null;
+    median_cost: number | null;
+  }>;
   performance_comparison: ResultsPerformanceComparisonView;
   recent_runs: ResultsHistoryRow[];
 }

--- a/frontend/src/styles/dashboard-results.css
+++ b/frontend/src/styles/dashboard-results.css
@@ -69,6 +69,15 @@
   height: 360px;
 }
 
+.results-adaptive-chart {
+  display: grid;
+  gap: 16px;
+}
+
+.dashboard-panel--embedded header {
+  margin-bottom: 8px;
+}
+
 .table-scroll {
   overflow-x: auto;
 }

--- a/frontend/tests/e2e/results-dashboard.spec.ts
+++ b/frontend/tests/e2e/results-dashboard.spec.ts
@@ -89,6 +89,12 @@ function resultsViewPayload(empty = false) {
       latency_series: rows.length
         ? [{ label: 'mistral:latest', points: [{ x: '2026-02-08T00:00:00.000Z', y: 80 }] }]
         : [],
+      model_summary: rows.length
+        ? [
+            { model_name: 'mistral:latest', run_count: 1, pass_rate: 100, median_latency_ms: 80, median_cost: 0.001 },
+            { model_name: 'qwen:latest', run_count: 1, pass_rate: 100, median_latency_ms: 120, median_cost: 0.002 }
+          ]
+        : [],
       performance_comparison: {
         default_metric: 'cold_penalty_ms',
         metrics: [
@@ -268,14 +274,25 @@ test('merged Results dashboard filter and render flow', async ({ page }) => {
 
   await expect(page.getByText('Total runs')).toBeVisible();
   await expect(page.getByText('Pass rate')).toBeVisible();
+  await expect(page.locator('[data-panel-type="adaptive-chart"]')).toBeVisible();
+  await expect(page.getByLabel('View')).toHaveValue('auto');
+  await expect(page.getByText('Auto selected: Cold-start comparison')).toBeVisible();
   await expect(page.locator('[data-panel-type="performance-comparison"]')).toBeVisible();
   await expect(page.getByRole('heading', { name: 'Cold-start comparison' })).toBeVisible();
   await expect(page.getByRole('cell', { name: 'mistral:latest' })).toBeVisible();
   await expect(page.getByRole('cell', { name: '80.00 ms' }).first()).toBeVisible();
+  await page.getByLabel('View').selectOption('latency-histogram');
+  await expect(page.locator('[data-panel-type="adaptive-chart"] p.muted')).toHaveText('Latency histogram');
+  await page.getByLabel('View').selectOption('model-summary');
+  await expect(page.getByRole('columnheader', { name: 'Runs' })).toBeVisible();
+  await expect(page.getByRole('cell', { name: '1' }).first()).toBeVisible();
+  await page.getByLabel('View').selectOption('auto');
   await expect(page.getByRole('heading', { name: 'Recent runs' })).toBeVisible();
 
   const recentRun = page.locator('.results-run-row').filter({ hasText: 'latency-benchmark' });
   await expect(recentRun).toBeVisible();
+  await recentRun.hover();
+  await expect(page.getByText('Auto selected: Latency trend')).toBeVisible();
   await recentRun.click();
   await expect(page.getByText('Run detail')).toBeVisible();
   await expect(page.getByText('run-dashboard-1')).toBeVisible();

--- a/frontend/tests/unit/results-adaptive-chart.test.ts
+++ b/frontend/tests/unit/results-adaptive-chart.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildLatencyHistogram,
+  resolveResultsChartMode
+} from '../../src/services/results-adaptive-chart.js';
+import type { ResultsDashboardView, ResultsFilterState, ResultsHistoryRow } from '../../src/services/results-view-api.js';
+
+const filters: ResultsFilterState = {
+  date_from: '2026-05-01T00:00:00.000Z',
+  date_to: '2026-05-02T00:00:00.000Z',
+  server_ids: [],
+  model_names: [],
+  template_ids: [],
+  statuses: [],
+  tags: [],
+  score_min: null,
+  score_max: null,
+  sort_by: 'started_at',
+  sort_dir: 'desc',
+  page: 1,
+  page_size: 50
+};
+
+function dashboard(overrides: Partial<ResultsDashboardView> = {}): ResultsDashboardView {
+  return {
+    scorecards: {
+      total_runs: 0,
+      pass_rate: null,
+      median_latency_ms: null,
+      median_cost: null
+    },
+    pass_rate_series: [],
+    latency_series: [],
+    model_summary: [],
+    performance_comparison: {
+      default_metric: 'cold_penalty_ms',
+      metrics: [{ metric_key: 'cold_penalty_ms', label: 'Cold penalty', unit: 'ms' }],
+      groups: []
+    },
+    recent_runs: [],
+    ...overrides
+  };
+}
+
+function row(overrides: Partial<ResultsHistoryRow>): ResultsHistoryRow {
+  return {
+    run_id: 'run-a',
+    status: 'pass',
+    started_at: '2026-05-01T10:00:00.000Z',
+    ended_at: null,
+    duration_ms: null,
+    server_id: 'srv',
+    server_name: 'Server',
+    model_name: 'model-a',
+    template_id: 'template',
+    template_label: 'Template',
+    score: 100,
+    latency_ms: 100,
+    cost: 0.001,
+    tags: [],
+    result_count: 1,
+    ...overrides
+  };
+}
+
+describe('results adaptive chart helpers', () => {
+  it('preserves cold-start comparison as the auto default when sample comparisons exist', () => {
+    const view = dashboard({
+      scorecards: { total_runs: 1, pass_rate: 100, median_latency_ms: 100, median_cost: null },
+      performance_comparison: {
+        default_metric: 'cold_penalty_ms',
+        metrics: [{ metric_key: 'cold_penalty_ms', label: 'Cold penalty', unit: 'ms' }],
+        groups: [
+          {
+            group_id: 'srv|model-a|template',
+            server_id: 'srv',
+            server_name: 'Server',
+            model_name: 'model-a',
+            template_id: 'template',
+            template_label: 'Template',
+            metrics: {
+              cold_penalty_ms: {
+                metric_key: 'cold_penalty_ms',
+                label: 'Cold penalty',
+                unit: 'ms',
+                samples: [80, 90, 100],
+                stats: { count: 3, min: 80, q1: 85, median: 90, q3: 95, p95: 99, max: 100, mean: 90 }
+              }
+            }
+          }
+        ]
+      }
+    });
+
+    expect(resolveResultsChartMode('auto', view, filters)).toBe('cold-start');
+  });
+
+  it('uses a latency histogram when auto has enough latency samples and no comparison samples', () => {
+    const view = dashboard({
+      scorecards: { total_runs: 6, pass_rate: 100, median_latency_ms: 125, median_cost: null },
+      latency_series: [{ label: 'model-a', points: [80, 90, 100, 120, 130, 140].map((y, index) => ({ x: `run-${index}`, y })) }]
+    });
+
+    expect(resolveResultsChartMode('auto', view, filters)).toBe('latency-histogram');
+  });
+
+  it('uses latency trend when a recent run is focused', () => {
+    const view = dashboard({
+      scorecards: { total_runs: 2, pass_rate: 100, median_latency_ms: 95, median_cost: null },
+      latency_series: [{ label: 'model-a', points: [{ x: 'run-a', y: 90 }, { x: 'run-b', y: 100 }] }]
+    });
+
+    expect(resolveResultsChartMode('auto', view, filters, row({ run_id: 'run-a' }))).toBe('latency-trend');
+  });
+
+  it('builds latency histogram buckets from model series', () => {
+    const buckets = buildLatencyHistogram([
+      { label: 'model-a', points: [{ x: 'a', y: 50 }, { x: 'b', y: 150 }] },
+      { label: 'model-b', points: [{ x: 'c', y: 250 }] }
+    ], 2);
+
+    expect(buckets).toHaveLength(2);
+    expect(buckets[0].series).toContainEqual({ label: 'model-a', count: 1 });
+    expect(buckets[1].series).toContainEqual({ label: 'model-a', count: 1 });
+    expect(buckets[1].series).toContainEqual({ label: 'model-b', count: 1 });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "inferharness",
       "version": "0.8.0",
+      "hasInstallScript": true,
       "workspaces": [
         "backend",
         "frontend"


### PR DESCRIPTION
Add an adaptive Results dashboard panel with Auto, cold-start comparison, latency trend, pass-rate trend, latency histogram, and model summary modes.

Expose filtered model_summary aggregates from the results-view dashboard API so table-style model comparisons are based on all matching runs instead of the current history page.

Update chart components for embedded rendering and focused model emphasis from recent-run hover/focus interactions.

Cover the behavior with backend integration tests, frontend helper tests, dashboard e2e assertions, and update README/CHANGELOG documentation.