### PR TITLE
feat(run): polish benchmark run experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,15 +14,26 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 - **Project workflow guardrails** — `AGENTS.md` now combines the main branch workflow, Node 25 rules, challenge-and-skill behavior instructions, and a static-data rule that keeps prompts, schemas, fixtures, and examples out of application code.
 - **Benchmark template agent** — Templates now includes a review-first benchmark-template agent that uses a database-persisted Settings model, challenges underspecified requests, loads its prompt from Markdown with the full `test_template` schema and example injected, validates generated drafts server-side, and applies drafts to the existing editor without auto-saving.
 - **Run-page persisted benchmark plan checkpoint** — Run can now select saved chat benchmark templates, prepare inline or server-side dataset manifests, persist unique runtime/dataset/plan artifacts per click, execute `/benchmark/plans/:id/run`, and render per-target results including failed targets without result documents.
+- **Run smoke chat benchmark template** — the built-in benchmark document library now includes a real "Run smoke chat" `test_template` for first-run prompt checks.
 - **Templates LLM-first layout** — Templates now uses an AI-first authoring split with live JSON, Advanced form, and Raw JSON tabs, plus a redesigned preview/list layout for JSON-only `test_template` documents.
 
 ### Changed
 
 - **Human-readable agent workflow guidance** — `AGENTS.md` now groups workflow rules into clearer sections, documents parallel worktree expectations including `origin/main` checks before commit/push requests and resync timing before validation or merge, directs agents to create a focused branch without pausing for confirmation, and asks agents to explicitly request commit approval with a suggested message and details.
 - **Templates agent composer** — The Templates authoring panel now gives the freeform request field more space and removes the preset suggestion chip.
+- **Run selection rail polish** — the Run page model chips, benchmark template selector, and response header now use clearer selected-state borders/backgrounds and denser mono text, with redundant server summary and model helper copy removed.
 
 ### Fixed
 
+- **Results sidebar count** — the Results navigation badge now reads the benchmark-native results total instead of the legacy runs endpoint.
+- **Catalog sidebar count** — the Catalog navigation item now shows the available model count in the sidebar badge.
+- **Run smoke template selection** — the Run page now selects the built-in "Run smoke chat" template by default and requires a real template document before starting a benchmark.
+- **Run multi-model response labels** — multi-model Run detail headers now reuse the same letter and accent color assigned in the selected model chips.
+- **Run multi-model layout** — multi-model benchmark details now use an auto-fitting grid that shows more cards per row on wide screens while keeping each card readable.
+- **Run metrics placement** — per-model metrics now sit directly under the model header in compact fields, with raw benchmark JSON moved beneath the benchmark audit.
+- **Run metric emphasis** — metric values in Run result cards now use bold mono text for faster scanning.
+- **Run benchmark audit presentation** — audit metadata now renders as compact 11px status lines with check, pending, and failure markers.
+- **Run placeholder actions** — disabled "Open in Evaluate" and "Copy as cURL" buttons were removed from the Run metrics panel.
 - **Templates authoring draft preservation** — Switching between Live JSON, Advanced form, and Raw JSON now preserves the agent-inferred benchmark draft instead of reverting to the starter document.
 - **Benchmark-only Results history** — Results dashboard, history, detail drawers, and deletion now read benchmark test run records instead of legacy run/result tables, so benchmark smoke runs appear after completion.
 - **Template agent starter drafting** — The benchmark-template agent now drafts conservative starter templates for recognizable benchmark families such as tool-call compliance instead of blocking on follow-up questions when reasonable assumptions are available.

--- a/backend/src/benchmark-library/documents/test_template/run-smoke-chat-v1.json
+++ b/backend/src/benchmark-library/documents/test_template/run-smoke-chat-v1.json
@@ -1,0 +1,59 @@
+{
+  "kind": "test_template",
+  "schema_version": "benchmark_test_template_v1",
+  "template_id": "run-smoke-chat-v1",
+  "template_version": "1.0.0",
+  "name": "Run smoke chat",
+  "description": "Runs one lightweight chat prompt from the Run page to confirm the selected server and model can complete a benchmark item.",
+  "operation": "chat_completion",
+  "required_capabilities": {
+    "chat_completion": true,
+    "streaming": false,
+    "tool_calling": false,
+    "structured_output": false
+  },
+  "input_contract": {
+    "required_fields": [
+      "prompt"
+    ],
+    "optional_fields": [
+      "system_prompt",
+      "tags",
+      "metadata"
+    ],
+    "min_items": 1
+  },
+  "stages": [
+    {
+      "id": "chat",
+      "type": "dataset_loop",
+      "iterations_per_item": 1,
+      "record_metrics": true,
+      "order": "sequential",
+      "cooldown_ms": 0,
+      "stop_on_error": false
+    }
+  ],
+  "metrics": [
+    "input_tokens",
+    "output_tokens",
+    "total_tokens",
+    "elapsed_ms",
+    "first_token_ms",
+    "tokens_per_second",
+    "decode_tokens_per_second",
+    "prefill_tokens_per_second"
+  ],
+  "aggregations": [
+    "mean",
+    "p50",
+    "p95",
+    "count"
+  ],
+  "metadata": {
+    "source": "built-in-run-library",
+    "benchmark_family": "smoke_chat",
+    "target_agent": "OpenAI-compatible chat model"
+  },
+  "extensions": {}
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,6 +27,7 @@ import { listBenchmarkDocuments, type BenchmarkTestTemplateDocument } from './se
 import { InferenceServerHealth, getConnectivityConfig, getInferenceServerHealth } from './services/connectivity-api.js';
 import { InferenceServerRecord, listInferenceServers } from './services/inference-servers-api.js';
 import { listModels, type ModelRecord } from './services/models-api.js';
+import { queryResultsView } from './services/results-view-api.js';
 import {
   clearDatabase,
   EnvEntry,
@@ -296,14 +297,14 @@ export function App() {
       const [templatesResult, modelsResult, runsResult] = await Promise.allSettled([
         listBenchmarkDocuments<BenchmarkTestTemplateDocument>('test_template'),
         listModels(),
-        apiGet<Record<string, unknown>[]>('/runs')
+        queryResultsView({ page: 1, page_size: 1 })
       ]);
       if (!isActive) {
         return;
       }
       setTemplateCount(templatesResult.status === 'fulfilled' ? templatesResult.value.length : null);
       setModelCount(modelsResult.status === 'fulfilled' ? modelsResult.value.length : null);
-      setRunCount(runsResult.status === 'fulfilled' ? runsResult.value.length : null);
+      setRunCount(runsResult.status === 'fulfilled' ? runsResult.value.history.total : null);
     };
 
     refreshCounts();
@@ -508,6 +509,7 @@ export function App() {
         <Sidebar
           version={packageInfo.version}
           health={sidebarHealth}
+          modelCount={modelCount}
           templateCount={templateCount}
           runCount={runCount}
           onboarding={onboardingStatus.active ? onboardingStatus : undefined}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -16,6 +16,7 @@ interface SidebarHealth {
 interface SidebarProps {
   version: string;
   health: SidebarHealth;
+  modelCount: number | null;
   templateCount: number | null;
   runCount: number | null;
   onboarding?: OnboardingStatus;
@@ -23,7 +24,7 @@ interface SidebarProps {
 }
 
 const navItems = [
-  { id: 'catalog', to: '/catalog?tab=servers', section: '/catalog', label: 'Catalog', sub: 'Servers · Models' },
+  { id: 'catalog', to: '/catalog?tab=servers', section: '/catalog', label: 'Catalog', sub: 'Servers · Models', badge: 'models' },
   { id: 'templates', to: '/templates', section: '/templates', label: 'Templates', sub: '', badge: 'templates' },
   { id: 'run', to: '/run', section: '/run', label: 'Run', sub: '1-8 models' },
   { id: 'results', to: '/results?tab=dashboard', section: '/results', label: 'Results', sub: 'Dash · Board · History', badge: 'runs' },
@@ -70,7 +71,7 @@ function RegLightRow({
   );
 }
 
-export function Sidebar({ version, health, templateCount, runCount, onboarding, onSettings }: SidebarProps) {
+export function Sidebar({ version, health, modelCount, templateCount, runCount, onboarding, onSettings }: SidebarProps) {
   const onboardingActive = onboarding?.active === true;
   const unlockedIndex = onboardingActive ? navOrder.indexOf(onboarding.unlockedThrough) : navOrder.length - 1;
   return (
@@ -102,6 +103,7 @@ export function Sidebar({ version, health, templateCount, runCount, onboarding, 
           >
             <span className="sidebar-item__main">
               <span>{item.label}</span>
+              {'badge' in item && item.badge === 'models' && modelCount !== null ? <b>{modelCount}</b> : null}
               {'badge' in item && item.badge === 'templates' && templateCount !== null ? <b>{templateCount}</b> : null}
               {'badge' in item && item.badge === 'runs' && runCount !== null ? <b>{runCount}</b> : null}
               {locked ? <em aria-hidden="true">lock</em> : null}

--- a/frontend/src/pages/RunUnified.tsx
+++ b/frontend/src/pages/RunUnified.tsx
@@ -28,12 +28,12 @@ import { DEFAULT_INFERENCE_PARAMS, type InferenceParams } from '../services/infe
 import { InferenceServerRecord, listInferenceServers } from '../services/inference-servers-api.js';
 import { listModels, ModelRecord } from '../services/models-api.js';
 import {
-  RUN_ACCENTS,
   assignRunAccents,
   mergeRunModelOptions,
   parseRunTargets,
   serializeRunTargets,
   targetKey,
+  type AccentedRunTarget,
   type RunModelOption,
   type RunTarget
 } from '../services/run-unified-utils.js';
@@ -285,11 +285,7 @@ function ConfigRail({
     option.inference_server_id === selectedServerId && !selectedKeys.has(targetKey(option))
   );
   const selectedOptions = new Map(options.map((option) => [targetKey(option), option]));
-  const target = selectedTargets[0] ?? null;
-  const serverLabel = target
-    ? servers.find((server) => server.inference_server.server_id === target.inference_server_id)?.inference_server.display_name ?? target.inference_server_id
-    : selectedServer?.inference_server.display_name ?? 'No server selected';
-  const canRun = selectedTargets.length >= 1 && !busy && (
+  const canRun = selectedTargets.length >= 1 && selectedTemplateId.length > 0 && !busy && (
     datasetMode === 'inline'
       ? prompt.trim().length > 0
       : datasetId.trim().length > 0 && datasetPath.trim().length > 0
@@ -299,10 +295,6 @@ function ConfigRail({
     <aside className="run-config-rail" aria-label="Run configuration">
       <div className="run-config-step">
         <div className="run-step-label">Step 1 · server</div>
-        <div className="run-server-field">
-          <span>{serverLabel}</span>
-          <button type="button" disabled>edit</button>
-        </div>
         <label className="run-server-select">
           Inference server
           <select value={customServerId} onChange={(event) => onCustomServerChange(event.target.value)}>
@@ -351,7 +343,6 @@ function ConfigRail({
           </label>
         </div>
         <div className="run-count-line">{selectedTargets.length || 0} of 8 models selected · {selectedTargets.length > 1 ? `run executes all ${selectedTargets.length} selected models` : 'run executes the selected model'}</div>
-        <p className="run-hint">Run one or more models through a smoke prompt or server-side dataset. Multiple models produce a side-by-side comparison.</p>
       </div>
 
       <div className="run-config-step">
@@ -359,7 +350,6 @@ function ConfigRail({
         <label className="run-template-picker">
           Benchmark template
           <select value={selectedTemplateId} onChange={(event) => onTemplateChange(event.target.value)}>
-            <option value="">Run smoke chat</option>
             {templates.map((template) => (
               <option key={template.id} value={template.id}>
                 {template.document.name || template.document.template_id}
@@ -576,7 +566,7 @@ function BenchmarkDetail({
   planId,
   busy
 }: {
-  target: RunTarget;
+  target: AccentedRunTarget;
   option: RunModelOption | undefined;
   instantiation: BenchmarkInstantiationRecord | null;
   result: BenchmarkResultRecord | null;
@@ -604,73 +594,13 @@ function BenchmarkDetail({
     <div className="run-detail">
       <main className="run-transcript">
         <header className="run-response-header">
-          <span className="run-avatar is-large" style={{ background: RUN_ACCENTS[0] }}>A</span>
+          <span className="run-avatar is-large" style={{ background: target.accent }}>{target.stable_letter}</span>
           <div>
             <strong>{option?.display_name ?? target.model_id}</strong>
             <span>{option?.server_name ?? target.inference_server_id}{option?.quantisation ? ` · ${option.quantisation}` : ''}</span>
           </div>
           <b className={`run-status-pill status-${status}`}>{status}</b>
         </header>
-        {result?.document.errors.length ? (
-          <div className="run-failure-banner">
-            <strong>Benchmark completed with errors.</strong>
-            <span>{result.document.errors.map((error) => String(error.message ?? error.code ?? 'Unknown error')).join('; ')}</span>
-          </div>
-        ) : null}
-        {!result && planResult && planResult.status !== 'completed' ? (
-          <div className="run-failure-banner">
-            <strong>Benchmark target did not produce a result.</strong>
-            <span>{planResult.status}</span>
-          </div>
-        ) : null}
-        <div className="run-message-list">
-          {busy || responses.length === 0 ? (
-            <section className={busy ? 'run-message-card is-streaming' : 'run-message-card'}>
-              <span>assistant · final</span>
-              {busy ? <small>Executing synchronous benchmark request</small> : null}
-              <pre>{busy ? 'Running...' : answerText(result)}{busy ? <i className="stream-cursor" /> : null}</pre>
-            </section>
-          ) : responses.map((item) => (
-            <section className="run-message-card" key={`${item.label}:${String(item.response.attempt ?? '')}`}>
-              <span>assistant · final · {item.label}</span>
-              <pre>{responseAnswerText(item.response)}</pre>
-            </section>
-          ))}
-        </div>
-        <section className="run-asserts">
-          <h3>Benchmark audit</h3>
-          <div className={result?.document.status === 'completed_with_errors' ? 'run-assert-row is-fail' : 'run-assert-row'}>
-            <span>{result?.document.status === 'completed_with_errors' ? 'x' : 'ok'}</span>
-            <code>{result?.document.status ?? 'not-run'}</code>
-          </div>
-          <div className="run-assert-row">
-            <span>id</span>
-            <code>{instantiation?.id ?? 'no-instantiation'}</code>
-          </div>
-          <div className="run-assert-row">
-            <span>plan</span>
-            <code>{planId ?? 'no-plan'}</code>
-          </div>
-          <div className="run-assert-row">
-            <span>run</span>
-            <code>{result?.run_id ?? 'no-result'}</code>
-          </div>
-          <div className="run-assert-row">
-            <span>items</span>
-            <code>{formatNumber(manifest?.item_count)}</code>
-          </div>
-          <div className="run-assert-row">
-            <span>dataset</span>
-            <code>{String(manifest?.dataset_id ?? 'no-dataset')}</code>
-          </div>
-          <div className="run-assert-row">
-            <span>hash</span>
-            <code>{String(manifest?.dataset_hash ?? 'no-hash')}</code>
-          </div>
-        </section>
-      </main>
-      <aside className="run-side-metrics">
-        <h3>Metrics</h3>
         <div className="run-metric-grid">
           <span><b>duration</b>{formatMetric(metrics.elapsed_ms)}</span>
           {serverTotalTimeMs !== null && (
@@ -710,30 +640,78 @@ function BenchmarkDetail({
           )}
         </div>
         {correctness.length > 0 && (
-          <>
-            <h3 style={{ marginTop: '16px' }}>Correctness</h3>
-            <div className="run-metric-grid">
-              {correctness.map(({ label, successRate, count }) => (
-                <span key={label}>
-                  <b>{label}</b>
-                  {`${(successRate * 100).toFixed(0)}%`}
-                  <span style={{ display: 'block', color: 'var(--ink-3)', fontSize: '9px' }}>
-                    {`${Math.round(successRate * count)} / ${count}`}
-                  </span>
-                </span>
-              ))}
-            </div>
-          </>
+          <div className="run-metric-grid run-correctness-grid" aria-label="Correctness metrics">
+            {correctness.map(({ label, successRate, count }) => (
+              <span key={label}>
+                <b>{label}</b>
+                {`${(successRate * 100).toFixed(0)}%`}
+                <small>{`${Math.round(successRate * count)} / ${count}`}</small>
+              </span>
+            ))}
+          </div>
         )}
-        <details>
-          <summary>Raw benchmark result</summary>
-          <pre>{JSON.stringify(result ?? instantiation ?? {}, null, 2)}</pre>
-        </details>
-        <div className="run-side-actions">
-          <button type="button" disabled>Open in Evaluate</button>
-          <button type="button" disabled>Copy as cURL</button>
+        {result?.document.errors.length ? (
+          <div className="run-failure-banner">
+            <strong>Benchmark completed with errors.</strong>
+            <span>{result.document.errors.map((error) => String(error.message ?? error.code ?? 'Unknown error')).join('; ')}</span>
+          </div>
+        ) : null}
+        {!result && planResult && planResult.status !== 'completed' ? (
+          <div className="run-failure-banner">
+            <strong>Benchmark target did not produce a result.</strong>
+            <span>{planResult.status}</span>
+          </div>
+        ) : null}
+        <div className="run-message-list">
+          {busy || responses.length === 0 ? (
+            <section className={busy ? 'run-message-card is-streaming' : 'run-message-card'}>
+              <span>assistant · final</span>
+              {busy ? <small>Executing synchronous benchmark request</small> : null}
+              <pre>{busy ? 'Running...' : answerText(result)}{busy ? <i className="stream-cursor" /> : null}</pre>
+            </section>
+          ) : responses.map((item) => (
+            <section className="run-message-card" key={`${item.label}:${String(item.response.attempt ?? '')}`}>
+              <span>assistant · final · {item.label}</span>
+              <pre>{responseAnswerText(item.response)}</pre>
+            </section>
+          ))}
         </div>
-      </aside>
+        <section className="run-asserts">
+          <h3>Benchmark audit</h3>
+          <div className={result?.document.status === 'completed_with_errors' ? 'run-assert-row is-fail' : 'run-assert-row'}>
+            <span aria-hidden="true" />
+            <code>{`status ${result?.document.status ?? 'not-run'}`}</code>
+          </div>
+          <div className={instantiation?.id ? 'run-assert-row' : 'run-assert-row is-pending'}>
+            <span aria-hidden="true" />
+            <code>{instantiation?.id ? `instantiation ${instantiation.id}` : 'instantiation pending'}</code>
+          </div>
+          <div className={planId ? 'run-assert-row' : 'run-assert-row is-pending'}>
+            <span aria-hidden="true" />
+            <code>{planId ? `plan ${planId}` : 'plan pending'}</code>
+          </div>
+          <div className={result?.run_id ? 'run-assert-row' : 'run-assert-row is-pending'}>
+            <span aria-hidden="true" />
+            <code>{result?.run_id ? `run ${result.run_id}` : 'run pending'}</code>
+          </div>
+          <div className={manifest?.item_count ? 'run-assert-row' : 'run-assert-row is-pending'}>
+            <span aria-hidden="true" />
+            <code>{`items ${formatNumber(manifest?.item_count)}`}</code>
+          </div>
+          <div className={manifest?.dataset_id ? 'run-assert-row' : 'run-assert-row is-pending'}>
+            <span aria-hidden="true" />
+            <code>{manifest?.dataset_id ? `dataset ${String(manifest.dataset_id)}` : 'dataset pending'}</code>
+          </div>
+          <div className={manifest?.dataset_hash ? 'run-assert-row' : 'run-assert-row is-pending'}>
+            <span aria-hidden="true" />
+            <code>{manifest?.dataset_hash ? `hash ${String(manifest.dataset_hash)}` : 'hash pending'}</code>
+          </div>
+          <details className="run-raw-result">
+            <summary>Raw benchmark result</summary>
+            <pre>{JSON.stringify(result ?? instantiation ?? {}, null, 2)}</pre>
+          </details>
+        </section>
+      </main>
     </div>
   );
 }
@@ -781,7 +759,8 @@ export function RunUnified({
         setServers(serverData);
         setModels(modelData);
         setTemplates(chatTemplates);
-        setSelectedTemplateId((current) => current || chatTemplates[0]?.id || '');
+        const smokeTemplate = chatTemplates.find((entry) => entry.document.template_id === 'run-smoke-chat-v1');
+        setSelectedTemplateId((current) => current || smokeTemplate?.id || chatTemplates[0]?.id || '');
         setCustomServerId((current) => current || serverData[0]?.inference_server.server_id || '');
       })
       .catch((err) => setError(err instanceof Error ? err.message : 'Unable to load run configuration.'));
@@ -873,6 +852,11 @@ export function RunUnified({
     if (datasetMode === 'manifest_only' && (!datasetId.trim() || !datasetPath.trim())) {
       return;
     }
+    const selectedTemplate = templates.find((entry) => entry.id === selectedTemplateId);
+    if (!selectedTemplate) {
+      setError('Select a benchmark template before running.');
+      return;
+    }
     setBusy(true);
     setError(null);
     clearRunState();
@@ -884,7 +868,8 @@ export function RunUnified({
         systemPrompt,
         inferenceParams,
         timeoutSec,
-        seed
+        seed,
+        template: selectedTemplate.document
       });
       const preparedDataset = datasetMode === 'manifest_only'
         ? await prepareBenchmarkDatasetManifest({
@@ -916,19 +901,7 @@ export function RunUnified({
             metadata: { source: 'run-page-inline' }
           });
 
-      const selectedTemplate = templates.find((entry) => entry.id === selectedTemplateId);
-      let templateRef = selectedTemplate?.id ?? '';
-      if (!templateRef) {
-        const smokeTemplate = {
-          ...smokePayload.template,
-          template_id: `run-template-${runSuffix}`,
-          metadata: {
-            source: 'run-page-smoke'
-          }
-        };
-        const savedTemplate = await saveBenchmarkDocument(smokeTemplate);
-        templateRef = savedTemplate.id;
-      }
+      const templateRef = selectedTemplate.id;
 
       const runtimeProfile = {
         ...smokePayload.runtime_profile,
@@ -1052,9 +1025,9 @@ export function RunUnified({
             {!selectedTarget ? (
               <RunUnifiedEmpty />
             ) : selectedTargets.length > 1 ? (
-              <div style={{ display: 'flex', flexWrap: 'wrap' }}>
-                {selectedTargets.map((target, index) => (
-                  <div key={targetKey(target)} style={{ flex: '1 1 50%', minWidth: 0, borderRight: '1px solid var(--paper-7)', borderBottom: '1px solid var(--paper-7)', boxSizing: 'border-box' }}>
+              <div className="run-detail-grid">
+                {assignRunAccents(selectedTargets).map((target, index) => (
+                  <div className="run-detail-grid-cell" key={targetKey(target)}>
                     <BenchmarkDetail
                       target={target}
                       option={optionMap.get(targetKey(target))}
@@ -1069,7 +1042,7 @@ export function RunUnified({
               </div>
             ) : (
               <BenchmarkDetail
-                target={selectedTarget}
+                target={assignRunAccents([selectedTarget])[0]}
                 option={selectedOption}
                 instantiation={instantiation}
                 result={result}

--- a/frontend/src/services/benchmark-api.ts
+++ b/frontend/src/services/benchmark-api.ts
@@ -236,33 +236,12 @@ export function buildBenchmarkSmokePayload(input: BuildBenchmarkSmokeInput): Cre
         ]
       };
 
+  if (!input.template) {
+    throw new Error('A benchmark template is required to build a run payload.');
+  }
+
   return {
-    template: input.template ?? {
-      kind: 'test_template',
-      schema_version: 'benchmark_test_template_v1',
-      template_id: 'run-smoke-chat',
-      template_version: '1.0.0',
-      name: 'Run smoke chat',
-      description: 'One prompt smoke test from the Run page.',
-      operation: 'chat_completion',
-      required_capabilities: {
-        chat_completion: true,
-        streaming: stream,
-        tool_calling: false,
-        structured_output: false
-      },
-      stages: [
-        {
-          id: 'chat',
-          type: 'dataset_loop',
-          iterations_per_item: 1,
-          record_metrics: true,
-          stop_on_error: false
-        }
-      ],
-      metrics: ['input_tokens', 'output_tokens', 'total_tokens', 'elapsed_ms', 'first_token_ms', 'tokens_per_second', 'decode_tokens_per_second', 'prefill_tokens_per_second'],
-      aggregations: ['mean', 'p95', 'count']
-    },
+    template: input.template,
     server_id: input.target.inference_server_id,
     model_id: input.target.model_id,
     runtime_profile: {

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -1658,6 +1658,7 @@ button.is-pending::after {
   background: var(--paper-1);
   font-family: var(--font-mono);
   font-size: 11px;
+  font-weight: 700;
 }
 
 .run-server-field button,
@@ -1707,7 +1708,7 @@ button.is-pending::after {
   gap: 5px;
   max-width: 220px;
   padding: 3px 5px;
-  border: 1px solid var(--gold-9);
+  border: 1px solid var(--border-selected);
   border-radius: 999px;
   background: var(--bg-selected);
   font-family: var(--font-mono);
@@ -1771,10 +1772,17 @@ button.is-pending::after {
 }
 
 .run-template-picker select {
+  width: 100%;
+  min-width: 0;
   min-height: 36px;
-  margin-top: 4px;
+  border-color: var(--border-selected);
+  border-radius: 9px;
+  margin-top: 1px;
+  padding: 10px 8px;
+  background: var(--bg-selected);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: 11px;
+  font-weight: 600;
   text-transform: none;
 }
 
@@ -1968,19 +1976,28 @@ button.is-pending::after {
 }
 
 .run-detail {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 320px;
   min-height: 520px;
 }
 
-.run-transcript,
-.run-side-metrics {
-  padding: 18px 20px;
+.run-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
 }
 
-.run-side-metrics {
-  border-left: 1px solid var(--paper-7);
-  background: var(--paper-2);
+.run-detail-grid-cell {
+  min-width: 0;
+  border-right: 1px solid var(--paper-7);
+  border-bottom: 1px solid var(--paper-7);
+}
+
+@media (max-width: 640px) {
+  .run-detail-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.run-transcript {
+  padding: 18px 20px;
 }
 
 .run-response-header,
@@ -1989,6 +2006,10 @@ button.is-pending::after {
   grid-template-columns: auto minmax(0, 1fr) auto;
   gap: 10px;
   align-items: center;
+}
+
+.run-response-header {
+  border: 1px solid var(--paper-7);
 }
 
 .run-response-header strong,
@@ -2010,6 +2031,13 @@ button.is-pending::after {
   font-size: 10px;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.run-response-header .run-avatar.is-large {
+  padding: 6px 8px;
+  border-radius: 10px;
+  color: #ffffff;
+  font-size: 14px;
 }
 
 .run-status-pill {
@@ -2069,7 +2097,7 @@ button.is-pending::after {
 
 .run-message-card pre,
 .run-column-body pre,
-.run-side-metrics pre {
+.run-raw-result pre {
   overflow: auto;
   margin: 8px 0 0;
   font-family: var(--font-mono);
@@ -2084,11 +2112,11 @@ button.is-pending::after {
 }
 
 .run-column-body pre,
-.run-side-metrics pre {
+.run-raw-result pre {
   color: var(--ink-6);
 }
 
-.run-side-metrics details pre {
+.run-raw-result pre {
   padding: 10px;
   border: 1px solid var(--paper-7);
   border-radius: 8px;
@@ -2101,41 +2129,95 @@ button.is-pending::after {
 }
 
 .run-assert-row {
-  display: flex;
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr);
   gap: 8px;
   align-items: center;
-  min-height: 30px;
-  padding: 6px 8px;
-  border-radius: 4px;
-  background: #edf7ef;
+  min-height: 24px;
+  padding: 2px 0;
+  background: transparent;
+}
+
+.run-assert-row span {
+  width: 18px;
+  height: 18px;
+  display: inline-grid;
+  place-items: center;
+  border-radius: 999px;
+  background: var(--ok);
+  color: var(--paper-1);
+}
+
+.run-assert-row span::before {
+  content: "\2713";
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.run-assert-row code {
+  overflow-wrap: anywhere;
+  color: var(--ink-7);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.35;
 }
 
 .run-assert-row.is-fail {
-  background: #f7e4e4;
+  background: transparent;
+}
+
+.run-assert-row.is-fail span {
+  background: var(--danger);
+}
+
+.run-assert-row.is-fail span::before {
+  content: "!";
+}
+
+.run-assert-row.is-pending span {
+  background: var(--pending);
+}
+
+.run-assert-row.is-pending span::before {
+  content: "-";
 }
 
 .run-metric-grid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 8px;
+  grid-template-columns: repeat(auto-fit, minmax(72px, 1fr));
+  gap: 6px;
+  margin-top: 8px;
 }
 
 .run-metric-grid span {
-  min-height: 58px;
-  padding: 8px;
+  min-height: 40px;
+  padding: 6px 7px;
   border: 1px solid var(--paper-7);
-  border-radius: 8px;
+  border-radius: 6px;
   background: var(--paper-1);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: 11px;
+  font-weight: 700;
 }
 
 .run-metric-grid b {
   display: block;
-  margin-bottom: 4px;
+  margin-bottom: 2px;
   color: var(--ink-3);
   font-size: 9px;
   text-transform: uppercase;
+}
+
+.run-metric-grid small {
+  display: block;
+  color: var(--ink-3);
+  font-size: 9px;
+}
+
+.run-correctness-grid {
+  margin-top: 6px;
 }
 
 .run-metric-grid span.is-estimated {
@@ -2144,12 +2226,6 @@ button.is-pending::after {
 
 .run-metric-grid span.is-estimated b {
   color: #cc0000;
-}
-
-.run-side-actions {
-  display: grid;
-  gap: 8px;
-  margin-top: 16px;
 }
 
 .run-compare-grid {

--- a/frontend/tests/unit/benchmark-api.test.ts
+++ b/frontend/tests/unit/benchmark-api.test.ts
@@ -20,6 +20,31 @@ beforeEach(() => {
   vi.unstubAllGlobals();
 });
 
+const smokeTemplate = {
+  kind: 'test_template',
+  schema_version: 'benchmark_test_template_v1',
+  template_id: 'run-smoke-chat-v1',
+  template_version: '1.0.0',
+  name: 'Run smoke chat',
+  operation: 'chat_completion',
+  required_capabilities: {
+    chat_completion: true,
+    streaming: false,
+    tool_calling: false,
+    structured_output: false
+  },
+  stages: [
+    {
+      id: 'chat',
+      type: 'dataset_loop',
+      iterations_per_item: 1,
+      record_metrics: true
+    }
+  ],
+  metrics: ['input_tokens', 'output_tokens', 'total_tokens', 'elapsed_ms'],
+  aggregations: ['mean', 'count']
+} as const;
+
 describe('benchmark API helpers', () => {
   it('builds a benchmark smoke payload from Run page inputs', () => {
     const payload = buildBenchmarkSmokePayload({
@@ -34,17 +59,13 @@ describe('benchmark API helpers', () => {
         stream: true
       },
       timeoutSec: '12.5',
-      seed: '42'
+      seed: '42',
+      template: smokeTemplate
     });
 
     expect(payload.server_id).toBe('srv-1');
     expect(payload.model_id).toBe('model-a');
-    expect(payload.template).toMatchObject({
-      kind: 'test_template',
-      schema_version: 'benchmark_test_template_v1',
-      operation: 'chat_completion',
-      required_capabilities: { streaming: true }
-    });
+    expect(payload.template).toBe(smokeTemplate);
     expect(payload.runtime_profile.runtime_parameters).toMatchObject({
       temperature: 0.1,
       top_p: 0.9,
@@ -71,10 +92,11 @@ describe('benchmark API helpers', () => {
         stream: false
       },
       timeoutSec: '',
-      seed: ''
+      seed: '',
+      template: smokeTemplate
     });
 
-    expect(payload.template.required_capabilities).toMatchObject({ streaming: false });
+    expect(payload.template).toBe(smokeTemplate);
     expect(payload.runtime_profile.runtime_parameters).toEqual({
       temperature: null,
       top_p: null,
@@ -98,6 +120,7 @@ describe('benchmark API helpers', () => {
       },
       timeoutSec: '30',
       seed: '',
+      template: smokeTemplate,
       dataset: {
         mode: 'manifest_only',
         manifest: {


### PR DESCRIPTION
Add a real built-in Run smoke chat test_template document and make Run require selected benchmark templates instead of synthesizing static template data in frontend code.

Polish the Run page result cards: template picker styling, model-chip selected border, response header accents, compact metric placement, audit status lines, responsive multi-model grid, and removed placeholder actions.

Update sidebar badges to show benchmark-native Results totals and Catalog model counts.

Update frontend benchmark helper tests and changelog.

Validation: node -v; npm run check:node; git diff --check; npm -w frontend run test -- --run benchmark-api.test.ts; npm -w backend run test -- --run benchmark-library.test.ts; npm -w frontend run build (passes with existing Vite large chunk warning).