### PR TITLE
docs: clarify pre-push sync checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,8 +21,10 @@
 
 - This repo may use multiple git worktrees in parallel for separate features or agents.
 - Treat each worktree as isolated. Do not assume changes from another worktree are available locally.
-- Commit local work whenever it is coherent. Push the branch when it needs backup, review, or CI.
-- Before final validation, PR readiness, or merge, update the branch against the current base branch to catch conflicts and drift.
+- Treat `origin/main` as the source of truth for the current base branch. Local `main` may be stale.
+- Before asking whether to commit and push, fetch `origin` and check the current branch against both local `main` and `origin/main`.
+- Commit local work whenever it is coherent. If the branch is behind or diverged from `origin/main`, commit first when needed, then update the branch against the current base before final validation or push.
+- Do not describe a branch as ready for review, PR, or merge until it is checked against `origin/main` and any conflicts or drift are resolved.
 - After a branch is merged, resync any related worktrees from the updated base branch before continuing dependent work.
 - Re-check the Node.js runtime before installs, rebuilds, backend startup, or tests in each worktree.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 
 ### Changed
 
-- **Human-readable agent workflow guidance** — `AGENTS.md` now groups workflow rules into clearer sections, documents parallel worktree expectations including when to resync before validation or merge, directs agents to create a focused branch without pausing for confirmation, and asks agents to explicitly request commit approval with a suggested message and details.
+- **Human-readable agent workflow guidance** — `AGENTS.md` now groups workflow rules into clearer sections, documents parallel worktree expectations including `origin/main` checks before commit/push requests and resync timing before validation or merge, directs agents to create a focused branch without pausing for confirmation, and asks agents to explicitly request commit approval with a suggested message and details.
 
 ### Fixed
 


### PR DESCRIPTION
Updates AGENTS.md to require origin/main checks before commit/push requests and records the workflow clarification in CHANGELOG.md.