### PR TITLE
chore(release): prepare 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-06-17
+
 ### Added
 
 - **File-backed benchmark document library** — benchmark templates, datasets, runtime profiles, and plans now load from built-in JSON documents plus a writable local library, with API saves persisted to files so documents can be reconstructed after SQLite loss.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # InferHarness
 
-[![version](https://img.shields.io/badge/version-0.8.0-blue)](https://github.com/Fango2007/InferHarness/releases/tag/v0.8.0)
+[![version](https://img.shields.io/badge/version-0.9.0-blue)](https://github.com/Fango2007/InferHarness/releases/tag/v0.9.0)
 [![node](https://img.shields.io/badge/node-25.x-339933)](package.json)
 [![python](https://img.shields.io/badge/python-3.10%2B-3776AB)](backend/src/scripts/requirements.txt)
 [![CI](https://github.com/Fango2007/InferHarness/actions/workflows/ci.yml/badge.svg)](https://github.com/Fango2007/InferHarness/actions/workflows/ci.yml)

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inferharness/backend",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inferharness/frontend",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "inferharness",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "inferharness",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "hasInstallScript": true,
       "workspaces": [
         "backend",
@@ -34,7 +34,7 @@
     },
     "backend": {
       "name": "@inferharness/backend",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "dependencies": {
         "ajv": "^8.12.0",
         "better-sqlite3": "^12.9.0",
@@ -54,7 +54,7 @@
     },
     "frontend": {
       "name": "@inferharness/frontend",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "dependencies": {
         "@vitejs/plugin-react": "^6.0.1",
         "echarts": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inferharness",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
Bump root, backend, frontend, and lockfile versions to 0.9.0.

Move Unreleased changelog entries into the 0.9.0 section dated 2026-06-17 and update the README release badge/link.

Validation: node -v; npm run check:node; git diff --check; npm run release:check passed outside sandbox after tsx IPC was blocked by sandbox on the first run.