### PR TITLE
Add native Anthropic and Gemini tool-call benchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 
 ### Added
 
+- **Native Anthropic and Gemini benchmark tool calls** — benchmark execution now resolves Anthropic Messages and Gemini GenerateContent operations, maps dataset tools and `tool_choice` into provider-native payloads, and normalizes returned tool calls and usage metrics.
 - **Adaptive Results performance views** — the Results dashboard now has an Auto performance view with manual modes for cold-start comparison, latency trend, pass-rate trend, latency histogram, and model-summary table comparisons backed by filtered model aggregates.
 - **Project workflow guardrails** — `AGENTS.md` now combines the main branch workflow, Node 25 rules, challenge-and-skill behavior instructions, and a static-data rule that keeps prompts, schemas, fixtures, and examples out of application code.
 - **Benchmark template agent** — Templates now includes a review-first benchmark-template agent that uses a database-persisted Settings model, challenges underspecified requests, loads its prompt from Markdown with the full `test_template` schema and example injected, validates generated drafts server-side, and applies drafts to the existing editor without auto-saving.

--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ InferHarness supports local inference servers and native cloud provider APIs.
 | [Cerebras](https://cerebras.ai) | OpenAI-compatible | `/v1/models` | Bearer token |
 
 Cloud providers use the direct public API (not Bedrock or Vertex AI). Tokens are never stored in plaintext; use the `token_env` field to reference an environment variable.
+Benchmark runs use provider-native request payloads for non-streaming Anthropic Messages and Gemini GenerateContent tool-call tests, including provider-specific tool declarations and normalized returned tool calls.
 
 Model formats supported in the catalog include `GGUF`, `MLX`, `GPTQ`, `AWQ`, and `SafeTensors`.
 

--- a/backend/src/schemas/benchmark/dataset_manifest.schema.json
+++ b/backend/src/schemas/benchmark/dataset_manifest.schema.json
@@ -38,6 +38,7 @@
           "system_prompt": { "type": ["string", "null"] },
           "interaction_mode": { "type": "string", "enum": ["chat", "tool_calling", "structured_output", "multi_turn", "agentic"] },
           "tools": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+          "tool_choice": { "type": ["string", "object", "null"], "additionalProperties": true },
           "expected_tool_calls": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
           "expected_answer": { "type": ["string", "number", "boolean", "object", "array", "null"] },
           "expected_format": { "type": "string", "enum": ["free_text", "json", "markdown", "code", "boolean", "number", "schema", "regex"] },

--- a/backend/src/schemas/benchmark/model_profile.schema.json
+++ b/backend/src/schemas/benchmark/model_profile.schema.json
@@ -164,7 +164,7 @@
             "schema_family": {
               "type": "array",
               "minItems": 1,
-              "items": { "type": "string", "enum": ["openai-compatible", "ollama", "custom"] },
+              "items": { "type": "string", "enum": ["openai-compatible", "ollama", "anthropic", "gemini", "custom"] },
               "uniqueItems": true
             },
             "api_version": { "type": ["string", "null"] }

--- a/backend/src/schemas/benchmark/model_snapshot.schema.json
+++ b/backend/src/schemas/benchmark/model_snapshot.schema.json
@@ -222,7 +222,7 @@
             "schema_family": {
               "type": "array",
               "minItems": 1,
-              "items": { "type": "string", "enum": ["openai-compatible", "ollama", "custom"] },
+              "items": { "type": "string", "enum": ["openai-compatible", "ollama", "anthropic", "gemini", "custom"] },
               "uniqueItems": true
             },
             "api_version": { "type": ["string", "null"] }

--- a/backend/src/schemas/benchmark/test_instantiation.schema.json
+++ b/backend/src/schemas/benchmark/test_instantiation.schema.json
@@ -48,7 +48,7 @@
         "method": { "type": "string", "enum": ["GET", "POST"] },
         "url": { "type": "string", "minLength": 1 },
         "endpoint": { "type": "string", "minLength": 1 },
-        "protocol": { "type": "string", "enum": ["ollama_chat", "ollama_generate", "ollama_embedding", "ollama_list_models", "openai_chat", "openai_embedding", "openai_list_models"] },
+        "protocol": { "type": "string", "enum": ["ollama_chat", "ollama_generate", "ollama_embedding", "ollama_list_models", "openai_chat", "openai_embedding", "openai_list_models", "anthropic_messages", "gemini_generate_content"] },
         "operation": { "type": "string", "enum": ["chat_completion", "completion", "embedding", "list_models", "healthcheck"] },
         "supports_streaming": { "type": "boolean" },
         "supports_usage": { "type": "boolean" }

--- a/backend/src/services/benchmark-datasets.ts
+++ b/backend/src/services/benchmark-datasets.ts
@@ -22,6 +22,7 @@ const optionalItemFields: Record<string, (value: unknown) => boolean> = {
   system_prompt: (value) => value === null || typeof value === 'string',
   interaction_mode: (value) => ['chat', 'tool_calling', 'structured_output', 'multi_turn', 'agentic'].includes(String(value)),
   tools: Array.isArray,
+  tool_choice: (value) => value === null || typeof value === 'string' || (typeof value === 'object' && !Array.isArray(value)),
   expected_tool_calls: Array.isArray,
   expected_answer: () => true,
   expected_format: (value) => ['free_text', 'json', 'markdown', 'code', 'boolean', 'number', 'schema', 'regex'].includes(String(value)),

--- a/backend/src/services/benchmark-foundation.ts
+++ b/backend/src/services/benchmark-foundation.ts
@@ -277,6 +277,30 @@ export function resolveOperationSpec(
       supports_usage: false
     };
   }
+  if (schemaFamily.includes('anthropic')) {
+    return {
+      method: 'POST',
+      url: new URL('/v1/messages', baseUrl).toString(),
+      endpoint: '/v1/messages',
+      protocol: 'anthropic_messages',
+      operation,
+      supports_streaming: false,
+      supports_usage: true
+    };
+  }
+  if (schemaFamily.includes('gemini')) {
+    const modelId = String((snapshot.model as { model_id?: unknown } | undefined)?.model_id ?? '');
+    const modelPath = modelId.startsWith('models/') ? modelId : `models/${modelId}`;
+    return {
+      method: 'POST',
+      url: new URL(`/v1beta/${modelPath}:generateContent`, baseUrl).toString(),
+      endpoint: `/v1beta/{model}:generateContent`,
+      protocol: 'gemini_generate_content',
+      operation,
+      supports_streaming: false,
+      supports_usage: true
+    };
+  }
   if (schemaFamily.includes('openai-compatible')) {
     return {
       method: 'POST',

--- a/backend/src/services/benchmark-runner.ts
+++ b/backend/src/services/benchmark-runner.ts
@@ -300,6 +300,126 @@ function messagesFromItem(item: Record<string, unknown>): Array<Record<string, s
   return messages;
 }
 
+function arrayFromItem(item: Record<string, unknown>, key: string): unknown[] {
+  const value = item[key];
+  return Array.isArray(value) ? value : [];
+}
+
+function functionName(tool: unknown): string | null {
+  const record = objectValue(tool);
+  const fn = objectValue(record?.function);
+  return textFromValue(fn?.name) ?? textFromValue(record?.name);
+}
+
+function functionDescription(tool: unknown): string | undefined {
+  const record = objectValue(tool);
+  const fn = objectValue(record?.function);
+  return textFromValue(fn?.description) ?? textFromValue(record?.description) ?? undefined;
+}
+
+function functionParameters(tool: unknown): Record<string, unknown> {
+  const record = objectValue(tool);
+  const fn = objectValue(record?.function);
+  const parameters = objectValue(fn?.parameters) ?? objectValue(record?.parameters) ?? objectValue(record?.input_schema);
+  return parameters ?? { type: 'object', properties: {} };
+}
+
+function openAiToolsFromItem(item: Record<string, unknown>): unknown[] | undefined {
+  const tools = arrayFromItem(item, 'tools');
+  return tools.length > 0 ? tools : undefined;
+}
+
+function anthropicToolsFromItem(item: Record<string, unknown>): Array<Record<string, unknown>> | undefined {
+  const tools = arrayFromItem(item, 'tools')
+    .map((tool) => {
+      const name = functionName(tool);
+      if (!name) return null;
+      const declaration: Record<string, unknown> = {
+        name,
+        ...(functionDescription(tool) ? { description: functionDescription(tool) } : {}),
+        input_schema: functionParameters(tool)
+      };
+      return declaration;
+    })
+    .filter((tool): tool is Record<string, unknown> => tool !== null);
+  return tools.length > 0 ? tools : undefined;
+}
+
+function geminiToolsFromItem(item: Record<string, unknown>): Array<Record<string, unknown>> | undefined {
+  const functionDeclarations = arrayFromItem(item, 'tools')
+    .map((tool) => {
+      const name = functionName(tool);
+      if (!name) return null;
+      const declaration: Record<string, unknown> = {
+        name,
+        ...(functionDescription(tool) ? { description: functionDescription(tool) } : {}),
+        parameters: functionParameters(tool)
+      };
+      return declaration;
+    })
+    .filter((tool): tool is Record<string, unknown> => tool !== null);
+  return functionDeclarations.length > 0 ? [{ functionDeclarations }] : undefined;
+}
+
+function toolChoiceFromSource(item: Record<string, unknown>, params: Record<string, unknown>): unknown {
+  return item.tool_choice ?? params.tool_choice;
+}
+
+function openAiToolChoice(choice: unknown): unknown {
+  return choice;
+}
+
+function anthropicToolChoice(choice: unknown): unknown {
+  if (choice === 'auto' || choice === undefined || choice === null) return undefined;
+  if (choice === 'none') return { type: 'none' };
+  if (choice === 'required') return { type: 'any' };
+  if (typeof choice === 'string') return { type: 'tool', name: choice };
+  const record = objectValue(choice);
+  const fn = objectValue(record?.function);
+  const name = textFromValue(fn?.name) ?? textFromValue(record?.name);
+  return name ? { type: 'tool', name } : choice;
+}
+
+function geminiToolConfig(choice: unknown): unknown {
+  if (choice === undefined || choice === null || choice === 'auto') return undefined;
+  if (choice === 'none') {
+    return { functionCallingConfig: { mode: 'NONE' } };
+  }
+  if (choice === 'required') {
+    return { functionCallingConfig: { mode: 'ANY' } };
+  }
+  if (typeof choice === 'string') {
+    return { functionCallingConfig: { mode: 'ANY', allowedFunctionNames: [choice] } };
+  }
+  const record = objectValue(choice);
+  const fn = objectValue(record?.function);
+  const name = textFromValue(fn?.name) ?? textFromValue(record?.name);
+  return name ? { functionCallingConfig: { mode: 'ANY', allowedFunctionNames: [name] } } : choice;
+}
+
+function anthropicMessages(messages: Array<Record<string, string>>): Array<Record<string, string>> {
+  return messages
+    .filter((message) => message.role !== 'system')
+    .map((message) => ({
+      role: message.role === 'assistant' ? 'assistant' : 'user',
+      content: message.content
+    }));
+}
+
+function systemPromptFromMessages(messages: Array<Record<string, string>>): string | undefined {
+  const system = messages.filter((message) => message.role === 'system').map((message) => message.content).join('\n\n');
+  return system.trim().length > 0 ? system : undefined;
+}
+
+function geminiContents(messages: Array<Record<string, string>>): Array<Record<string, unknown>> {
+  return messages
+    .filter((message) => message.role !== 'system')
+    .map((message) => ({
+      role: message.role === 'assistant' ? 'model' : 'user',
+      parts: [{ text: message.content }]
+    }));
+}
+
 function runtimeParameters(instantiation: Record<string, unknown>): Record<string, unknown> {
   return objectAt(instantiation, 'runtime_parameters') ?? {};
 }
@@ -385,6 +505,10 @@ export function buildBenchmarkRequestPayload(
         payload[key] = params[key];
       }
     }
+    const tools = openAiToolsFromItem(item);
+    const toolChoice = openAiToolChoice(toolChoiceFromSource(item, params));
+    if (tools) payload.tools = tools;
+    if (toolChoice !== undefined && toolChoice !== null) payload.tool_choice = toolChoice;
     return payload;
   }
 
@@ -398,7 +522,50 @@ export function buildBenchmarkRequestPayload(
       model,
       messages,
       stream,
+      ...(openAiToolsFromItem(item) ? { tools: openAiToolsFromItem(item) } : {}),
       ...(Object.keys(options).length > 0 ? { options } : {})
+    };
+  }
+
+  if (protocol === 'anthropic_messages') {
+    if (stream) {
+      throw new BenchmarkValidationError('Streaming benchmark execution is not supported for anthropic_messages in this checkpoint.');
+    }
+    const payload: Record<string, unknown> = {
+      model,
+      messages: anthropicMessages(messages),
+      max_tokens: typeof params.max_tokens === 'number' ? params.max_tokens : 1024
+    };
+    const system = systemPromptFromMessages(messages);
+    const tools = anthropicToolsFromItem(item);
+    const toolChoice = anthropicToolChoice(toolChoiceFromSource(item, params));
+    if (system) payload.system = system;
+    if (params.temperature !== undefined && params.temperature !== null) payload.temperature = params.temperature;
+    if (params.top_p !== undefined && params.top_p !== null) payload.top_p = params.top_p;
+    if (params.stop !== undefined && params.stop !== null) payload.stop_sequences = params.stop;
+    if (tools) payload.tools = tools;
+    if (toolChoice !== undefined && toolChoice !== null) payload.tool_choice = toolChoice;
+    return payload;
+  }
+
+  if (protocol === 'gemini_generate_content') {
+    if (stream) {
+      throw new BenchmarkValidationError('Streaming benchmark execution is not supported for gemini_generate_content in this checkpoint.');
+    }
+    const generationConfig: Record<string, unknown> = {};
+    if (params.temperature !== undefined && params.temperature !== null) generationConfig.temperature = params.temperature;
+    if (params.top_p !== undefined && params.top_p !== null) generationConfig.topP = params.top_p;
+    if (params.max_tokens !== undefined && params.max_tokens !== null) generationConfig.maxOutputTokens = params.max_tokens;
+    if (params.stop !== undefined && params.stop !== null) generationConfig.stopSequences = params.stop;
+    const system = systemPromptFromMessages(messages);
+    const tools = geminiToolsFromItem(item);
+    const toolConfig = geminiToolConfig(toolChoiceFromSource(item, params));
+    return {
+      contents: geminiContents(messages),
+      ...(system ? { systemInstruction: { parts: [{ text: system }] } } : {}),
+      ...(Object.keys(generationConfig).length > 0 ? { generationConfig } : {}),
+      ...(tools ? { tools } : {}),
+      ...(toolConfig ? { toolConfig } : {})
     };
   }
 
@@ -443,12 +610,21 @@ function extractServerEvalMs(metadata: Record<string, unknown> | null): number |
 
 function usageTokens(metadata: Record<string, unknown> | null): Pick<NormalizedResponse, 'input_tokens' | 'output_tokens' | 'total_tokens'> {
   const usage = objectValue(metadata?.usage);
-  const inputTokens = numberAt(usage, 'prompt_tokens') ?? numberAt(metadata, 'prompt_eval_count');
-  const outputTokens = numberAt(usage, 'completion_tokens') ?? numberAt(metadata, 'eval_count');
+  const usageMetadata = objectValue(metadata?.usageMetadata);
+  const inputTokens = numberAt(usage, 'prompt_tokens')
+    ?? numberAt(usage, 'input_tokens')
+    ?? numberAt(usageMetadata, 'promptTokenCount')
+    ?? numberAt(metadata, 'prompt_eval_count');
+  const outputTokens = numberAt(usage, 'completion_tokens')
+    ?? numberAt(usage, 'output_tokens')
+    ?? numberAt(usageMetadata, 'candidatesTokenCount')
+    ?? numberAt(metadata, 'eval_count');
   return {
     input_tokens: inputTokens,
     output_tokens: outputTokens,
-    total_tokens: numberAt(usage, 'total_tokens') ?? (inputTokens !== null && outputTokens !== null ? inputTokens + outputTokens : null)
+    total_tokens: numberAt(usage, 'total_tokens')
+      ?? numberAt(usageMetadata, 'totalTokenCount')
+      ?? (inputTokens !== null && outputTokens !== null ? inputTokens + outputTokens : null)
   };
 }
 
@@ -566,9 +742,90 @@ function normalizeStreamResponse(protocol: unknown, contentType: string, respons
   };
 }
 
-function normalizeResponse(body: unknown, text: string | null): NormalizedResponse {
+function normalizeAnthropicResponse(record: Record<string, unknown>): NormalizedResponse {
+  const content = Array.isArray(record.content) ? record.content : [];
+  const textParts: string[] = [];
+  const toolCalls: unknown[] = [];
+  for (const block of content) {
+    const entry = objectValue(block);
+    if (!entry) continue;
+    if (entry.type === 'text' && typeof entry.text === 'string') {
+      textParts.push(entry.text);
+    }
+    if (entry.type === 'tool_use') {
+      const name = textFromValue(entry.name);
+      if (name) {
+        toolCalls.push({
+          id: textFromValue(entry.id) ?? undefined,
+          type: 'function',
+          function: {
+            name,
+            arguments: entry.input ?? {}
+          }
+        });
+      }
+    }
+  }
+  return {
+    answer_text: textParts.join(''),
+    ...usageTokens(record),
+    load_duration_ms: extractLoadDurationMs(record),
+    server_total_time_ms: extractServerTotalTimeMs(record),
+    server_prompt_eval_ms: extractServerPromptEvalMs(record),
+    server_eval_ms: extractServerEvalMs(record),
+    tool_calls: toolCalls.length > 0 ? toolCalls : null,
+    body: record,
+    text: null
+  };
+}
+
+function normalizeGeminiResponse(record: Record<string, unknown>): NormalizedResponse {
+  const candidates = Array.isArray(record.candidates) ? record.candidates : [];
+  const firstCandidate = objectValue(candidates[0]);
+  const content = objectValue(firstCandidate?.content);
+  const parts = Array.isArray(content?.parts) ? content.parts : [];
+  const textParts: string[] = [];
+  const toolCalls: unknown[] = [];
+  for (const part of parts) {
+    const entry = objectValue(part);
+    if (!entry) continue;
+    if (typeof entry.text === 'string') {
+      textParts.push(entry.text);
+    }
+    const functionCall = objectValue(entry.functionCall);
+    const name = textFromValue(functionCall?.name);
+    if (name) {
+      toolCalls.push({
+        type: 'function',
+        function: {
+          name,
+          arguments: objectValue(functionCall?.args) ?? {}
+        }
+      });
+    }
+  }
+  return {
+    answer_text: textParts.join(''),
+    ...usageTokens(record),
+    load_duration_ms: extractLoadDurationMs(record),
+    server_total_time_ms: extractServerTotalTimeMs(record),
+    server_prompt_eval_ms: extractServerPromptEvalMs(record),
+    server_eval_ms: extractServerEvalMs(record),
+    tool_calls: toolCalls.length > 0 ? toolCalls : null,
+    body: record,
+    text: null
+  };
+}
+
+function normalizeResponse(protocol: unknown, body: unknown, text: string | null): NormalizedResponse {
   if (body && typeof body === 'object' && !Array.isArray(body)) {
     const record = body as Record<string, unknown>;
+    if (protocol === 'anthropic_messages') {
+      return normalizeAnthropicResponse(record);
+    }
+    if (protocol === 'gemini_generate_content') {
+      return normalizeGeminiResponse(record);
+    }
     const choices = Array.isArray(record.choices) ? record.choices : [];
     const firstChoice = choices[0] as Record<string, unknown> | undefined;
     const message = firstChoice && typeof firstChoice.message === 'object' && !Array.isArray(firstChoice.message)
@@ -616,6 +873,13 @@ function normalizeResponse(body: unknown, text: string | null): NormalizedRespon
   };
 }
 
+function providerHeaders(protocol: unknown): Record<string, string> {
+  if (protocol === 'anthropic_messages') {
+    return { 'anthropic-version': '2023-06-01' };
+  }
+  return {};
+}
+
 async function executeItem(
   instantiation: Record<string, unknown>,
   stage: BenchmarkStage,
@@ -651,7 +915,7 @@ async function executeItem(
     try {
       const response = await backendFetch(url, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...authHeaders },
+        headers: { 'Content-Type': 'application/json', ...providerHeaders(operationSpec?.protocol), ...authHeaders },
         body: JSON.stringify(payload),
         signal: controller.signal
       });
@@ -692,7 +956,7 @@ async function executeItem(
       try {
         normalized = effectiveStreaming
           ? normalizeStreamResponse(operationSpec?.protocol, contentType, responseText)
-          : normalizeResponse(responseBody, responseBody === null ? responseText : null);
+          : normalizeResponse(operationSpec?.protocol, responseBody, responseBody === null ? responseText : null);
       } catch (error) {
         if (!(error instanceof BenchmarkStreamParseError)) {
           throw error;

--- a/backend/tests/integration/benchmark-runner.test.ts
+++ b/backend/tests/integration/benchmark-runner.test.ts
@@ -40,6 +40,29 @@ function benchmarkTemplate(iterations = 1, stopOnError = false): Record<string, 
   };
 }
 
+function toolBenchmarkTemplate(): Record<string, unknown> {
+  return {
+    ...benchmarkTemplate(),
+    template_id: 'runner_tool_chat_v1',
+    required_capabilities: {
+      chat_completion: true,
+      streaming: false,
+      tool_calling: true,
+      structured_output: false
+    },
+    metrics: [
+      'tool_call_count',
+      'tool_selected_correctly',
+      'tool_arguments_valid',
+      'missing_tool_call',
+      'hallucinated_tool_call',
+      'input_tokens',
+      'output_tokens'
+    ],
+    aggregations: ['mean', 'count']
+  };
+}
+
 function pairedBenchmarkTemplate(stopOnError = false): Record<string, unknown> {
   return {
     ...benchmarkTemplate(1, stopOnError),
@@ -69,10 +92,11 @@ function pairedBenchmarkTemplate(stopOnError = false): Record<string, unknown> {
 
 function seedServerAndModel(
   baseUrl: string,
-  options: { schemaFamily?: string[]; streaming?: boolean; authToken?: string } = {}
+  options: { schemaFamily?: string[]; streaming?: boolean; authToken?: string; authHeader?: string; tools?: boolean } = {}
 ): void {
   const schemaFamily = options.schemaFamily ?? ['openai-compatible'];
   const streaming = options.streaming ?? true;
+  const tools = options.tools ?? false;
   createInferenceServer({
     inference_server: {
       server_id: 'srv-runner',
@@ -94,11 +118,11 @@ function seedServerAndModel(
     },
     endpoints: { base_url: baseUrl, health_url: null, https: false },
     auth: options.authToken
-      ? { type: 'bearer', header_name: 'Authorization', token_env: null, token: options.authToken }
+      ? { type: options.authHeader ? 'custom' : 'bearer', header_name: options.authHeader ?? 'Authorization', token_env: null, token: options.authToken }
       : { type: 'none', header_name: 'Authorization', token_env: null, token: null },
     capabilities: {
       server: { streaming, models_endpoint: true },
-      generation: { text: true, json_schema_output: true, tools: false, embeddings: false },
+      generation: { text: true, json_schema_output: true, tools, embeddings: false },
       multimodal: {
         vision: { input_images: false, output_images: false },
         audio: { input_audio: false, output_audio: false }
@@ -145,7 +169,7 @@ function seedServerAndModel(
     },
     modalities: { input: ['text'], output: ['text'] },
     capabilities: {
-      generation: { text: true, json_schema_output: true, tools: false, embeddings: false },
+      generation: { text: true, json_schema_output: true, tools, embeddings: false },
       multimodal: { vision: false, audio: false },
       reasoning: { supported: false, explicit_tokens: false },
       use_case: { thinking: false, coding: false, instruct: true, mixture_of_experts: false }
@@ -169,6 +193,47 @@ function seedServerAndModel(
     discovery: { retrieved_at: '2026-06-05T10:00:00.000Z', source: 'manual' },
     raw: {}
   });
+}
+
+function toolDataset(): Record<string, unknown> {
+  return {
+    dataset_id: 'embedded-tool-runner',
+    source: { source_type: 'inline', format: 'json' },
+    snapshot_policy: 'embedded',
+    items: [
+      {
+        id: 'item-1',
+        system_prompt: 'Use tools when they are the precise way to answer.',
+        prompt: 'What is the weather in Paris in celsius?',
+        tools: [
+          {
+            type: 'function',
+            function: {
+              name: 'get_weather',
+              description: 'Get current weather for a city.',
+              parameters: {
+                type: 'object',
+                properties: {
+                  city: { type: 'string' },
+                  unit: { type: 'string', enum: ['celsius', 'fahrenheit'] }
+                },
+                required: ['city', 'unit']
+              }
+            }
+          }
+        ],
+        tool_choice: 'get_weather',
+        expected_tool_calls: [
+          {
+            function: {
+              name: 'get_weather'
+            },
+            arguments: { city: 'Paris', unit: 'celsius' }
+          }
+        ]
+      }
+    ]
+  };
 }
 
 function installMockInferenceFetch(status: number | number[] = 200): { baseUrl: string; requests: unknown[]; headers: Record<string, string>[] } {
@@ -285,6 +350,78 @@ function installMockOllamaStreamFetch(): { baseUrl: string; requests: unknown[] 
   return { baseUrl: 'http://mock.local', requests };
 }
 
+function installMockAnthropicFetch(): { baseUrl: string; requests: unknown[]; headers: Record<string, string>[] } {
+  const requests: unknown[] = [];
+  const headers: Record<string, string>[] = [];
+  vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (url !== 'http://mock.local/v1/messages') {
+      return new Response('', { status: 404 });
+    }
+    const body = typeof init?.body === 'string' ? JSON.parse(init.body) as Record<string, unknown> : {};
+    requests.push(body);
+    headers.push(Object.fromEntries(new Headers(init?.headers).entries()));
+    return new Response(JSON.stringify({
+      id: 'msg_1',
+      type: 'message',
+      role: 'assistant',
+      content: [
+        {
+          type: 'tool_use',
+          id: 'toolu_1',
+          name: 'get_weather',
+          input: { city: 'Paris', unit: 'celsius' }
+        }
+      ],
+      usage: { input_tokens: 21, output_tokens: 9 }
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }));
+  return { baseUrl: 'http://mock.local', requests, headers };
+}
+
+function installMockGeminiFetch(): { baseUrl: string; requests: unknown[]; headers: Record<string, string>[] } {
+  const requests: unknown[] = [];
+  const headers: Record<string, string>[] = [];
+  vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (url !== 'http://mock.local/v1beta/models/mock-chat:generateContent') {
+      return new Response('', { status: 404 });
+    }
+    const body = typeof init?.body === 'string' ? JSON.parse(init.body) as Record<string, unknown> : {};
+    requests.push(body);
+    headers.push(Object.fromEntries(new Headers(init?.headers).entries()));
+    return new Response(JSON.stringify({
+      candidates: [
+        {
+          content: {
+            role: 'model',
+            parts: [
+              {
+                functionCall: {
+                  name: 'get_weather',
+                  args: { city: 'Paris', unit: 'celsius' }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      usageMetadata: {
+        promptTokenCount: 19,
+        candidatesTokenCount: 7,
+        totalTokenCount: 26
+      }
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }));
+  return { baseUrl: 'http://mock.local', requests, headers };
+}
+
 function runtimeProfile(executionPolicy: Record<string, unknown>): Record<string, unknown> {
   return {
     kind: 'runtime_profile',
@@ -390,7 +527,7 @@ describe('benchmark runner API', () => {
       url: `/benchmark/instantiations/${instantiation.id}/run`,
       headers: AUTH_HEADERS
     });
-    expect(runResponse.statusCode).toBe(201);
+    expect(runResponse.statusCode, JSON.stringify(runResponse.json())).toBe(201);
     const result = runResponse.json();
     expect(result.instantiation_id).toBe(instantiation.id);
     expect(result.document.status).toBe('completed');
@@ -444,7 +581,7 @@ describe('benchmark runner API', () => {
       url: `/benchmark/instantiations/${createResponse.json().id}/run`,
       headers: AUTH_HEADERS
     });
-    expect(runResponse.statusCode).toBe(201);
+    expect(runResponse.statusCode, JSON.stringify(runResponse.json())).toBe(201);
     const result = runResponse.json();
     expect(result.document.status).toBe('completed');
     expect(mockServer.requests).toHaveLength(4);
@@ -492,11 +629,176 @@ describe('benchmark runner API', () => {
       url: `/benchmark/instantiations/${createResponse.json().id}/run`,
       headers: AUTH_HEADERS
     });
-    expect(runResponse.statusCode).toBe(201);
+    expect(runResponse.statusCode, JSON.stringify(runResponse.json())).toBe(201);
     expect(mockServer.headers?.[0]).toMatchObject({
       authorization: 'Bearer mistral-secret',
       'content-type': 'application/json'
     });
+    await app.close();
+  });
+
+  it('executes Anthropic Messages tool-call benchmarks with native payload and normalization', async () => {
+    mockServer = installMockAnthropicFetch();
+    const app = createServer();
+    seedServerAndModel(mockServer.baseUrl, {
+      schemaFamily: ['anthropic'],
+      streaming: true,
+      authToken: 'anthropic-secret',
+      authHeader: 'x-api-key',
+      tools: true
+    });
+
+    const createResponse = await app.inject({
+      method: 'POST',
+      url: '/benchmark/instantiations',
+      headers: AUTH_HEADERS,
+      payload: {
+        template: toolBenchmarkTemplate(),
+        server_id: 'srv-runner',
+        model_id: 'mock-chat',
+        runtime_profile: runtimeProfile({ timeout_ms: 5000 }),
+        dataset: toolDataset()
+      }
+    });
+    expect(createResponse.statusCode, JSON.stringify(createResponse.json())).toBe(201);
+    expect(createResponse.json().document.operation_spec.protocol).toBe('anthropic_messages');
+
+    const runResponse = await app.inject({
+      method: 'POST',
+      url: `/benchmark/instantiations/${createResponse.json().id}/run`,
+      headers: AUTH_HEADERS
+    });
+    expect(runResponse.statusCode, JSON.stringify(runResponse.json())).toBe(201);
+    const result = runResponse.json();
+    expect(result.document.status).toBe('completed');
+    expect(mockServer.headers?.[0]).toMatchObject({
+      'anthropic-version': '2023-06-01',
+      'x-api-key': 'anthropic-secret'
+    });
+    const request = mockServer.requests[0] as Record<string, unknown>;
+    expect(request).toMatchObject({
+      model: 'mock-chat',
+      system: 'Use tools when they are the precise way to answer.',
+      max_tokens: 32,
+      tool_choice: { type: 'tool', name: 'get_weather' }
+    });
+    expect(request.messages).toEqual([{ role: 'user', content: 'What is the weather in Paris in celsius?' }]);
+    expect(request.tools).toEqual([
+      {
+        name: 'get_weather',
+        description: 'Get current weather for a city.',
+        input_schema: {
+          type: 'object',
+          properties: {
+            city: { type: 'string' },
+            unit: { type: 'string', enum: ['celsius', 'fahrenheit'] }
+          },
+          required: ['city', 'unit']
+        }
+      }
+    ]);
+    expect(result.document.normalized_responses[0].tool_calls[0]).toMatchObject({
+      id: 'toolu_1',
+      type: 'function',
+      function: {
+        name: 'get_weather',
+        arguments: { city: 'Paris', unit: 'celsius' }
+      }
+    });
+    expect(result.document.metric_results[0].tool_call_count).toBe(1);
+    expect(result.document.metric_results[0].tool_selected_correctly).toBe(true);
+    expect(result.document.metric_results[0].tool_arguments_valid).toBe(true);
+    expect(result.document.metric_results[0].missing_tool_call).toBe(false);
+    expect(result.document.metric_results[0].hallucinated_tool_call).toBe(false);
+    expect(result.document.metric_results[0].input_tokens).toBe(21);
+    expect(result.document.metric_results[0].output_tokens).toBe(9);
+    await app.close();
+  });
+
+  it('executes Gemini GenerateContent tool-call benchmarks with native payload and normalization', async () => {
+    mockServer = installMockGeminiFetch();
+    const app = createServer();
+    seedServerAndModel(mockServer.baseUrl, {
+      schemaFamily: ['gemini'],
+      streaming: true,
+      authToken: 'gemini-secret',
+      authHeader: 'x-goog-api-key',
+      tools: true
+    });
+
+    const createResponse = await app.inject({
+      method: 'POST',
+      url: '/benchmark/instantiations',
+      headers: AUTH_HEADERS,
+      payload: {
+        template: toolBenchmarkTemplate(),
+        server_id: 'srv-runner',
+        model_id: 'mock-chat',
+        runtime_profile: runtimeProfile({ timeout_ms: 5000 }),
+        dataset: toolDataset()
+      }
+    });
+    expect(createResponse.statusCode, JSON.stringify(createResponse.json())).toBe(201);
+    expect(createResponse.json().document.operation_spec.protocol).toBe('gemini_generate_content');
+
+    const runResponse = await app.inject({
+      method: 'POST',
+      url: `/benchmark/instantiations/${createResponse.json().id}/run`,
+      headers: AUTH_HEADERS
+    });
+    expect(runResponse.statusCode, JSON.stringify(runResponse.json())).toBe(201);
+    const result = runResponse.json();
+    expect(result.document.status).toBe('completed');
+    expect(mockServer.headers?.[0]).toMatchObject({
+      'x-goog-api-key': 'gemini-secret'
+    });
+    const request = mockServer.requests[0] as Record<string, unknown>;
+    expect(request).toMatchObject({
+      contents: [
+        {
+          role: 'user',
+          parts: [{ text: 'What is the weather in Paris in celsius?' }]
+        }
+      ],
+      systemInstruction: {
+        parts: [{ text: 'Use tools when they are the precise way to answer.' }]
+      },
+      generationConfig: { temperature: 0.1, maxOutputTokens: 32 },
+      toolConfig: {
+        functionCallingConfig: { mode: 'ANY', allowedFunctionNames: ['get_weather'] }
+      }
+    });
+    expect(request.tools).toEqual([
+      {
+        functionDeclarations: [
+          {
+            name: 'get_weather',
+            description: 'Get current weather for a city.',
+            parameters: {
+              type: 'object',
+              properties: {
+                city: { type: 'string' },
+                unit: { type: 'string', enum: ['celsius', 'fahrenheit'] }
+              },
+              required: ['city', 'unit']
+            }
+          }
+        ]
+      }
+    ]);
+    expect(result.document.normalized_responses[0].tool_calls[0]).toMatchObject({
+      type: 'function',
+      function: {
+        name: 'get_weather',
+        arguments: { city: 'Paris', unit: 'celsius' }
+      }
+    });
+    expect(result.document.metric_results[0].tool_call_count).toBe(1);
+    expect(result.document.metric_results[0].tool_selected_correctly).toBe(true);
+    expect(result.document.metric_results[0].tool_arguments_valid).toBe(true);
+    expect(result.document.metric_results[0].input_tokens).toBe(19);
+    expect(result.document.metric_results[0].output_tokens).toBe(7);
+    expect(result.document.metric_results[0].total_tokens).toBe(26);
     await app.close();
   });
 


### PR DESCRIPTION
Extend benchmark schemas and operation resolution with native Anthropic Messages and Gemini GenerateContent protocols.

Map provider-neutral dataset tools and tool_choice values into Anthropic and Gemini request payloads, including provider-specific parameters, headers, system prompts, and usage extraction.

Normalize Anthropic tool_use blocks and Gemini functionCall parts into the existing benchmark tool_calls shape, with integration coverage for native payloads and metrics.

Document the behavior in the changelog and README so project-visible provider support stays aligned.