### PR TITLE
Redesign Templates as a catalog-style browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 - **Human-readable agent workflow guidance** — `AGENTS.md` now groups workflow rules into clearer sections, documents parallel worktree expectations including `origin/main` checks before commit/push requests and resync timing before validation or merge, directs agents to create a focused branch without pausing for confirmation, and asks agents to explicitly request commit approval with a suggested message and details.
 - **Templates agent composer** — The Templates authoring panel now gives the freeform request field more space and removes the preset suggestion chip.
 - **Run selection rail polish** — the Run page model chips, benchmark template selector, and response header now use clearer selected-state borders/backgrounds and denser mono text, with redundant server summary and model helper copy removed.
+- **Templates catalog shell** — `/templates` now opens as a browse-first catalog with category buckets, grouped template cards, dedicated preview state, and the existing AI-first authoring flow embedded in the new shell instead of auto-selecting the first template row.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Start with built-in benchmark templates, then create tests for one prompt, a dat
 Benchmark documents are persisted as JSON in a file-backed library and indexed into SQLite for runtime use. Built-in documents ship with the app, while user-created templates, datasets, runtime profiles, and plans are written to a local library directory so they can be restored if the database is rebuilt.
 
 **Benchmark template agent**
-Use the Templates page agent as the primary authoring flow to challenge underspecified benchmark ideas, draft runnable `chat_completion` benchmark templates, validate them against the benchmark schema, and review the live JSON before saving. The full structured editor remains available as an Advanced escape hatch.
+Use the Templates catalog page agent as the primary authoring flow to challenge underspecified benchmark ideas, draft runnable `chat_completion` benchmark templates, validate them against the benchmark schema, browse the library by category, and review the live JSON before saving. The full structured editor remains available as an Advanced escape hatch.
 
 **Benchmark runs**
 Run the same test against one model, many models, or the same model served by different inference servers.

--- a/frontend/src/pages/Templates.tsx
+++ b/frontend/src/pages/Templates.tsx
@@ -17,8 +17,9 @@ import { TOOL_CALL_ASSERTION_METRIC } from '../services/benchmark-metric-metadat
 import { listModels, type ModelRecord } from '../services/models-api.js';
 import { getAppSettings, type AppSettings } from '../services/system-api.js';
 
-type TemplateMode = { kind: 'preview' } | { kind: 'create' } | { kind: 'modify' };
+type TemplateMode = { kind: 'grid' } | { kind: 'preview' } | { kind: 'create' } | { kind: 'modify' };
 type TemplateOperationFilter = 'all' | BenchmarkOperation;
+type TemplateCategory = 'all' | 'tool' | 'agentic' | 'structured';
 type AuthorTab = 'live' | 'advanced' | 'raw';
 type DraftSource = 'none' | 'seed' | 'agent' | 'advanced' | 'raw';
 
@@ -34,8 +35,20 @@ interface ChatEntry {
   questions?: string[];
 }
 
+interface TemplateCategoryDefinition {
+  id: TemplateCategory;
+  name: string;
+  blurb: string;
+}
+
 const OPERATION_FILTERS: TemplateOperationFilter[] = ['all', 'chat_completion', 'completion', 'embedding', 'list_models', 'healthcheck'];
 const ENABLED_OPERATION_FILTERS = new Set<TemplateOperationFilter>(['all', 'chat_completion']);
+const TEMPLATE_CATEGORIES: TemplateCategoryDefinition[] = [
+  { id: 'all', name: 'All templates', blurb: 'Every benchmark in the workspace' },
+  { id: 'tool', name: 'Tool calling', blurb: 'Selection, arguments, and tool-choice mechanics' },
+  { id: 'agentic', name: 'Agentic', blurb: 'Multi-step agents, repo edits, and workflow execution' },
+  { id: 'structured', name: 'Structured output', blurb: 'JSON contracts and schema validation' }
+];
 
 const DEFAULT_TEMPLATE_DRAFT: BenchmarkTestTemplateDocument = {
   kind: 'test_template',
@@ -90,6 +103,27 @@ function parseTemplateStats(template: BenchmarkTestTemplateRecord): {
     capabilityCount: Object.values(capabilities).filter(Boolean).length,
     summary: document.description || `${document.operation} benchmark template`
   };
+}
+
+function categorizeTemplateDocument(document: BenchmarkTestTemplateDocument): Exclude<TemplateCategory, 'all'> {
+  const id = document.template_id.toLowerCase();
+  if (id.startsWith('agent-')) {
+    return 'agentic';
+  }
+  if (id.startsWith('functional-')) {
+    return 'structured';
+  }
+  if (document.required_capabilities?.structured_output && !document.required_capabilities?.tool_calling) {
+    return 'structured';
+  }
+  if (document.required_capabilities?.tool_calling) {
+    return 'tool';
+  }
+  return 'tool';
+}
+
+function categoryName(category: TemplateCategory): string {
+  return TEMPLATE_CATEGORIES.find((entry) => entry.id === category)?.name ?? 'Templates';
 }
 
 function formatDate(value: string): string {
@@ -190,71 +224,146 @@ function JsonView({ lines, showNotes }: { lines: JsonLine[]; showNotes: boolean 
   );
 }
 
-function TemplatesRail({
+function TemplateCategoryRail({
+  category,
+  counts,
+  onCategory
+}: {
+  category: TemplateCategory;
+  counts: Record<TemplateCategory, number>;
+  onCategory: (value: TemplateCategory) => void;
+}) {
+  return (
+    <aside className="template-category-rail">
+      <div className="template-category-rail__top">
+        <div className="template-category-rail__label">Browse by</div>
+        <nav className="template-category-rail__list" aria-label="Template categories">
+          {TEMPLATE_CATEGORIES.map((entry) => (
+            <button
+              key={entry.id}
+              type="button"
+              className={category === entry.id ? 'template-category-item is-active' : 'template-category-item'}
+              onClick={() => onCategory(entry.id)}
+            >
+              <span className="template-category-item__body">
+                <span className="template-category-item__name">{entry.name}</span>
+                <span className="template-category-item__blurb">{entry.blurb}</span>
+              </span>
+              <span className="template-category-item__count">{counts[entry.id] ?? 0}</span>
+            </button>
+          ))}
+        </nav>
+      </div>
+    </aside>
+  );
+}
+
+function TemplateCard({
+  template,
+  onSelect
+}: {
+  template: BenchmarkTestTemplateRecord;
+  onSelect: (templateId: string) => void;
+}) {
+  return (
+    <button type="button" className="template-card" onClick={() => onSelect(template.id)}>
+      <div className="template-card__top">
+        <span className="template-card__name">{templateLabel(template)}</span>
+        <span className="template-card__chip">{template.document.operation}</span>
+      </div>
+      <p className="template-card__description">{template.document.description ?? `${template.document.operation} benchmark template`}</p>
+      <div className="template-card__footer">
+        <span className="template-card__id">{template.document.template_id}</span>
+        <span className="template-card__meta">{template.document.metrics.length} metrics</span>
+      </div>
+    </button>
+  );
+}
+
+function TemplateBrowseGrid({
   templates,
-  selectedId,
+  category,
   query,
   operationFilter,
-  mode,
-  busy,
   onQuery,
   onFilter,
   onSelect,
   onNew
 }: {
   templates: BenchmarkTestTemplateRecord[];
-  selectedId: string | null;
+  category: TemplateCategory;
   query: string;
   operationFilter: TemplateOperationFilter;
-  mode: TemplateMode;
-  busy: boolean;
   onQuery: (value: string) => void;
   onFilter: (value: TemplateOperationFilter) => void;
-  onSelect: (id: string) => void;
+  onSelect: (templateId: string) => void;
   onNew: () => void;
 }) {
+  const groupedSections = category === 'all'
+    ? TEMPLATE_CATEGORIES
+        .filter((entry): entry is TemplateCategoryDefinition & { id: Exclude<TemplateCategory, 'all'> } => entry.id !== 'all')
+        .map((entry) => ({
+          category: entry,
+          items: templates.filter((template) => categorizeTemplateDocument(template.document) === entry.id)
+        }))
+        .filter((section) => section.items.length > 0)
+    : [];
+
   return (
-    <aside className="templates-rail">
-      <div className="templates-rail-tools">
-        <div className="templates-rail-search">
-          <input value={query} onChange={(event) => onQuery(event.target.value)} placeholder="Search templates" />
-          <button type="button" className="templates-rail-new" onClick={onNew} disabled={busy} aria-label="New benchmark template">
-            + New
+    <section className="template-browse">
+      <div className="template-browse__bar">
+        <div className="template-browse__title">
+          <h2>{categoryName(category)}</h2>
+          <span className="template-browse__count">{templates.length} template{templates.length === 1 ? '' : 's'}</span>
+        </div>
+        <div className="template-browse__tools">
+          <div className="template-browse__search">
+            <input value={query} onChange={(event) => onQuery(event.target.value)} placeholder="Search templates" />
+          </div>
+          <button type="button" className="templates-rail-new" onClick={onNew}>+ New</button>
+        </div>
+      </div>
+      <div className="templates-operation-filter template-browse__filters" aria-label="Template operation">
+        {OPERATION_FILTERS.map((value) => (
+          <button
+            key={value}
+            type="button"
+            className={operationFilter === value ? 'is-active' : ''}
+            onClick={() => onFilter(value)}
+            disabled={!ENABLED_OPERATION_FILTERS.has(value)}
+          >
+            {value}
           </button>
-        </div>
-        <div className="templates-operation-filter" aria-label="Template operation">
-          {OPERATION_FILTERS.map((value) => (
-            <button
-              key={value}
-              type="button"
-              className={operationFilter === value ? 'is-active' : ''}
-              onClick={() => onFilter(value)}
-              disabled={!ENABLED_OPERATION_FILTERS.has(value)}
-            >
-              {value}
-            </button>
-          ))}
-        </div>
+        ))}
       </div>
-      <div className="templates-list">
-        {templates.map((template) => {
-          const document = template.document;
-          return (
-            <button
-              key={template.id}
-              type="button"
-              className={selectedId === template.id && mode.kind === 'preview' ? 'template-row is-selected' : 'template-row'}
-              onClick={() => onSelect(template.id)}
-            >
-              <span className="template-row__name">{document.name ?? document.template_id}</span>
-              <span className="template-row__chip">{document.operation}</span>
-              <span className="template-row__description">{document.description ?? `${document.operation} benchmark template`}</span>
-            </button>
-          );
-        })}
-        {templates.length === 0 ? <p className="muted templates-list-empty">No templates match.</p> : null}
+
+      <div className="template-browse__body">
+        {templates.length === 0 ? (
+          <div className="template-browse-empty">
+            <h3>No templates match</h3>
+            <p>Try a different category, clear the search, or create a new template.</p>
+            <button type="button" className="btn btn--sm" onClick={onNew}>+ New template</button>
+          </div>
+        ) : category === 'all' ? (
+          groupedSections.map((section) => (
+            <section key={section.category.id} className="template-category-section">
+              <div className="template-category-section__head">
+                <span className="template-category-section__name">{section.category.name}</span>
+                <span className="template-category-section__count">{section.items.length}</span>
+                <span className="template-category-section__rule" />
+              </div>
+              <div className="template-card-grid">
+                {section.items.map((template) => <TemplateCard key={template.id} template={template} onSelect={onSelect} />)}
+              </div>
+            </section>
+          ))
+        ) : (
+          <div className="template-card-grid">
+            {templates.map((template) => <TemplateCard key={template.id} template={template} onSelect={onSelect} />)}
+          </div>
+        )}
       </div>
-    </aside>
+    </section>
   );
 }
 
@@ -294,10 +403,12 @@ function TemplateJsonWindow({
 
 function TemplatePreview({
   template,
+  onBack,
   onModify,
   onDelete
 }: {
   template: BenchmarkTestTemplateRecord;
+  onBack: () => void;
   onModify: () => void;
   onDelete: () => void;
 }) {
@@ -307,6 +418,7 @@ function TemplatePreview({
   const includesToolCallAssertion = document.metrics.includes(TOOL_CALL_ASSERTION_METRIC);
   return (
     <article className="template-preview-panel">
+      <button type="button" className="template-preview-backlink" onClick={onBack}>← All templates</button>
       <header>
         <div>
           <span className="template-kind template-kind--benchmark">benchmark</span>
@@ -490,6 +602,13 @@ function TemplateAgentPanel({
         ) : null}
       </div>
 
+      {currentDraft ? (
+        <div className="template-agent-draft-card">
+          <strong>Validated draft / passes benchmark_test_template_v1</strong>
+          <p>{currentDraft.name ?? currentDraft.template_id} / {currentDraft.operation} / {currentDraft.metrics.length} metrics</p>
+        </div>
+      ) : null}
+
       <footer className="template-agent-composer">
         <div className="template-agent-input-row">
           <textarea
@@ -506,12 +625,6 @@ function TemplateAgentPanel({
           />
           <button type="button" className="template-agent-send" onClick={() => sendMessage()} disabled={!canSend}>Send</button>
         </div>
-        {currentDraft ? (
-          <div className="template-agent-draft-card">
-            <strong>Validated draft / passes benchmark_test_template_v1</strong>
-            <p>{currentDraft.name ?? currentDraft.template_id} / {currentDraft.operation} / {currentDraft.metrics.length} metrics</p>
-          </div>
-        ) : null}
       </footer>
     </section>
   );
@@ -582,6 +695,7 @@ function TemplateAuthor({
   const saveEnabled = canSave && (mode === 'modify' || draftSource !== 'none');
   const title = mode === 'modify' ? 'Modify template' : 'Create template';
   const filename = `${currentDraft?.template_id || selectedTemplate?.document.template_id || 'template'}.json`;
+  const category = categorizeTemplateDocument(authorDocument);
 
   function openTab(nextTab: AuthorTab) {
     if (nextTab === 'raw' && !rawDirty) {
@@ -634,7 +748,13 @@ function TemplateAuthor({
     <div className="template-author">
       <div className="template-author__center">
         <div className="template-author__header">
-          <h2>{title}</h2>
+          <div className="template-author__heading">
+            <h2>{title}</h2>
+            <span className="template-category-badge">
+              <i className="template-category-badge__dot" aria-hidden="true" />
+              Category <strong>{categoryName(category)}</strong>
+            </span>
+          </div>
           <div className="template-author-tabs">
             <button type="button" className={tab === 'live' ? 'is-active' : ''} onClick={() => openTab('live')}>Live JSON</button>
             <button type="button" className={tab === 'advanced' ? 'is-active' : ''} onClick={() => openTab('advanced')}>Advanced form</button>
@@ -707,7 +827,8 @@ function TemplateAuthor({
 export function Templates() {
   const [templates, setTemplates] = useState<BenchmarkTestTemplateRecord[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [mode, setMode] = useState<TemplateMode>({ kind: 'preview' });
+  const [mode, setMode] = useState<TemplateMode>({ kind: 'grid' });
+  const [category, setCategory] = useState<TemplateCategory>('all');
   const [query, setQuery] = useState('');
   const [operationFilter, setOperationFilter] = useState<TemplateOperationFilter>('all');
   const [error, setError] = useState<string | null>(null);
@@ -723,9 +844,27 @@ export function Templates() {
     [templates, selectedId]
   );
 
+  const categoryCounts = useMemo<Record<TemplateCategory, number>>(() => {
+    const counts: Record<TemplateCategory, number> = {
+      all: templates.length,
+      tool: 0,
+      agentic: 0,
+      structured: 0
+    };
+    templates.forEach((template) => {
+      counts[categorizeTemplateDocument(template.document)] += 1;
+    });
+    return counts;
+  }, [templates]);
+
+  const categorizedTemplates = useMemo(() => {
+    if (category === 'all') return templates;
+    return templates.filter((template) => categorizeTemplateDocument(template.document) === category);
+  }, [category, templates]);
+
   const filteredTemplates = useMemo(() => {
     const lower = query.trim().toLowerCase();
-    return templates.filter((template) => {
+    return categorizedTemplates.filter((template) => {
       if (operationFilter !== 'all' && template.document.operation !== operationFilter) return false;
       if (!lower) return true;
       return [
@@ -735,34 +874,34 @@ export function Templates() {
         template.document.description ?? ''
       ].some((value) => value.toLowerCase().includes(lower));
     });
-  }, [operationFilter, query, templates]);
-
-  useEffect(() => {
-    if (mode.kind !== 'preview') return;
-    setSelectedId((current) => (
-      current && filteredTemplates.some((template) => template.id === current)
-        ? current
-        : filteredTemplates[0]?.id ?? null
-    ));
-  }, [filteredTemplates, mode.kind]);
+  }, [categorizedTemplates, operationFilter, query]);
 
   const loadTemplates = useCallback(async () => {
     const data = await listBenchmarkDocuments<BenchmarkTestTemplateDocument>('test_template');
     setTemplates(data);
-    setSelectedId((current) => current && data.some((template) => template.id === current) ? current : data[0]?.id ?? null);
+    return data;
   }, []);
 
   useEffect(() => {
     loadTemplates().catch(() => setTemplates([]));
   }, [loadTemplates]);
 
+  useEffect(() => {
+    if (mode.kind !== 'preview' && mode.kind !== 'modify') return;
+    if (selectedTemplate) return;
+    setMode({ kind: 'grid' });
+    setSelectedId(null);
+  }, [mode.kind, selectedTemplate]);
+
   async function handleSave(input: BenchmarkTestTemplateDocument) {
     setError(null);
     setBusy(true);
     try {
       await saveBenchmarkDocument(input);
-      await loadTemplates();
-      setSelectedId(input.template_id);
+      const data = await loadTemplates();
+      const savedTemplate = data.find((template) => template.id === input.template_id || template.document.template_id === input.template_id) ?? null;
+      setSelectedId(savedTemplate?.id ?? input.template_id);
+      setCategory(categorizeTemplateDocument(input));
       setMode({ kind: 'preview' });
       window.dispatchEvent(new CustomEvent('templates:changed'));
     } catch (err) {
@@ -782,9 +921,8 @@ export function Templates() {
       await deleteBenchmarkDocument('test_template', template.id);
       await loadTemplates();
       window.dispatchEvent(new CustomEvent('templates:changed'));
-      if (selectedId === template.id) {
-        setSelectedId(null);
-      }
+      setSelectedId(null);
+      setMode({ kind: 'grid' });
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Unable to delete benchmark template');
     } finally {
@@ -792,11 +930,14 @@ export function Templates() {
     }
   }
 
+  const selectedCategory = selectedTemplate ? categorizeTemplateDocument(selectedTemplate.document) : category;
   const breadcrumb = mode.kind === 'create'
     ? 'Templates / New'
     : mode.kind === 'modify' && selectedTemplate
       ? `Templates / ${templateLabel(selectedTemplate)} / Modify`
-      : undefined;
+      : mode.kind === 'preview' && selectedTemplate
+        ? `Templates / ${categoryName(selectedCategory)} / ${templateLabel(selectedTemplate)}`
+        : undefined;
 
   const subtitle = breadcrumb ? `${breadcrumb} / Reusable benchmark test_template documents.` : 'Reusable benchmark test_template documents.';
 
@@ -804,84 +945,93 @@ export function Templates() {
     <>
       <MergedPageHeader title="Templates" subtitle={subtitle} />
       <section className="page templates-page templates-page--polish">
-        {templates.length === 0 && mode.kind === 'preview' ? (
-          <EmptyState
-            className="templates-empty"
-            title="Your benchmark templates live here"
-            body="Create a reusable test_template document for benchmark runs."
-            actions={<button type="button" onClick={() => setMode({ kind: 'create' })}>New benchmark template</button>}
+        <div className="templates-layout templates-layout--catalog">
+          <TemplateCategoryRail
+            category={category}
+            counts={categoryCounts}
+            onCategory={(nextCategory) => {
+              setCategory(nextCategory);
+              setMode({ kind: 'grid' });
+              setSelectedId(null);
+              setError(null);
+            }}
           />
-        ) : (
-          <div className="templates-layout">
-            <TemplatesRail
-              templates={filteredTemplates}
-              selectedId={selectedId}
-              query={query}
-              operationFilter={operationFilter}
-              mode={mode}
-              busy={busy}
-              onQuery={setQuery}
-              onFilter={setOperationFilter}
-              onSelect={(id) => {
-                setSelectedId(id);
-                setMode({ kind: 'preview' });
-                setError(null);
-              }}
-              onNew={() => {
-                setMode({ kind: 'create' });
-                setError(null);
-              }}
-            />
-            <main className="templates-main">
-              {mode.kind === 'create' ? (
-                <TemplateAuthor
-                  mode="create"
-                  selectedTemplate={null}
-                  error={error}
-                  busy={busy}
-                  onCancel={() => {
+          <main className="templates-main">
+            {mode.kind === 'create' ? (
+              <TemplateAuthor
+                mode="create"
+                selectedTemplate={null}
+                error={error}
+                busy={busy}
+                onCancel={() => {
+                  setMode({ kind: 'grid' });
+                  setError(null);
+                }}
+                onSave={handleSave}
+                onBusy={setBusy}
+                onError={setError}
+              />
+            ) : mode.kind === 'modify' && selectedTemplate ? (
+              <TemplateAuthor
+                mode="modify"
+                selectedTemplate={selectedTemplate}
+                error={error}
+                busy={busy}
+                onCancel={() => {
+                  setMode({ kind: 'preview' });
+                  setError(null);
+                }}
+                onSave={handleSave}
+                onBusy={setBusy}
+                onError={setError}
+              />
+            ) : mode.kind === 'preview' && selectedTemplate ? (
+              <>
+                {error ? <div className="error templates-page-error">{error}</div> : null}
+                <TemplatePreview
+                  template={selectedTemplate}
+                  onBack={() => {
+                    setMode({ kind: 'grid' });
+                    setError(null);
+                  }}
+                  onModify={() => {
+                    setMode({ kind: 'modify' });
+                    setError(null);
+                  }}
+                  onDelete={() => handleDelete(selectedTemplate)}
+                />
+              </>
+            ) : templates.length === 0 ? (
+              <EmptyState
+                className="templates-empty"
+                title="Your benchmark templates live here"
+                body="Create a reusable test_template document for benchmark runs."
+                actions={<button type="button" onClick={() => setMode({ kind: 'create' })}>New benchmark template</button>}
+              />
+            ) : (
+              <>
+                {error ? <div className="error templates-page-error">{error}</div> : null}
+                <TemplateBrowseGrid
+                  templates={filteredTemplates}
+                  category={category}
+                  query={query}
+                  operationFilter={operationFilter}
+                  onQuery={setQuery}
+                  onFilter={setOperationFilter}
+                  onSelect={(templateId) => {
+                    setSelectedId(templateId);
                     setMode({ kind: 'preview' });
                     setError(null);
                   }}
-                  onSave={handleSave}
-                  onBusy={setBusy}
-                  onError={setError}
-                />
-              ) : mode.kind === 'modify' && selectedTemplate ? (
-                <TemplateAuthor
-                  mode="modify"
-                  selectedTemplate={selectedTemplate}
-                  error={error}
-                  busy={busy}
-                  onCancel={() => {
-                    setMode({ kind: 'preview' });
+                  onNew={() => {
+                    setMode({ kind: 'create' });
                     setError(null);
                   }}
-                  onSave={handleSave}
-                  onBusy={setBusy}
-                  onError={setError}
                 />
-              ) : selectedTemplate ? (
-                <>
-                  {error ? <div className="error templates-page-error">{error}</div> : null}
-                  <TemplatePreview
-                    template={selectedTemplate}
-                    onModify={() => {
-                      setMode({ kind: 'modify' });
-                      setError(null);
-                    }}
-                    onDelete={() => handleDelete(selectedTemplate)}
-                  />
-                </>
-              ) : (
-                <EmptyState
-                  title="Select a template"
-                  body="Choose a benchmark test_template from the list to preview its schema, metrics, and version details."
-                />
-              )}
-            </main>
-          </div>
-        )}
+              </>
+            )}
+          </main>
+        </div>
       </section>
     </>
   );

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -4887,7 +4887,7 @@ pre.code-block {
   display: grid;
   grid-template-columns: 268px minmax(0, 1fr);
   min-height: calc(100vh - 98px);
-  background: var(--paper-1);
+  background: var(--paper-2);
   border-bottom: 1px solid var(--border-divider);
 }
 
@@ -5041,6 +5041,7 @@ pre.code-block {
   min-width: 0;
   min-height: 0;
   overflow: hidden;
+  background: var(--bg-page);
 }
 
 .template-preview-panel {
@@ -5700,5 +5701,437 @@ pre.code-block {
   .template-author__header {
     flex-direction: column;
     align-items: stretch;
+  }
+}
+
+.templates-layout--catalog {
+  grid-template-columns: 236px minmax(0, 1fr);
+}
+
+.template-category-rail {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  border-right: 1px solid var(--border-divider);
+  background: var(--paper-2);
+}
+
+.template-category-rail__top {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+  gap: 8px;
+  overflow-y: auto;
+  padding: 16px 12px 8px;
+}
+
+.template-category-rail__label {
+  padding: 0 8px;
+  color: var(--ink-3);
+  font-size: 10px;
+  font-weight: var(--fw-semibold);
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+}
+
+.template-category-rail__list {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.template-category-item {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 11px;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  background: transparent;
+  text-align: left;
+}
+
+.template-category-item:hover {
+  background: var(--paper-0);
+}
+
+.template-category-item.is-active {
+  background: var(--bg-selected);
+  border-color: var(--border-selected);
+}
+
+.template-category-item__body {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.template-category-item__name {
+  color: var(--ink-9);
+  font-size: 13.5px;
+  font-weight: var(--fw-semibold);
+  line-height: 1.25;
+}
+
+.template-category-item__blurb {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  color: var(--ink-3);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.template-category-item__count {
+  display: inline-flex;
+  min-width: 24px;
+  height: 22px;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  padding: 0 7px;
+  border: 1px solid var(--border-divider);
+  border-radius: 999px;
+  background: var(--paper-5);
+  color: var(--ink-5);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: var(--fw-semibold);
+}
+
+.template-category-item.is-active .template-category-item__count {
+  border-color: var(--gold-2);
+  background: var(--gold-1);
+  color: var(--gold-5);
+}
+
+.template-browse {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.template-browse__bar {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  padding: 20px 28px 12px;
+}
+
+.template-browse__title {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.template-browse__title h2 {
+  margin: 0;
+  font-size: 20px;
+}
+
+.template-browse__count {
+  color: var(--ink-3);
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.template-browse__tools {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.template-browse__search {
+  display: flex;
+  align-items: center;
+}
+
+.template-browse__search input {
+  width: 230px;
+  height: 34px;
+  padding: 0 12px;
+  border: 1px solid var(--border-input);
+  border-radius: 8px;
+  background: #fffdfa;
+  color: var(--ink-9);
+  font-size: 13px;
+}
+
+.template-browse__filters {
+  padding: 0 28px 14px;
+  border-bottom: 1px solid var(--border-divider);
+}
+
+.template-browse__body {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+  gap: 26px;
+  overflow-y: auto;
+  padding: 18px 28px 36px;
+}
+
+.template-category-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.template-category-section__head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.template-category-section__name {
+  color: var(--ink-6);
+  font-size: 12px;
+  font-weight: var(--fw-semibold);
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+}
+
+.template-category-section__count {
+  display: inline-flex;
+  min-width: 20px;
+  height: 18px;
+  align-items: center;
+  justify-content: center;
+  padding: 0 6px;
+  border: 1px solid var(--border-divider);
+  border-radius: 999px;
+  background: var(--paper-5);
+  color: var(--ink-5);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: var(--fw-semibold);
+}
+
+.template-category-section__rule {
+  height: 1px;
+  flex: 1;
+  background: var(--border-divider);
+}
+
+.template-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(258px, 1fr));
+  gap: 12px;
+  align-content: start;
+}
+
+.template-card {
+  display: flex;
+  min-height: 158px;
+  flex-direction: column;
+  gap: 9px;
+  padding: 14px 15px;
+  border: 1px solid var(--border-default);
+  border-radius: 12px;
+  background: var(--paper-1);
+  text-align: left;
+  transition: transform var(--t-fast) var(--ease-out), box-shadow var(--t-fast), border-color var(--t-fast);
+}
+
+.template-card:hover {
+  transform: translateY(-2px);
+  border-color: var(--gold-2);
+  box-shadow: var(--shadow-card);
+}
+
+.template-card:active {
+  transform: translateY(0);
+}
+
+.template-card__top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.template-card__name {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  color: var(--ink-9);
+  font-size: 14px;
+  font-weight: var(--fw-semibold);
+  line-height: 1.3;
+}
+
+.template-card__description {
+  min-height: 51px;
+  margin: 0;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  color: var(--ink-3);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.template-card__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: auto;
+  padding-top: 9px;
+  border-top: 1px solid var(--border-divider);
+}
+
+.template-card__id {
+  overflow: hidden;
+  color: var(--ink-2);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+}
+
+.template-card__meta {
+  flex-shrink: 0;
+  color: var(--ink-3);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+}
+
+.template-browse-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 60px 20px;
+  color: var(--ink-3);
+  text-align: center;
+}
+
+.template-browse-empty h3 {
+  margin: 0;
+  color: var(--ink-7);
+  font-size: 16px;
+}
+
+.template-browse-empty p {
+  max-width: 38ch;
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.template-preview-backlink {
+  align-self: flex-start;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--ink-5);
+  font-size: 13px;
+  font-weight: var(--fw-medium);
+}
+
+.template-preview-backlink:hover {
+  color: var(--ink-9);
+}
+
+.template-author__heading {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 12px;
+}
+
+.template-category-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+  padding: 3px 10px;
+  border: 1px solid var(--gold-2);
+  border-radius: 999px;
+  background: var(--gold-1);
+  color: var(--ink-5);
+  font-size: 11.5px;
+}
+
+.template-category-badge strong {
+  color: var(--gold-5);
+  font-weight: var(--fw-semibold);
+}
+
+.template-category-badge__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--gold-3);
+}
+
+.template-agent-draft-card {
+  margin: 0 16px 12px;
+  border-radius: 12px;
+}
+
+@media (max-width: 980px) {
+  .templates-layout--catalog {
+    grid-template-columns: 1fr;
+  }
+
+  .template-category-rail {
+    border-right: 0;
+    border-bottom: 1px solid var(--border-divider);
+  }
+
+  .template-category-rail__top {
+    padding-bottom: 12px;
+  }
+
+  .template-category-rail__list {
+    overflow-x: auto;
+    flex-direction: row;
+    padding-bottom: 4px;
+  }
+
+  .template-category-item {
+    min-width: 220px;
+  }
+}
+
+@media (max-width: 820px) {
+  .template-browse__bar,
+  .template-browse__filters,
+  .template-browse__body {
+    padding-left: 18px;
+    padding-right: 18px;
+  }
+
+  .template-browse__search input {
+    width: 100%;
+  }
+
+  .template-browse__tools {
+    width: 100%;
+    flex-wrap: wrap;
+  }
+
+  .template-browse__search {
+    flex: 1;
+    min-width: 180px;
+  }
+
+  .template-author__heading {
+    flex-wrap: wrap;
   }
 }

--- a/frontend/tests/e2e/templates-crud.spec.ts
+++ b/frontend/tests/e2e/templates-crud.spec.ts
@@ -59,7 +59,9 @@ test('creates, updates, and deletes templates from the redesigned Templates page
 
   try {
     await page.goto('/templates');
-    await page.getByRole('button', { name: 'New benchmark template' }).first().click();
+    await expect(page.getByText('Browse by')).toBeVisible();
+    await expect(page.locator('.template-card').first()).toBeVisible();
+    await page.getByRole('button', { name: '+ New' }).click();
     await page.getByRole('button', { name: 'Advanced form' }).click();
     const createForm = page.locator('.template-advanced-panel form');
     await expect(createForm).toBeVisible();
@@ -91,11 +93,13 @@ test('creates, updates, and deletes templates from the redesigned Templates page
     await page.getByRole('button', { name: 'Live JSON' }).click();
     await page.getByRole('button', { name: 'Save template' }).click();
 
-    const createdRow = page.locator('.template-row').filter({ hasText: templateName });
-    await expect(createdRow).toBeVisible();
-    await expect(createdRow).toContainText(templateName);
+    await expect(page.locator('.template-preview-panel')).toContainText(templateId);
+    await page.getByRole('button', { name: '← All templates' }).click();
 
-    await createdRow.click();
+    const createdCard = page.locator('.template-card').filter({ hasText: templateName });
+    await expect(createdCard).toBeVisible();
+    await expect(createdCard).toContainText(templateName);
+    await createdCard.click();
     await expect(page.locator('.template-preview-panel')).toContainText(templateId);
     await page.locator('.template-preview-panel').getByRole('button', { name: 'Modify' }).click();
     await page.getByRole('button', { name: 'Advanced form' }).click();
@@ -108,10 +112,13 @@ test('creates, updates, and deletes templates from the redesigned Templates page
     await page.getByRole('button', { name: 'Update draft' }).click();
     await page.getByRole('button', { name: 'Save template' }).click();
 
-    const updatedRow = page.locator('.template-row').filter({ hasText: updatedName });
-    await expect(updatedRow).toBeVisible();
-    await expect(updatedRow).toContainText(updatedName);
-    await updatedRow.click();
+    await expect(page.locator('.template-preview-panel')).toContainText(updatedName);
+    await page.getByRole('button', { name: '← All templates' }).click();
+
+    const updatedCard = page.locator('.template-card').filter({ hasText: updatedName });
+    await expect(updatedCard).toBeVisible();
+    await expect(updatedCard).toContainText(updatedName);
+    await updatedCard.click();
     await page.locator('.template-preview-panel').getByRole('button', { name: 'Modify' }).click();
     await page.getByRole('button', { name: 'Raw JSON' }).click();
     await expect(page.locator('.template-raw-json')).toHaveValue(/"pair": \[/);
@@ -120,9 +127,8 @@ test('creates, updates, and deletes templates from the redesigned Templates page
     await page.getByRole('button', { name: 'x Close' }).click();
 
     page.on('dialog', (dialog) => dialog.accept());
-    await updatedRow.click();
     await page.locator('.template-preview-panel').getByRole('button', { name: 'Delete' }).click();
-    await expect(page.locator('.template-row').filter({ hasText: updatedName })).toHaveCount(0);
+    await expect(page.locator('.template-card').filter({ hasText: updatedName })).toHaveCount(0);
   } finally {
     await cleanupTemplateIds(page.request, [templateId]);
   }
@@ -201,7 +207,7 @@ test('authors a template through the in-page benchmark agent', async ({ page }) 
 
   try {
     await page.goto('/templates');
-    await page.getByRole('button', { name: 'New benchmark template' }).first().click();
+    await page.getByRole('button', { name: '+ New' }).click();
     await page.getByPlaceholder('Describe what you want...').fill('Create a tool-call benchmark.');
     await page.getByRole('button', { name: 'Send' }).click();
     await expect(page.getByText('Which success signal should this benchmark score?')).toBeVisible();
@@ -226,9 +232,7 @@ test('authors a template through the in-page benchmark agent', async ({ page }) 
     await expect(page.locator('.template-json-code')).toContainText(templateId);
     await page.getByRole('button', { name: 'Save template' }).click();
 
-    const row = page.locator('.template-row').filter({ hasText: templateName });
-    await expect(row).toBeVisible();
-    await row.click();
+    await expect(page.locator('.template-preview-panel')).toContainText(templateId);
     await expect(page.locator('.template-preview-panel')).toContainText('Tool-call assertion missing');
   } finally {
     await cleanupTemplateIds(page.request, [templateId]);


### PR DESCRIPTION
Recompose /templates around a browse-first catalog shell with category buckets, grouped cards, preview state, and embedded create/modify authoring.

Keep benchmark template CRUD, AI draft propagation, Advanced form, Raw JSON, and e2e coverage aligned with the new flow.