### PR TITLE
feat(run): persist benchmark plan executions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 - **Adaptive Results performance views** — the Results dashboard now has an Auto performance view with manual modes for cold-start comparison, latency trend, pass-rate trend, latency histogram, and model-summary table comparisons backed by filtered model aggregates.
 - **Project workflow guardrails** — `AGENTS.md` now combines the main branch workflow, Node 25 rules, challenge-and-skill behavior instructions, and a static-data rule that keeps prompts, schemas, fixtures, and examples out of application code.
 - **Benchmark template agent** — Templates now includes a review-first benchmark-template agent that uses a database-persisted Settings model, challenges underspecified requests, loads its prompt from Markdown with the full `test_template` schema and example injected, validates generated drafts server-side, and applies drafts to the existing editor without auto-saving.
+- **Run-page persisted benchmark plan checkpoint** — Run can now select saved chat benchmark templates, prepare inline or server-side dataset manifests, persist unique runtime/dataset/plan artifacts per click, execute `/benchmark/plans/:id/run`, and render per-target results including failed targets without result documents.
 
 ### Fixed
 

--- a/backend/src/services/benchmark-datasets.ts
+++ b/backend/src/services/benchmark-datasets.ts
@@ -11,10 +11,12 @@ type DatasetItem = Record<string, unknown>;
 export interface PrepareDatasetManifestInput {
   dataset_id: string;
   source: {
-    source_type: 'file';
+    source_type: 'file' | 'inline';
     format: 'json' | 'jsonl' | 'csv';
-    path: string;
+    path?: string;
   };
+  items?: DatasetItem[];
+  snapshot_policy?: 'embedded' | 'manifest_only';
   metadata?: Record<string, unknown>;
 }
 
@@ -220,10 +222,31 @@ export function prepareBenchmarkDatasetManifest(input: PrepareDatasetManifestInp
   if (!datasetId) {
     throw new BenchmarkValidationError('Benchmark dataset manifest requires dataset_id.');
   }
+  if (input.source.source_type === 'inline') {
+    if (input.snapshot_policy && input.snapshot_policy !== 'embedded') {
+      throw new BenchmarkValidationError('Inline benchmark datasets must use snapshot_policy=embedded.');
+    }
+    const items = normalizeItems(input.items ?? []);
+    return buildDatasetManifest({
+      dataset_id: datasetId,
+      source: {
+        source_type: 'inline',
+        format: input.source.format
+      },
+      snapshot_policy: 'embedded',
+      item_count: items.length,
+      items,
+      metadata: input.metadata
+    });
+  }
+  const sourcePath = input.source.path?.trim();
+  if (!sourcePath) {
+    throw new BenchmarkValidationError('Benchmark dataset manifest requires source.path for file datasets.');
+  }
   const source = {
     source_type: input.source.source_type,
     format: input.source.format,
-    path: input.source.path.trim()
+    path: sourcePath
   };
   const items = readBenchmarkDatasetFile(source);
   return buildDatasetManifest({

--- a/backend/tests/unit/benchmark-datasets.test.ts
+++ b/backend/tests/unit/benchmark-datasets.test.ts
@@ -99,6 +99,40 @@ describe('benchmark dataset resolver', () => {
     })));
   });
 
+  it('prepares an embedded inline dataset manifest', () => {
+    const prepared = prepareBenchmarkDatasetManifest({
+      dataset_id: 'inline-dataset',
+      source: { source_type: 'inline', format: 'json' },
+      snapshot_policy: 'embedded',
+      items
+    });
+
+    expect(prepared).toMatchObject({
+      kind: 'dataset_manifest',
+      schema_version: 'benchmark_dataset_manifest_v1',
+      dataset_id: 'inline-dataset',
+      source: { source_type: 'inline', format: 'json' },
+      snapshot_policy: 'embedded',
+      item_count: 2,
+      items
+    });
+    expect(prepared.dataset_hash).toBe(sha256Document({
+      source: { source_type: 'inline', format: 'json' },
+      canonicalization_version: 'dataset_canonical_v1',
+      item_count: items.length,
+      items
+    }));
+  });
+
+  it('rejects manifest_only inline dataset manifests', () => {
+    expect(() => prepareBenchmarkDatasetManifest({
+      dataset_id: 'inline-dataset',
+      source: { source_type: 'inline', format: 'json' },
+      snapshot_policy: 'manifest_only',
+      items
+    })).toThrow(/snapshot_policy=embedded/);
+  });
+
   it('loads manifest_only JSON array datasets', () => {
     const jsonSource = { ...source, format: 'json', path: 'dataset.json' };
     write(path.join(tmpDir, 'dataset.json'), JSON.stringify(items));

--- a/frontend/src/pages/RunUnified.tsx
+++ b/frontend/src/pages/RunUnified.tsx
@@ -8,20 +8,22 @@ import { useOnboardingContext } from '../onboarding-context.js';
 import { isRibbonDismissed } from '../onboarding.js';
 import {
   STARTER_BENCHMARK_TEMPLATE_ID,
-  buildBenchmarkPlanPayload,
+  buildPersistedBenchmarkPlanDocument,
   buildBenchmarkSmokePayload,
-  createBenchmarkInstantiation,
+  getBenchmarkInstantiation,
   getBenchmarkResult,
   listBenchmarkDocuments,
   prepareBenchmarkDatasetManifest,
-  runBenchmarkInstantiation,
-  runBenchmarkPlan,
+  runPersistedBenchmarkPlan,
   saveBenchmarkDocument,
+  saveBenchmarkPlan,
   starterBenchmarkTemplateDocument,
   type BenchmarkDatasetFormat,
   type BenchmarkInstantiationRecord,
+  type BenchmarkPlanRunResult,
   type BenchmarkResultRecord,
-  type BenchmarkTestTemplateDocument
+  type BenchmarkTestTemplateDocument,
+  type BenchmarkTestTemplateRecord
 } from '../services/benchmark-api.js';
 import type { InferenceServerHealth } from '../services/connectivity-api.js';
 import { DEFAULT_INFERENCE_PARAMS, type InferenceParams } from '../services/inference-param-presets-api.js';
@@ -184,6 +186,13 @@ function streamSummary(result: BenchmarkResultRecord | null): string {
 
 type RunDatasetMode = 'inline' | 'manifest_only';
 
+function newRunId(prefix: string): string {
+  if (globalThis.crypto && 'randomUUID' in globalThis.crypto) {
+    return `${prefix}-${globalThis.crypto.randomUUID()}`;
+  }
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
 function datasetManifest(instantiation: BenchmarkInstantiationRecord | null): Record<string, unknown> | null {
   const dataset = instantiation?.document.dataset;
   return dataset && typeof dataset === 'object' && !Array.isArray(dataset)
@@ -196,6 +205,11 @@ function resultStatus(result: BenchmarkResultRecord | null, busy: boolean): stri
     return 'running';
   }
   return result?.document.status ?? 'idle';
+}
+
+function planResultForTarget(planResults: BenchmarkPlanRunResult[], target: RunTarget): BenchmarkPlanRunResult | null {
+  const ref = `${target.inference_server_id}:${target.model_id}`;
+  return planResults.find((entry) => entry.model_profile_ref === ref) ?? null;
 }
 
 function ConfigRail({
@@ -213,6 +227,8 @@ function ConfigRail({
   datasetId,
   datasetFormat,
   datasetPath,
+  templates,
+  selectedTemplateId,
   inferenceParams,
   onboardingActive,
   starterTemplateReady,
@@ -229,6 +245,7 @@ function ConfigRail({
   onDatasetIdChange,
   onDatasetFormatChange,
   onDatasetPathChange,
+  onTemplateChange,
   onRun,
   onUseStarterTemplate
 }: {
@@ -246,6 +263,8 @@ function ConfigRail({
   datasetId: string;
   datasetFormat: BenchmarkDatasetFormat;
   datasetPath: string;
+  templates: BenchmarkTestTemplateRecord[];
+  selectedTemplateId: string;
   inferenceParams: InferenceParams;
   onboardingActive?: boolean;
   starterTemplateReady?: boolean;
@@ -262,6 +281,7 @@ function ConfigRail({
   onDatasetIdChange: (value: string) => void;
   onDatasetFormatChange: (value: BenchmarkDatasetFormat) => void;
   onDatasetPathChange: (value: string) => void;
+  onTemplateChange: (value: string) => void;
   onRun: () => void;
   onUseStarterTemplate: () => Promise<void>;
 }) {
@@ -345,7 +365,7 @@ function ConfigRail({
       </div>
 
       <div className="run-config-step">
-        <div className="run-step-label">Step 3 · dataset</div>
+        <div className="run-step-label">Step 3 · template</div>
         {onboardingActive && selectedTargets.length > 0 ? (
           <div className="run-starter-template">
             <div>
@@ -357,6 +377,22 @@ function ConfigRail({
             </button>
           </div>
         ) : null}
+        <label className="run-template-picker">
+          Benchmark template
+          <select value={selectedTemplateId} onChange={(event) => onTemplateChange(event.target.value)}>
+            <option value="">Run smoke chat</option>
+            {templates.map((template) => (
+              <option key={template.id} value={template.id}>
+                {template.document.name || template.document.template_id}
+              </option>
+            ))}
+          </select>
+        </label>
+        <p className="run-hint">Saved chat templates run against the selected dataset. The smoke template remains available for quick checks.</p>
+      </div>
+
+      <div className="run-config-step">
+        <div className="run-step-label">Step 4 · dataset</div>
         <div className="segmented-control run-dataset-mode" aria-label="Dataset mode">
           <button type="button" className={datasetMode === 'inline' ? 'is-active' : ''} onClick={() => onDatasetModeChange('inline')}>
             Prompt
@@ -422,7 +458,7 @@ function ConfigRail({
       </div>
 
       <div className={selectedTargets.length === 0 ? 'run-config-step is-disabled' : 'run-config-step'}>
-        <div className="run-step-label">Step 4 · options</div>
+        <div className="run-step-label">Step 5 · options</div>
         <div className="run-options-grid">
           <label>
             Items
@@ -557,16 +593,20 @@ function BenchmarkDetail({
   option,
   instantiation,
   result,
+  planResult,
+  planId,
   busy
 }: {
   target: RunTarget;
   option: RunModelOption | undefined;
   instantiation: BenchmarkInstantiationRecord | null;
   result: BenchmarkResultRecord | null;
+  planResult?: BenchmarkPlanRunResult | null;
+  planId?: string | null;
   busy: boolean;
 }) {
   const metrics = benchmarkMetrics(result);
-  const status = resultStatus(result, busy);
+  const status = planResult?.status ?? resultStatus(result, busy);
   const manifest = datasetManifest(instantiation);
   const responses = normalizedResponseItems(result);
   const itemCount = aggStat(result, 'elapsed_ms', 'count');
@@ -598,6 +638,12 @@ function BenchmarkDetail({
             <span>{result.document.errors.map((error) => String(error.message ?? error.code ?? 'Unknown error')).join('; ')}</span>
           </div>
         ) : null}
+        {!result && planResult && planResult.status !== 'completed' ? (
+          <div className="run-failure-banner">
+            <strong>Benchmark target did not produce a result.</strong>
+            <span>{planResult.status}</span>
+          </div>
+        ) : null}
         <div className="run-message-list">
           {busy || responses.length === 0 ? (
             <section className={busy ? 'run-message-card is-streaming' : 'run-message-card'}>
@@ -621,6 +667,10 @@ function BenchmarkDetail({
           <div className="run-assert-row">
             <span>id</span>
             <code>{instantiation?.id ?? 'no-instantiation'}</code>
+          </div>
+          <div className="run-assert-row">
+            <span>plan</span>
+            <code>{planId ?? 'no-plan'}</code>
           </div>
           <div className="run-assert-row">
             <span>run</span>
@@ -732,21 +782,27 @@ export function RunUnified({
   const [datasetId, setDatasetId] = useState('codegen-small');
   const [datasetFormat, setDatasetFormat] = useState<BenchmarkDatasetFormat>('jsonl');
   const [datasetPath, setDatasetPath] = useState('codegen-small.jsonl');
+  const [templates, setTemplates] = useState<BenchmarkTestTemplateRecord[]>([]);
+  const [selectedTemplateId, setSelectedTemplateId] = useState('');
   const [inferenceParams, setInferenceParams] = useState<InferenceParams>(DEFAULT_INFERENCE_PARAMS);
   const [starterTemplate, setStarterTemplate] = useState<BenchmarkTestTemplateDocument | null>(null);
   const [starterBusy, setStarterBusy] = useState(false);
   const [instantiation, setInstantiation] = useState<BenchmarkInstantiationRecord | null>(null);
   const [result, setResult] = useState<BenchmarkResultRecord | null>(null);
+  const [planId, setPlanId] = useState<string | null>(null);
+  const [planResults, setPlanResults] = useState<BenchmarkPlanRunResult[]>([]);
+  const [instantiations, setInstantiations] = useState<(BenchmarkInstantiationRecord | null)[]>([]);
   const [multiResults, setMultiResults] = useState<(BenchmarkResultRecord | null)[]>([]);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [showResultsHandoff, setShowResultsHandoff] = useState(false);
 
   useEffect(() => {
-    Promise.all([listInferenceServers(), listModels()])
-      .then(([serverData, modelData]) => {
+    Promise.all([listInferenceServers(), listModels(), listBenchmarkDocuments<BenchmarkTestTemplateDocument>('test_template')])
+      .then(([serverData, modelData, templateData]) => {
         setServers(serverData);
         setModels(modelData);
+        setTemplates(templateData.filter((entry) => entry.document.operation === 'chat_completion'));
         setCustomServerId((current) => current || serverData[0]?.inference_server.server_id || '');
       })
       .catch((err) => setError(err instanceof Error ? err.message : 'Unable to load run configuration.'));
@@ -795,11 +851,18 @@ export function RunUnified({
     ? `${selectedTarget.model_id} · ${datasetMode === 'manifest_only' ? 'dataset run' : 'benchmark smoke'}`
     : `No model · ${datasetMode === 'manifest_only' ? 'dataset run' : 'benchmark smoke'}`;
 
-  function addTarget(target: RunTarget) {
+  function clearRunState() {
     setInstantiation(null);
     setResult(null);
+    setPlanId(null);
+    setPlanResults([]);
+    setInstantiations([]);
     setMultiResults([]);
     setShowResultsHandoff(false);
+  }
+
+  function addTarget(target: RunTarget) {
+    clearRunState();
     setSelectedTargets((current) => {
       const key = targetKey(target);
       if (current.some((entry) => targetKey(entry) === key)) {
@@ -810,10 +873,7 @@ export function RunUnified({
   }
 
   function removeTarget(target: RunTarget) {
-    setInstantiation(null);
-    setResult(null);
-    setMultiResults([]);
-    setShowResultsHandoff(false);
+    clearRunState();
     setSelectedTargets((current) => current.filter((entry) => targetKey(entry) !== targetKey(target)));
   }
 
@@ -825,11 +885,17 @@ export function RunUnified({
         .then((documents) => documents.find((record) => record.id === STARTER_BENCHMARK_TEMPLATE_ID || record.document.template_id === STARTER_BENCHMARK_TEMPLATE_ID))
         .catch(() => null);
       const document = existing?.document ?? starterBenchmarkTemplateDocument();
+      let savedTemplate = existing ?? null;
       if (!existing) {
-        await saveBenchmarkDocument(document);
+        savedTemplate = await saveBenchmarkDocument(document);
         window.dispatchEvent(new CustomEvent('templates:changed'));
       }
       setStarterTemplate(document);
+      const readyTemplate = savedTemplate;
+      if (readyTemplate) {
+        setTemplates((current) => current.some((record) => record.id === readyTemplate.id) ? current : [readyTemplate, ...current]);
+        setSelectedTemplateId(readyTemplate.id);
+      }
       setDatasetMode('inline');
       setPrompt('Explain what this function does, identify one edge case, and describe the time complexity:\n\nfunction clamp(value, min, max) {\n  return Math.min(Math.max(value, min), max);\n}');
       setSystemPrompt('You are a careful code reviewer. Be concise and specific.');
@@ -853,65 +919,106 @@ export function RunUnified({
     }
     setBusy(true);
     setError(null);
-    setResult(null);
-    setMultiResults([]);
-    setShowResultsHandoff(false);
+    clearRunState();
     try {
+      const runSuffix = newRunId('run');
+      const smokePayload = buildBenchmarkSmokePayload({
+        target: selectedTarget,
+        prompt: prompt.trim(),
+        systemPrompt,
+        inferenceParams,
+        timeoutSec,
+        seed
+      });
       const preparedDataset = datasetMode === 'manifest_only'
         ? await prepareBenchmarkDatasetManifest({
-            dataset_id: datasetId.trim(),
+            dataset_id: `run-dataset-${runSuffix}`,
             source: {
               source_type: 'file',
               format: datasetFormat,
               path: datasetPath.trim()
             },
-            metadata: { source: 'run-page-dataset-path' }
+            metadata: {
+              source: 'run-page-dataset-path',
+              requested_dataset_id: datasetId.trim()
+            }
           })
-        : undefined;
-      const datasetInput = preparedDataset
-        ? { mode: 'manifest_only' as const, manifest: preparedDataset }
-        : { mode: 'inline' as const, prompt: prompt.trim(), systemPrompt };
+        : await prepareBenchmarkDatasetManifest({
+            dataset_id: `run-dataset-${runSuffix}`,
+            source: {
+              source_type: 'inline',
+              format: 'json'
+            },
+            snapshot_policy: 'embedded',
+            items: [
+              {
+                id: 'item-1',
+                prompt: prompt.trim(),
+                ...(systemPrompt.trim() ? { system_prompt: systemPrompt.trim() } : {})
+              }
+            ],
+            metadata: { source: 'run-page-inline' }
+          });
 
-      if (selectedTargets.length > 1) {
-        const payload = buildBenchmarkPlanPayload({
-          targets: selectedTargets,
-          prompt: prompt.trim(),
-          systemPrompt,
-          inferenceParams,
-          timeoutSec,
-          seed,
-          dataset: datasetInput,
-          template: starterTemplate ?? undefined
-        });
-        const plan = await runBenchmarkPlan(payload);
-        const fetched = await Promise.all(
-          plan.run_results.map((r) =>
-            r.run_id ? getBenchmarkResult(r.run_id).catch(() => null) : Promise.resolve(null)
-          )
-        );
-        setMultiResults(fetched);
-        window.dispatchEvent(new CustomEvent('runs:changed'));
-      } else {
-        const payload = buildBenchmarkSmokePayload({
-          target: selectedTarget,
-          prompt: prompt.trim(),
-          systemPrompt,
-          inferenceParams,
-          timeoutSec,
-          seed,
-          dataset: datasetInput,
-          template: starterTemplate ?? undefined
-        });
-        const created = await createBenchmarkInstantiation(payload);
-        setInstantiation(created);
-        const completed = await runBenchmarkInstantiation(created.id);
-        setResult(completed);
-        if (completed.document.status === 'completed' && completed.document.errors.length === 0) {
-          onFirstRunSuccess?.();
-          setShowResultsHandoff(true);
-        }
-        window.dispatchEvent(new CustomEvent('runs:changed'));
+      const selectedTemplate = templates.find((entry) => entry.id === selectedTemplateId);
+      let templateRef = selectedTemplate?.id ?? starterTemplate?.template_id ?? '';
+      if (!templateRef) {
+        const smokeTemplate = {
+          ...smokePayload.template,
+          template_id: `run-template-${runSuffix}`,
+          metadata: {
+            source: 'run-page-smoke'
+          }
+        };
+        const savedTemplate = await saveBenchmarkDocument(smokeTemplate);
+        templateRef = savedTemplate.id;
       }
+
+      const runtimeProfile = {
+        ...smokePayload.runtime_profile,
+        profile_id: `run-runtime-${runSuffix}`,
+        metadata: {
+          source: 'run-page'
+        }
+      };
+      const savedDataset = await saveBenchmarkDocument(preparedDataset);
+      const savedRuntime = await saveBenchmarkDocument(runtimeProfile);
+      const planDocument = buildPersistedBenchmarkPlanDocument({
+        planId: `run-plan-${runSuffix}`,
+        templateRef,
+        datasetRef: savedDataset.id,
+        runtimeProfileRef: savedRuntime.id,
+        targets: selectedTargets,
+        metadata: {
+          source: 'run-page',
+          selected_template_id: selectedTemplate?.id ?? null
+        }
+      });
+      const savedPlan = await saveBenchmarkPlan(planDocument);
+      setPlanId(savedPlan.id);
+      const plan = await runPersistedBenchmarkPlan(savedPlan.id);
+      setPlanResults(plan.run_results);
+
+      const fetchedInstantiations = await Promise.all(
+        plan.run_results.map((entry) =>
+          entry.instantiation_id ? getBenchmarkInstantiation(entry.instantiation_id).catch(() => null) : Promise.resolve(null)
+        )
+      );
+      const fetchedResults = await Promise.all(
+        plan.run_results.map((entry) =>
+          entry.run_id ? getBenchmarkResult(entry.run_id).catch(() => null) : Promise.resolve(null)
+        )
+      );
+      setInstantiations(fetchedInstantiations);
+      setMultiResults(fetchedResults);
+      setInstantiation(fetchedInstantiations[0] ?? null);
+      setResult(fetchedResults[0] ?? null);
+      const firstResult = fetchedResults[0] ?? null;
+      if (firstResult?.document.status === 'completed' && firstResult.document.errors.length === 0) {
+        onFirstRunSuccess?.();
+        setShowResultsHandoff(true);
+      }
+      window.dispatchEvent(new CustomEvent('runs:changed'));
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Unable to run benchmark.');
     } finally {
@@ -951,6 +1058,8 @@ export function RunUnified({
             datasetId={datasetId}
             datasetFormat={datasetFormat}
             datasetPath={datasetPath}
+            templates={templates}
+            selectedTemplateId={selectedTemplateId}
             inferenceParams={inferenceParams}
             onboardingActive={onboarding?.status.active}
             starterTemplateReady={Boolean(starterTemplate)}
@@ -967,6 +1076,7 @@ export function RunUnified({
             onDatasetIdChange={setDatasetId}
             onDatasetFormatChange={setDatasetFormat}
             onDatasetPathChange={setDatasetPath}
+            onTemplateChange={setSelectedTemplateId}
             onRun={handleRun}
             onUseStarterTemplate={ensureStarterTemplate}
           />
@@ -974,7 +1084,7 @@ export function RunUnified({
             <header className="run-page-header">
               <div>
                 <h1>Run</h1>
-                <p>{subtitle}{multiResults.length > 0 ? ` · ${multiResults.length} models` : result ? ` · ${result.document.status}` : busy ? ' · running' : ''}</p>
+                <p>{subtitle}{selectedTargets.length > 1 && planResults.length > 0 ? ` · ${planResults.length} models` : result ? ` · ${result.document.status}` : busy ? ' · running' : ''}</p>
               </div>
               <div className="run-header-actions">
                 <button type="button" disabled={!result}>Export</button>
@@ -989,15 +1099,17 @@ export function RunUnified({
             />
             {!selectedTarget ? (
               <RunUnifiedEmpty />
-            ) : selectedTargets.length > 1 || multiResults.length > 0 ? (
+            ) : selectedTargets.length > 1 ? (
               <div style={{ display: 'flex', flexWrap: 'wrap' }}>
                 {selectedTargets.map((target, index) => (
                   <div key={targetKey(target)} style={{ flex: '1 1 50%', minWidth: 0, borderRight: '1px solid var(--paper-7)', borderBottom: '1px solid var(--paper-7)', boxSizing: 'border-box' }}>
                     <BenchmarkDetail
                       target={target}
                       option={optionMap.get(targetKey(target))}
-                      instantiation={null}
+                      instantiation={instantiations[index] ?? null}
                       result={multiResults[index] ?? null}
+                      planResult={planResultForTarget(planResults, target)}
+                      planId={planId}
                       busy={busy}
                     />
                   </div>
@@ -1009,6 +1121,8 @@ export function RunUnified({
                 option={selectedOption}
                 instantiation={instantiation}
                 result={result}
+                planResult={planResults[0] ?? null}
+                planId={planId}
                 busy={busy}
               />
             )}

--- a/frontend/src/services/benchmark-api.ts
+++ b/frontend/src/services/benchmark-api.ts
@@ -60,6 +60,47 @@ export interface BenchmarkTestTemplateDocument extends Record<string, unknown> {
 
 export type BenchmarkTestTemplateRecord = BenchmarkDocumentRecord<BenchmarkTestTemplateDocument>;
 
+export interface BenchmarkRuntimeProfileDocument extends Record<string, unknown> {
+  kind: 'runtime_profile';
+  schema_version: 'benchmark_runtime_profile_v1';
+  profile_id: string;
+  runtime_parameters?: Record<string, unknown>;
+  execution_policy?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+  extensions?: Record<string, unknown>;
+}
+
+export interface BenchmarkDatasetManifestDocument extends Record<string, unknown> {
+  kind: 'dataset_manifest';
+  schema_version: 'benchmark_dataset_manifest_v1';
+  dataset_id: string;
+  source: Record<string, unknown>;
+  canonicalization_version?: string;
+  snapshot_policy: 'embedded' | 'manifest_only' | 'compressed_blob';
+  dataset_hash?: string;
+  item_count?: number;
+  items?: Array<Record<string, unknown>>;
+  item_hashes?: Array<Record<string, unknown>>;
+  metadata?: Record<string, unknown>;
+}
+
+export interface BenchmarkPlanDocument extends Record<string, unknown> {
+  kind: 'benchmark_plan';
+  schema_version: 'benchmark_plan_v1';
+  plan_id: string;
+  template_ref: string;
+  dataset_ref: string;
+  runtime_profile_ref: string;
+  model_profile_refs: string[];
+  execution: {
+    mode: 'sequential' | 'parallel';
+    continue_on_model_error: boolean;
+    concurrency?: number;
+  };
+  metadata?: Record<string, unknown>;
+  extensions?: Record<string, unknown>;
+}
+
 export interface BenchmarkRunResultDocument {
   kind: 'test_run_result';
   schema_version: 'benchmark_test_run_result_v1';
@@ -119,10 +160,12 @@ export interface CreateBenchmarkInstantiationPayload {
 export interface PrepareBenchmarkDatasetManifestInput {
   dataset_id: string;
   source: {
-    source_type: 'file';
+    source_type: 'file' | 'inline';
     format: BenchmarkDatasetFormat;
-    path: string;
+    path?: string;
   };
+  items?: Array<Record<string, unknown>>;
+  snapshot_policy?: 'embedded' | 'manifest_only';
   metadata?: Record<string, unknown>;
 }
 
@@ -337,6 +380,44 @@ export interface BenchmarkPlanPayload {
 
 export async function runBenchmarkPlan(payload: BenchmarkPlanPayload): Promise<BenchmarkPlanResult> {
   return apiPost<BenchmarkPlanResult>('/benchmark/plans/run', payload);
+}
+
+export async function saveBenchmarkPlan(document: BenchmarkPlanDocument): Promise<BenchmarkDocumentRecord<BenchmarkPlanDocument>> {
+  return apiPost<BenchmarkDocumentRecord<BenchmarkPlanDocument>>('/benchmark/plans', document);
+}
+
+export async function runPersistedBenchmarkPlan(id: string): Promise<BenchmarkPlanResult> {
+  return apiPost<BenchmarkPlanResult>(`/benchmark/plans/${id}/run`, {});
+}
+
+export async function getBenchmarkInstantiation(id: string): Promise<BenchmarkInstantiationRecord> {
+  return apiGet<BenchmarkInstantiationRecord>(`/benchmark/instantiations/${id}`);
+}
+
+export function buildPersistedBenchmarkPlanDocument(input: {
+  planId: string;
+  templateRef: string;
+  datasetRef: string;
+  runtimeProfileRef: string;
+  targets: RunTarget[];
+  continueOnModelError?: boolean;
+  metadata?: Record<string, unknown>;
+}): BenchmarkPlanDocument {
+  return {
+    kind: 'benchmark_plan',
+    schema_version: 'benchmark_plan_v1',
+    plan_id: input.planId,
+    template_ref: input.templateRef,
+    dataset_ref: input.datasetRef,
+    runtime_profile_ref: input.runtimeProfileRef,
+    model_profile_refs: input.targets.map((target) => `${target.inference_server_id}:${target.model_id}`),
+    execution: {
+      mode: 'sequential',
+      continue_on_model_error: input.continueOnModelError ?? true,
+      concurrency: 1
+    },
+    metadata: input.metadata
+  };
 }
 
 export function buildBenchmarkPlanPayload(input: {

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -1769,10 +1769,18 @@ button.is-pending::after {
 
 .run-template-picker {
   margin: 0;
+  color: var(--ink-3);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
 }
 
 .run-template-picker select {
-  min-height: 96px;
+  min-height: 36px;
+  margin-top: 4px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  text-transform: none;
 }
 
 .run-prompt-field {

--- a/frontend/tests/unit/benchmark-api.test.ts
+++ b/frontend/tests/unit/benchmark-api.test.ts
@@ -1,12 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  buildPersistedBenchmarkPlanDocument,
   buildBenchmarkSmokePayload,
   createBenchmarkInstantiation,
   deleteBenchmarkDocument,
+  getBenchmarkInstantiation,
   listBenchmarkDocuments,
   prepareBenchmarkDatasetManifest,
+  runPersistedBenchmarkPlan,
   runBenchmarkInstantiation,
+  saveBenchmarkPlan,
   saveBenchmarkDocument,
   starterBenchmarkTemplateDocument
 } from '../../src/services/benchmark-api.js';
@@ -159,6 +163,36 @@ describe('benchmark API helpers', () => {
     expect(manifest).toEqual({ dataset_id: 'codegen-small', item_count: 2 });
   });
 
+  it('prepares inline dataset manifests through the benchmark API', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ manifest: { dataset_id: 'run-dataset-1', snapshot_policy: 'embedded', item_count: 1 } })
+    } as Response);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const manifest = await prepareBenchmarkDatasetManifest({
+      dataset_id: 'run-dataset-1',
+      source: {
+        source_type: 'inline',
+        format: 'json'
+      },
+      snapshot_policy: 'embedded',
+      items: [{ id: 'item-1', prompt: 'Say OK' }]
+    });
+
+    expect((fetchMock.mock.calls[0][1] as RequestInit).body).toBe(JSON.stringify({
+      dataset_id: 'run-dataset-1',
+      source: {
+        source_type: 'inline',
+        format: 'json'
+      },
+      snapshot_policy: 'embedded',
+      items: [{ id: 'item-1', prompt: 'Say OK' }]
+    }));
+    expect(manifest).toEqual({ dataset_id: 'run-dataset-1', snapshot_policy: 'embedded', item_count: 1 });
+  });
+
   it('posts benchmark instantiation and run requests to the existing backend routes', async () => {
     const fetchMock = vi
       .fn()
@@ -228,5 +262,56 @@ describe('benchmark API helpers', () => {
     expect((fetchMock.mock.calls[1][1] as RequestInit).body).toBe(JSON.stringify(document));
     expect(fetchMock.mock.calls[2][0]).toBe('http://localhost:8080/benchmark/documents/test_template/ui-template');
     expect((fetchMock.mock.calls[2][1] as RequestInit).method).toBe('DELETE');
+  });
+
+  it('builds and runs persisted benchmark plan documents', async () => {
+    const document = buildPersistedBenchmarkPlanDocument({
+      planId: 'run-plan-1',
+      templateRef: 'run-template-1',
+      datasetRef: 'run-dataset-1',
+      runtimeProfileRef: 'run-runtime-1',
+      targets: [
+        { inference_server_id: 'srv-1', model_id: 'model-a' },
+        { inference_server_id: 'srv-1', model_id: 'model-b' }
+      ]
+    });
+    expect(document).toMatchObject({
+      kind: 'benchmark_plan',
+      schema_version: 'benchmark_plan_v1',
+      plan_id: 'run-plan-1',
+      template_ref: 'run-template-1',
+      dataset_ref: 'run-dataset-1',
+      runtime_profile_ref: 'run-runtime-1',
+      model_profile_refs: ['srv-1:model-a', 'srv-1:model-b'],
+      execution: { mode: 'sequential', continue_on_model_error: true, concurrency: 1 }
+    });
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        json: async () => ({ id: 'run-plan-1', kind: 'benchmark_plan', document })
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        json: async () => ({ kind: 'benchmark_plan_result', plan_id: 'run-plan-1', run_results: [] })
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ id: 'bti-1', document: {} })
+      } as Response);
+    vi.stubGlobal('fetch', fetchMock);
+
+    await saveBenchmarkPlan(document);
+    await runPersistedBenchmarkPlan('run-plan-1');
+    await getBenchmarkInstantiation('bti-1');
+
+    expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:8080/benchmark/plans');
+    expect((fetchMock.mock.calls[0][1] as RequestInit).body).toBe(JSON.stringify(document));
+    expect(fetchMock.mock.calls[1][0]).toBe('http://localhost:8080/benchmark/plans/run-plan-1/run');
+    expect(fetchMock.mock.calls[2][0]).toBe('http://localhost:8080/benchmark/instantiations/bti-1');
   });
 });


### PR DESCRIPTION
Route Run-page benchmark execution through persisted benchmark_plan documents. The page now loads saved chat templates, prepares canonical inline or server-side dataset manifests, saves unique runtime/dataset/plan artifacts per click, executes /benchmark/plans/:id/run, and renders per-target plan status including targets that fail before producing a run result.

Extend the benchmark dataset manifest preparation service to support inline embedded datasets while rejecting manifest_only inline inputs. Add focused backend and frontend unit coverage for inline manifest preparation and persisted plan API helpers.

Verification: git diff --check passed. Vitest was not run because this sandbox initially had no node_modules and npm ci could not fetch packages under restricted network/DNS.