### PR TITLE
Prepare 0.11.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-06-25
+
 ### Added
 
 - **Long-context Python function retrieval benchmark** — added seven built-in context-window templates linked to file-backed Python function-retrieval datasets, with front/middle/late function placement, two-function retrieval, and a negative control.
@@ -20,6 +22,7 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 - **Run template capability filtering** — Run now disables benchmark templates that exceed a selected model's declared context window or require tool calling when the selected model/server is not tool-capable.
 - **Run audit and functional checks split** — Run now separates pipeline execution health from functional benchmark checks, and treats missing required terms as a visible functional failure when exact matching is disabled.
 - **Run functional failure clue** — Run now surfaces a benchmark assertion failure line when quality metrics fail despite a technically completed run, with categories such as invalid tool arguments or missing tool calls.
+- **Templates catalog shell** — `/templates` now opens as a browse-first catalog with category buckets, grouped template cards, dedicated preview state, and the existing AI-first authoring flow embedded in the new shell instead of auto-selecting the first template row.
 
 ## [0.10.0] - 2026-06-19
 
@@ -67,7 +70,6 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 - **Human-readable agent workflow guidance** — `AGENTS.md` now groups workflow rules into clearer sections, documents parallel worktree expectations including `origin/main` checks before commit/push requests and resync timing before validation or merge, directs agents to create a focused branch without pausing for confirmation, and asks agents to explicitly request commit approval with a suggested message and details.
 - **Templates agent composer** — The Templates authoring panel now gives the freeform request field more space and removes the preset suggestion chip.
 - **Run selection rail polish** — the Run page model chips, benchmark template selector, and response header now use clearer selected-state borders/backgrounds and denser mono text, with redundant server summary and model helper copy removed.
-- **Templates catalog shell** — `/templates` now opens as a browse-first catalog with category buckets, grouped template cards, dedicated preview state, and the existing AI-first authoring flow embedded in the new shell instead of auto-selecting the first template row.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # InferHarness
 
-[![version](https://img.shields.io/badge/version-0.10.0-blue)](https://github.com/Fango2007/InferHarness/releases/tag/v0.10.0)
+[![version](https://img.shields.io/badge/version-0.11.0-blue)](https://github.com/Fango2007/InferHarness/releases/tag/v0.11.0)
 [![node](https://img.shields.io/badge/node-25.x-339933)](package.json)
 [![python](https://img.shields.io/badge/python-3.10%2B-3776AB)](backend/src/scripts/requirements.txt)
 [![CI](https://github.com/Fango2007/InferHarness/actions/workflows/ci.yml/badge.svg)](https://github.com/Fango2007/InferHarness/actions/workflows/ci.yml)

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inferharness/backend",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inferharness/frontend",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "inferharness",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "inferharness",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "hasInstallScript": true,
       "workspaces": [
         "backend",
@@ -34,7 +34,7 @@
     },
     "backend": {
       "name": "@inferharness/backend",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "dependencies": {
         "ajv": "^8.12.0",
         "better-sqlite3": "^12.9.0",
@@ -54,7 +54,7 @@
     },
     "frontend": {
       "name": "@inferharness/frontend",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "dependencies": {
         "@vitejs/plugin-react": "^6.0.1",
         "echarts": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inferharness",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "workspaces": [
     "backend",


### PR DESCRIPTION
Bump workspace package versions and README badge to 0.11.0.

Move post-0.10.0 changelog entries into the 0.11.0 release section and correct the Templates catalog entry placement.