### PR TITLE
Add native provider tool-call streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 
 ## [Unreleased]
 
+### Added
+
+- **Native provider tool-call streaming** — benchmark execution now supports Anthropic Messages and Gemini GenerateContent SSE responses and normalizes streamed tool calls across OpenAI-compatible, Ollama, Anthropic, and Gemini protocols.
+
 ### Changed
 
 - **Agent workflow commands** — `AGENTS.md` now records the common validation, development, E2E, and benchmark data persistence workflows agents should use when changing the repo.

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ InferHarness supports local inference servers and native cloud provider APIs.
 | [Cerebras](https://cerebras.ai) | OpenAI-compatible | `/v1/models` | Bearer token |
 
 Cloud providers use the direct public API (not Bedrock or Vertex AI). Tokens are never stored in plaintext; use the `token_env` field to reference an environment variable.
-Benchmark runs use provider-native request payloads for non-streaming Anthropic Messages and Gemini GenerateContent tool-call tests, including provider-specific tool declarations and normalized returned tool calls.
+Benchmark runs use provider-native request payloads for Anthropic Messages and Gemini GenerateContent tool-call tests, including provider-specific tool declarations. Non-streaming and streaming responses normalize returned tool calls across OpenAI-compatible, Ollama, Anthropic, and Gemini protocols.
 
 Model formats supported in the catalog include `GGUF`, `MLX`, `GPTQ`, `AWQ`, and `SafeTensors`.
 

--- a/backend/src/services/benchmark-foundation.ts
+++ b/backend/src/services/benchmark-foundation.ts
@@ -252,13 +252,16 @@ function assertCapabilities(template: Record<string, unknown>, snapshot: Record<
 
 export function resolveOperationSpec(
   template: Record<string, unknown>,
-  snapshot: Record<string, unknown>
+  snapshot: Record<string, unknown>,
+  runtimeProfile?: Record<string, unknown>
 ): Record<string, unknown> {
   const operation = String(template.operation ?? 'chat_completion');
   const runtime = snapshot.runtime as { api?: { schema_family?: string[] } };
   const endpoints = snapshot.endpoints as { base_url?: string };
   const schemaFamily = runtime.api?.schema_family ?? [];
   const baseUrl = endpoints.base_url ?? '';
+  const streaming = runtimeParameters(runtimeProfile).stream === true;
+  const supportsStreaming = Boolean((snapshot.capabilities as { server?: { streaming?: boolean } }).server?.streaming);
 
   if (operation !== 'chat_completion') {
     throw new BenchmarkValidationError(`Only chat_completion operation resolution is supported in this checkpoint.`);
@@ -284,20 +287,25 @@ export function resolveOperationSpec(
       endpoint: '/v1/messages',
       protocol: 'anthropic_messages',
       operation,
-      supports_streaming: false,
+      supports_streaming: supportsStreaming,
       supports_usage: true
     };
   }
   if (schemaFamily.includes('gemini')) {
     const modelId = String((snapshot.model as { model_id?: unknown } | undefined)?.model_id ?? '');
     const modelPath = modelId.startsWith('models/') ? modelId : `models/${modelId}`;
+    const endpoint = streaming
+      ? `/v1beta/${modelPath}:streamGenerateContent?alt=sse`
+      : `/v1beta/${modelPath}:generateContent`;
     return {
       method: 'POST',
-      url: new URL(`/v1beta/${modelPath}:generateContent`, baseUrl).toString(),
-      endpoint: `/v1beta/{model}:generateContent`,
+      url: new URL(endpoint, baseUrl).toString(),
+      endpoint: streaming
+        ? '/v1beta/{model}:streamGenerateContent?alt=sse'
+        : '/v1beta/{model}:generateContent',
       protocol: 'gemini_generate_content',
       operation,
-      supports_streaming: false,
+      supports_streaming: supportsStreaming,
       supports_usage: true
     };
   }
@@ -331,7 +339,7 @@ export function buildBenchmarkInstantiationDocument(input: InstantiateBenchmarkI
   const modelProfile = buildModelProfile(input.server_id, input.model_id);
   const modelSnapshot = captureModelSnapshot(input.server_id, input.model_id);
   assertCapabilities(input.template, modelSnapshot);
-  const operationSpec = resolveOperationSpec(input.template, modelSnapshot);
+  const operationSpec = resolveOperationSpec(input.template, modelSnapshot, input.runtime_profile);
   const dataset =
     'kind' in input.dataset && (input.dataset as Record<string, unknown>).kind === 'dataset_manifest'
       ? input.dataset as Record<string, unknown>

--- a/backend/src/services/benchmark-runner.ts
+++ b/backend/src/services/benchmark-runner.ts
@@ -115,6 +115,7 @@ interface StreamEventSnapshot {
   json: Record<string, unknown> | unknown[] | null;
   done: boolean;
   seq: number;
+  event_name?: string;
 }
 
 interface StreamNormalization {
@@ -125,6 +126,7 @@ interface StreamNormalization {
   input_tokens: number | null;
   output_tokens: number | null;
   total_tokens: number | null;
+  tool_calls: unknown[] | null;
   final_metadata: Record<string, unknown> | null;
 }
 
@@ -136,6 +138,19 @@ export class BenchmarkStreamParseError extends Error {
   constructor(message: string, format: 'sse' | 'jsonl', events: StreamEventSnapshot[]) {
     super(message);
     this.name = 'BenchmarkStreamParseError';
+    this.format = format;
+    this.events = events;
+  }
+}
+
+export class BenchmarkUpstreamStreamError extends Error {
+  readonly code = 'upstream_stream_error';
+  readonly format: 'sse' | 'jsonl';
+  readonly events: StreamEventSnapshot[];
+
+  constructor(message: string, format: 'sse' | 'jsonl', events: StreamEventSnapshot[]) {
+    super(message);
+    this.name = 'BenchmarkUpstreamStreamError';
     this.format = format;
     this.events = events;
   }
@@ -567,13 +582,11 @@ export function buildBenchmarkRequestPayload(
   }
 
   if (protocol === 'anthropic_messages') {
-    if (stream) {
-      throw new BenchmarkValidationError('Streaming benchmark execution is not supported for anthropic_messages in this checkpoint.');
-    }
     const payload: Record<string, unknown> = {
       model,
       messages: anthropicMessages(messages),
-      max_tokens: typeof params.max_tokens === 'number' ? params.max_tokens : 1024
+      max_tokens: typeof params.max_tokens === 'number' ? params.max_tokens : 1024,
+      ...(stream ? { stream: true } : {})
     };
     const system = systemPromptFromMessages(messages);
     const tools = anthropicToolsFromItem(item);
@@ -588,9 +601,6 @@ export function buildBenchmarkRequestPayload(
   }
 
   if (protocol === 'gemini_generate_content') {
-    if (stream) {
-      throw new BenchmarkValidationError('Streaming benchmark execution is not supported for gemini_generate_content in this checkpoint.');
-    }
     const generationConfig: Record<string, unknown> = {};
     if (params.temperature !== undefined && params.temperature !== null) generationConfig.temperature = params.temperature;
     if (params.top_p !== undefined && params.top_p !== null) generationConfig.topP = params.top_p;
@@ -667,46 +677,132 @@ function usageTokens(metadata: Record<string, unknown> | null): Pick<NormalizedR
   };
 }
 
-function openAiDeltaContent(json: unknown): string {
-  const record = objectValue(json);
-  const choices = Array.isArray(record?.choices) ? record.choices : [];
-  const firstChoice = objectValue(choices[0]);
-  const delta = objectValue(firstChoice?.delta);
-  const message = objectValue(firstChoice?.message);
-  if (typeof delta?.content === 'string') return delta.content;
-  if (typeof message?.content === 'string') return message.content;
-  return '';
+function streamEventSnapshot(
+  raw: string,
+  json: Record<string, unknown> | unknown[] | null,
+  done: boolean,
+  seq: number,
+  eventName?: string
+): StreamEventSnapshot {
+  return {
+    raw,
+    json,
+    done,
+    seq,
+    ...(eventName ? { event_name: eventName } : {})
+  };
+}
+
+function streamErrorMessage(record: Record<string, unknown> | null): string | null {
+  const error = objectValue(record?.error);
+  return textFromValue(error?.message)
+    ?? textFromValue(record?.error)
+    ?? textFromValue(record?.message);
+}
+
+function parseToolArguments(
+  value: unknown,
+  context: string,
+  format: 'sse' | 'jsonl',
+  events: StreamEventSnapshot[]
+): Record<string, unknown> {
+  if (value === undefined || value === null || value === '') {
+    return {};
+  }
+  let parsed: unknown = value;
+  if (typeof value === 'string') {
+    try {
+      parsed = JSON.parse(value) as unknown;
+    } catch (error) {
+      throw new BenchmarkStreamParseError(`Malformed ${context} tool arguments: ${(error as Error).message}`, format, events);
+    }
+  }
+  const record = objectValue(parsed);
+  if (!record) {
+    throw new BenchmarkStreamParseError(`Malformed ${context} tool arguments: expected a JSON object.`, format, events);
+  }
+  return record;
+}
+
+function canonicalToolCall(name: string, args: Record<string, unknown>, id?: string): Record<string, unknown> {
+  return {
+    ...(id ? { id } : {}),
+    type: 'function',
+    function: { name, arguments: args }
+  };
 }
 
 export function parseOpenAiSseStream(raw: string): StreamNormalization {
   const parsed = parseSseEvents(raw);
   const events: StreamEventSnapshot[] = [];
   const content: string[] = [];
+  const toolCallParts = new Map<number, { id: string; name: string; arguments: string }>();
   let done = false;
   let finalMetadata: Record<string, unknown> | null = null;
 
   parsed.forEach((event, index) => {
     if (event.type === 'done') {
       done = true;
-      events.push({ raw: '[DONE]', json: null, done: true, seq: index });
+      events.push(streamEventSnapshot('[DONE]', null, true, index, event.event));
       return;
     }
     const eventRaw = event.payload ?? '';
     try {
       const json = JSON.parse(eventRaw) as Record<string, unknown> | unknown[];
-      events.push({ raw: eventRaw, json, done: false, seq: index });
-      const delta = openAiDeltaContent(json);
-      if (delta) {
-        content.push(delta);
-      }
+      events.push(streamEventSnapshot(eventRaw, json, false, index, event.event));
       const jsonRecord = objectValue(json);
+      if (event.event === 'error' || jsonRecord?.error) {
+        throw new BenchmarkUpstreamStreamError(
+          streamErrorMessage(jsonRecord) ?? 'OpenAI-compatible provider returned a stream error.',
+          'sse',
+          events
+        );
+      }
+      const choices = Array.isArray(jsonRecord?.choices) ? jsonRecord.choices : [];
+      for (const choice of choices) {
+        const choiceRecord = objectValue(choice);
+        const delta = objectValue(choiceRecord?.delta);
+        const message = objectValue(choiceRecord?.message);
+        const text = typeof delta?.content === 'string'
+          ? delta.content
+          : typeof message?.content === 'string' ? message.content : null;
+        if (text !== null) {
+          content.push(text);
+        }
+        const streamedCalls = Array.isArray(delta?.tool_calls)
+          ? delta.tool_calls
+          : Array.isArray(message?.tool_calls) ? message.tool_calls : [];
+        streamedCalls.forEach((call, callIndex) => {
+          const callRecord = objectValue(call);
+          const callPosition = typeof callRecord?.index === 'number' ? callRecord.index : callIndex;
+          const functionRecord = objectValue(callRecord?.function);
+          const current = toolCallParts.get(callPosition) ?? { id: '', name: '', arguments: '' };
+          if (typeof callRecord?.id === 'string') current.id += callRecord.id;
+          if (typeof functionRecord?.name === 'string') current.name += functionRecord.name;
+          if (typeof functionRecord?.arguments === 'string') current.arguments += functionRecord.arguments;
+          else if (objectValue(functionRecord?.arguments)) current.arguments = JSON.stringify(functionRecord?.arguments);
+          toolCallParts.set(callPosition, current);
+        });
+      }
       if (jsonRecord?.usage || jsonRecord?.choices) {
         finalMetadata = jsonRecord;
       }
     } catch (error) {
+      if (error instanceof BenchmarkUpstreamStreamError) {
+        throw error;
+      }
       throw new BenchmarkStreamParseError(`Malformed OpenAI SSE stream event ${index}: ${(error as Error).message}`, 'sse', events);
     }
   });
+
+  const toolCalls = [...toolCallParts.entries()]
+    .sort(([left], [right]) => left - right)
+    .map(([, call]) => {
+      if (!call.name) {
+        throw new BenchmarkStreamParseError('Malformed OpenAI streamed tool call: missing function name.', 'sse', events);
+      }
+      return canonicalToolCall(call.name, parseToolArguments(call.arguments, 'OpenAI', 'sse', events), call.id || undefined);
+    });
 
   return {
     format: 'sse',
@@ -714,6 +810,7 @@ export function parseOpenAiSseStream(raw: string): StreamNormalization {
     done,
     answer_text: content.join(''),
     ...usageTokens(finalMetadata),
+    tool_calls: toolCalls.length > 0 ? toolCalls : null,
     final_metadata: finalMetadata
   };
 }
@@ -722,6 +819,7 @@ export function parseOllamaJsonlStream(raw: string): StreamNormalization {
   const lines = raw.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
   const events: StreamEventSnapshot[] = [];
   const content: string[] = [];
+  const toolCalls: unknown[] = [];
   let done = false;
   let finalMetadata: Record<string, unknown> | null = null;
 
@@ -729,7 +827,14 @@ export function parseOllamaJsonlStream(raw: string): StreamNormalization {
     try {
       const json = JSON.parse(line) as Record<string, unknown>;
       const record = objectValue(json);
-      events.push({ raw: line, json, done: record?.done === true, seq: index });
+      events.push(streamEventSnapshot(line, json, record?.done === true, index));
+      if (record?.error) {
+        throw new BenchmarkUpstreamStreamError(
+          streamErrorMessage(record) ?? 'Ollama provider returned a stream error.',
+          'jsonl',
+          events
+        );
+      }
       const message = objectValue(record?.message);
       const part = typeof message?.content === 'string'
         ? message.content
@@ -737,11 +842,28 @@ export function parseOllamaJsonlStream(raw: string): StreamNormalization {
       if (part !== null) {
         content.push(part);
       }
+      const calls = Array.isArray(message?.tool_calls) ? message.tool_calls : [];
+      for (const call of calls) {
+        const callRecord = objectValue(call);
+        const functionRecord = objectValue(callRecord?.function);
+        const name = textFromValue(functionRecord?.name);
+        if (!name) {
+          throw new BenchmarkStreamParseError('Malformed Ollama streamed tool call: missing function name.', 'jsonl', events);
+        }
+        toolCalls.push(canonicalToolCall(
+          name,
+          parseToolArguments(functionRecord?.arguments, 'Ollama', 'jsonl', events),
+          textFromValue(callRecord?.id) ?? undefined
+        ));
+      }
       if (record?.done === true) {
         done = true;
         finalMetadata = record;
       }
     } catch (error) {
+      if (error instanceof BenchmarkStreamParseError || error instanceof BenchmarkUpstreamStreamError) {
+        throw error;
+      }
       throw new BenchmarkStreamParseError(`Malformed Ollama JSONL stream line ${index + 1}: ${(error as Error).message}`, 'jsonl', events);
     }
   });
@@ -752,6 +874,179 @@ export function parseOllamaJsonlStream(raw: string): StreamNormalization {
     done,
     answer_text: content.join(''),
     ...usageTokens(finalMetadata),
+    tool_calls: toolCalls.length > 0 ? toolCalls : null,
+    final_metadata: finalMetadata
+  };
+}
+
+export function parseAnthropicSseStream(raw: string): StreamNormalization {
+  const parsed = parseSseEvents(raw);
+  const events: StreamEventSnapshot[] = [];
+  const content: string[] = [];
+  const toolCalls: unknown[] = [];
+  const blocks = new Map<number, {
+    type: string;
+    id?: string;
+    name?: string;
+    initialInput: unknown;
+    partialJson: string;
+  }>();
+  let done = false;
+  let finalMetadata: Record<string, unknown> | null = null;
+
+  parsed.forEach((event, index) => {
+    const eventRaw = event.payload ?? '';
+    try {
+      const json = JSON.parse(eventRaw) as Record<string, unknown>;
+      const record = objectValue(json);
+      events.push(streamEventSnapshot(eventRaw, json, false, index, event.event));
+      const eventType = event.event ?? textFromValue(record?.type);
+      if (eventType === 'error' || record?.error) {
+        throw new BenchmarkUpstreamStreamError(
+          streamErrorMessage(record) ?? 'Anthropic returned a stream error.',
+          'sse',
+          events
+        );
+      }
+      if (eventType === 'message_start') {
+        const message = objectValue(record?.message);
+        if (message) finalMetadata = message;
+      } else if (eventType === 'content_block_start') {
+        const blockIndex = numberAt(record, 'index');
+        const block = objectValue(record?.content_block);
+        if (blockIndex !== null && block) {
+          const type = textFromValue(block.type) ?? 'unknown';
+          blocks.set(blockIndex, {
+            type,
+            id: textFromValue(block.id) ?? undefined,
+            name: textFromValue(block.name) ?? undefined,
+            initialInput: block.input,
+            partialJson: ''
+          });
+          if (type === 'text' && typeof block.text === 'string') content.push(block.text);
+        }
+      } else if (eventType === 'content_block_delta') {
+        const blockIndex = numberAt(record, 'index');
+        const delta = objectValue(record?.delta);
+        const block = blockIndex === null ? undefined : blocks.get(blockIndex);
+        if (delta?.type === 'text_delta' && typeof delta.text === 'string') {
+          content.push(delta.text);
+        } else if (block && delta?.type === 'input_json_delta' && typeof delta.partial_json === 'string') {
+          block.partialJson += delta.partial_json;
+        }
+      } else if (eventType === 'content_block_stop') {
+        const blockIndex = numberAt(record, 'index');
+        const block = blockIndex === null ? undefined : blocks.get(blockIndex);
+        if (block?.type === 'tool_use') {
+          if (!block.name) {
+            throw new BenchmarkStreamParseError('Malformed Anthropic streamed tool call: missing function name.', 'sse', events);
+          }
+          toolCalls.push(canonicalToolCall(
+            block.name,
+            parseToolArguments(block.partialJson || block.initialInput, 'Anthropic', 'sse', events),
+            block.id
+          ));
+        }
+        if (blockIndex !== null) blocks.delete(blockIndex);
+      } else if (eventType === 'message_delta') {
+        const usage = objectValue(record?.usage);
+        if (usage) {
+          finalMetadata = {
+            ...(finalMetadata ?? {}),
+            usage: {
+              ...(objectValue(finalMetadata?.usage) ?? {}),
+              ...usage
+            }
+          };
+        }
+      } else if (eventType === 'message_stop') {
+        done = true;
+        events[events.length - 1].done = true;
+      }
+    } catch (error) {
+      if (error instanceof BenchmarkStreamParseError || error instanceof BenchmarkUpstreamStreamError) {
+        throw error;
+      }
+      throw new BenchmarkStreamParseError(`Malformed Anthropic SSE stream event ${index}: ${(error as Error).message}`, 'sse', events);
+    }
+  });
+
+  if (!done || blocks.size > 0) {
+    throw new BenchmarkStreamParseError('Malformed Anthropic SSE stream: missing message_stop or incomplete content block.', 'sse', events);
+  }
+  return {
+    format: 'sse',
+    events,
+    done,
+    answer_text: content.join(''),
+    ...usageTokens(finalMetadata),
+    tool_calls: toolCalls.length > 0 ? toolCalls : null,
+    final_metadata: finalMetadata
+  };
+}
+
+export function parseGeminiSseStream(raw: string): StreamNormalization {
+  const parsed = parseSseEvents(raw);
+  const events: StreamEventSnapshot[] = [];
+  const content: string[] = [];
+  const toolCalls: unknown[] = [];
+  let finalMetadata: Record<string, unknown> | null = null;
+
+  parsed.forEach((event, index) => {
+    const eventRaw = event.payload ?? '';
+    try {
+      const json = JSON.parse(eventRaw) as Record<string, unknown>;
+      const record = objectValue(json);
+      events.push(streamEventSnapshot(eventRaw, json, false, index, event.event));
+      if (event.event === 'error' || record?.error) {
+        throw new BenchmarkUpstreamStreamError(
+          streamErrorMessage(record) ?? 'Gemini returned a stream error.',
+          'sse',
+          events
+        );
+      }
+      const candidates = Array.isArray(record?.candidates) ? record.candidates : [];
+      for (const candidate of candidates) {
+        const candidateRecord = objectValue(candidate);
+        const candidateContent = objectValue(candidateRecord?.content);
+        const parts = Array.isArray(candidateContent?.parts) ? candidateContent.parts : [];
+        for (const part of parts) {
+          const partRecord = objectValue(part);
+          if (typeof partRecord?.text === 'string') content.push(partRecord.text);
+          const functionCall = objectValue(partRecord?.functionCall);
+          const name = textFromValue(functionCall?.name);
+          if (functionCall && !name) {
+            throw new BenchmarkStreamParseError('Malformed Gemini streamed tool call: missing function name.', 'sse', events);
+          }
+          if (name) {
+            toolCalls.push(canonicalToolCall(
+              name,
+              parseToolArguments(functionCall?.args, 'Gemini', 'sse', events),
+              textFromValue(functionCall?.id) ?? undefined
+            ));
+          }
+        }
+      }
+      if (record?.usageMetadata || record?.candidates) finalMetadata = record;
+    } catch (error) {
+      if (error instanceof BenchmarkStreamParseError || error instanceof BenchmarkUpstreamStreamError) {
+        throw error;
+      }
+      throw new BenchmarkStreamParseError(`Malformed Gemini SSE stream event ${index}: ${(error as Error).message}`, 'sse', events);
+    }
+  });
+
+  if (events.length === 0) {
+    throw new BenchmarkStreamParseError('Malformed Gemini SSE stream: no response events.', 'sse', events);
+  }
+  events[events.length - 1].done = true;
+  return {
+    format: 'sse',
+    events,
+    done: true,
+    answer_text: content.join(''),
+    ...usageTokens(finalMetadata),
+    tool_calls: toolCalls.length > 0 ? toolCalls : null,
     final_metadata: finalMetadata
   };
 }
@@ -759,7 +1054,11 @@ export function parseOllamaJsonlStream(raw: string): StreamNormalization {
 function normalizeStreamResponse(protocol: unknown, contentType: string, responseText: string): NormalizedResponse {
   const stream = protocol === 'ollama_chat' && !contentType.includes('text/event-stream')
     ? parseOllamaJsonlStream(responseText)
-    : parseOpenAiSseStream(responseText);
+    : protocol === 'anthropic_messages'
+      ? parseAnthropicSseStream(responseText)
+      : protocol === 'gemini_generate_content'
+        ? parseGeminiSseStream(responseText)
+        : parseOpenAiSseStream(responseText);
   return {
     answer_text: stream.answer_text,
     input_tokens: stream.input_tokens,
@@ -769,7 +1068,7 @@ function normalizeStreamResponse(protocol: unknown, contentType: string, respons
     server_total_time_ms: extractServerTotalTimeMs(stream.final_metadata),
     server_prompt_eval_ms: extractServerPromptEvalMs(stream.final_metadata),
     server_eval_ms: extractServerEvalMs(stream.final_metadata),
-    tool_calls: null,
+    tool_calls: stream.tool_calls,
     body: stream.final_metadata,
     text: null,
     stream: {
@@ -940,7 +1239,7 @@ async function executeItem(
   }
   const timeoutMs = Number(runtimeParameters(instantiation).timeout_ms ?? objectAt(instantiation, 'execution_policy')?.timeout_ms ?? DEFAULT_TIMEOUT_MS);
   const payload = buildBenchmarkRequestPayload(instantiation, executable.item);
-  const streaming = payload.stream === true;
+  const streaming = runtimeParameters(instantiation).stream === true;
   const startedAt = nowIso();
   const start = performance.now();
   let firstTokenMs: number | null = null;
@@ -997,7 +1296,7 @@ async function executeItem(
           ? normalizeStreamResponse(operationSpec?.protocol, contentType, responseText)
           : normalizeResponse(operationSpec?.protocol, responseBody, responseBody === null ? responseText : null);
       } catch (error) {
-        if (!(error instanceof BenchmarkStreamParseError)) {
+        if (!(error instanceof BenchmarkStreamParseError) && !(error instanceof BenchmarkUpstreamStreamError)) {
           throw error;
         }
         const issue = {
@@ -1036,7 +1335,14 @@ async function executeItem(
             headers: Object.fromEntries(response.headers.entries()),
             body: null,
             text: responseText,
-            stream: { format: error.format, events: error.events, done: false, parse_error: error.message }
+            stream: {
+              format: error.format,
+              events: error.events,
+              done: false,
+              ...(error instanceof BenchmarkStreamParseError
+                ? { parse_error: error.message }
+                : { upstream_error: error.message })
+            }
           },
           normalizedResponse: {
             stage_id: stage.id,
@@ -1050,7 +1356,14 @@ async function executeItem(
             total_tokens: null,
             body: null,
             text: null,
-            stream: { format: error.format, events: error.events, done: false, parse_error: error.message }
+            stream: {
+              format: error.format,
+              events: error.events,
+              done: false,
+              ...(error instanceof BenchmarkStreamParseError
+                ? { parse_error: error.message }
+                : { upstream_error: error.message })
+            }
           },
           metrics: {
             stage_id: stage.id,

--- a/backend/src/services/sse-parser.ts
+++ b/backend/src/services/sse-parser.ts
@@ -1,25 +1,50 @@
 export interface SseEvent {
   type: 'data' | 'done';
   payload?: string;
+  event?: string;
 }
 
 export function parseSseEvents(raw: string): SseEvent[] {
   const events: SseEvent[] = [];
-  const chunks = raw.split(/\n\n/);
-  for (const chunk of chunks) {
-    const line = chunk.trim();
-    if (!line) {
+  let eventName: string | undefined;
+  let dataLines: string[] = [];
+
+  const dispatch = () => {
+    if (dataLines.length === 0) {
+      eventName = undefined;
+      return;
+    }
+    const payload = dataLines.join('\n');
+    if (payload.trim() === '[DONE]') {
+      events.push({ type: 'done', event: eventName });
+    } else {
+      events.push({ type: 'data', payload, event: eventName });
+    }
+    eventName = undefined;
+    dataLines = [];
+  };
+
+  for (const rawLine of raw.split(/\r?\n/)) {
+    const line = rawLine.trimStart();
+    if (line === '') {
+      dispatch();
       continue;
     }
-    const dataPrefix = 'data:';
-    if (line.startsWith(dataPrefix)) {
-      const payload = line.slice(dataPrefix.length).trim();
-      if (payload === '[DONE]') {
-        events.push({ type: 'done' });
-      } else {
-        events.push({ type: 'data', payload });
-      }
+    if (line.startsWith(':')) {
+      continue;
+    }
+    const colon = line.indexOf(':');
+    const field = colon === -1 ? line : line.slice(0, colon);
+    let value = colon === -1 ? '' : line.slice(colon + 1);
+    if (value.startsWith(' ')) {
+      value = value.slice(1);
+    }
+    if (field === 'event') {
+      eventName = value;
+    } else if (field === 'data') {
+      dataLines.push(value);
     }
   }
+  dispatch();
   return events;
 }

--- a/backend/tests/fixtures/streams/anthropic-error.sse
+++ b/backend/tests/fixtures/streams/anthropic-error.sse
@@ -1,0 +1,5 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_error","type":"message","role":"assistant","content":[],"model":"mock-chat","usage":{"input_tokens":5,"output_tokens":1}}}
+
+event: error
+data: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}

--- a/backend/tests/fixtures/streams/anthropic-text.sse
+++ b/backend/tests/fixtures/streams/anthropic-text.sse
@@ -1,0 +1,23 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_2","type":"message","role":"assistant","content":[],"model":"mock-chat","usage":{"input_tokens":5,"output_tokens":1}}}
+
+event: ping
+data: {"type":"ping"}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"benchmark "}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"answer"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":2}}
+
+event: message_stop
+data: {"type":"message_stop"}

--- a/backend/tests/fixtures/streams/anthropic-tool.sse
+++ b/backend/tests/fixtures/streams/anthropic-tool.sse
@@ -1,0 +1,20 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","content":[],"model":"mock-chat","usage":{"input_tokens":21,"output_tokens":1}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"get_weather","input":{}}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"city\":\"Par"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"is\",\"unit\":\"celsius\"}"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":9}}
+
+event: message_stop
+data: {"type":"message_stop"}

--- a/backend/tests/fixtures/streams/gemini-text.sse
+++ b/backend/tests/fixtures/streams/gemini-text.sse
@@ -1,0 +1,3 @@
+data: {"candidates":[{"content":{"role":"model","parts":[{"text":"benchmark "}]}}]}
+
+data: {"candidates":[{"content":{"role":"model","parts":[{"text":"answer"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":2,"totalTokenCount":7}}

--- a/backend/tests/fixtures/streams/gemini-tool.sse
+++ b/backend/tests/fixtures/streams/gemini-tool.sse
@@ -1,0 +1,1 @@
+data: {"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"get_weather","args":{"city":"Paris","unit":"celsius"}}}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":19,"candidatesTokenCount":7,"totalTokenCount":26}}

--- a/backend/tests/fixtures/streams/ollama-tool.jsonl
+++ b/backend/tests/fixtures/streams/ollama-tool.jsonl
@@ -1,0 +1,2 @@
+{"message":{"role":"assistant","content":"","tool_calls":[{"function":{"name":"get_weather","arguments":{"city":"Paris","unit":"celsius"}}}]},"done":false}
+{"done":true,"prompt_eval_count":19,"eval_count":7}

--- a/backend/tests/fixtures/streams/openai-tool.sse
+++ b/backend/tests/fixtures/streams/openai-tool.sse
@@ -1,0 +1,7 @@
+data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"get_weather","arguments":"{\"city\":\"Par"}}]}}]}
+
+data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"is\",\"unit\":\"celsius\"}"}}]}}]}
+
+data: {"choices":[{"delta":{}}],"usage":{"prompt_tokens":19,"completion_tokens":7,"total_tokens":26}}
+
+data: [DONE]

--- a/backend/tests/integration/benchmark-runner.test.ts
+++ b/backend/tests/integration/benchmark-runner.test.ts
@@ -13,6 +13,10 @@ import { sha256Document } from '../../src/services/benchmark-schemas.js';
 
 const AUTH_HEADERS = { 'x-api-token': 'test-token' };
 
+function streamFixture(name: string): string {
+  return fs.readFileSync(new URL(`../fixtures/streams/${name}`, import.meta.url), 'utf8');
+}
+
 function benchmarkTemplate(iterations = 1, stopOnError = false): Record<string, unknown> {
   return {
     kind: 'test_template',
@@ -447,6 +451,41 @@ function installMockGeminiFetch(): { baseUrl: string; requests: unknown[]; heade
   return { baseUrl: 'http://mock.local', requests, headers };
 }
 
+function installMockAnthropicStreamFetch(mode: 'ok' | 'error' = 'ok'): { baseUrl: string; requests: unknown[]; headers: Record<string, string>[] } {
+  const requests: unknown[] = [];
+  const headers: Record<string, string>[] = [];
+  vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    if (String(input) !== 'http://mock.local/v1/messages') {
+      return new Response('', { status: 404 });
+    }
+    const body = typeof init?.body === 'string' ? JSON.parse(init.body) as Record<string, unknown> : {};
+    requests.push(body);
+    headers.push(Object.fromEntries(new Headers(init?.headers).entries()));
+    const fixture = streamFixture(mode === 'error' ? 'anthropic-error.sse' : 'anthropic-tool.sse');
+    return streamResponse(
+      [fixture.slice(0, 137), fixture.slice(137, 411), fixture.slice(411)],
+      'text/event-stream'
+    );
+  }));
+  return { baseUrl: 'http://mock.local', requests, headers };
+}
+
+function installMockGeminiStreamFetch(): { baseUrl: string; requests: unknown[]; headers: Record<string, string>[] } {
+  const requests: unknown[] = [];
+  const headers: Record<string, string>[] = [];
+  vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    if (String(input) !== 'http://mock.local/v1beta/models/mock-chat:streamGenerateContent?alt=sse') {
+      return new Response('', { status: 404 });
+    }
+    const body = typeof init?.body === 'string' ? JSON.parse(init.body) as Record<string, unknown> : {};
+    requests.push(body);
+    headers.push(Object.fromEntries(new Headers(init?.headers).entries()));
+    const fixture = streamFixture('gemini-tool.sse');
+    return streamResponse([fixture.slice(0, 73), fixture.slice(73)], 'text/event-stream');
+  }));
+  return { baseUrl: 'http://mock.local', requests, headers };
+}
+
 function runtimeProfile(executionPolicy: Record<string, unknown>): Record<string, unknown> {
   return {
     kind: 'runtime_profile',
@@ -826,6 +865,168 @@ describe('benchmark runner API', () => {
     expect(result.document.metric_results[0].input_tokens).toBe(19);
     expect(result.document.metric_results[0].output_tokens).toBe(7);
     expect(result.document.metric_results[0].total_tokens).toBe(26);
+    await app.close();
+  });
+
+  it('executes streamed Anthropic tool calls with native events and unchanged metrics', async () => {
+    mockServer = installMockAnthropicStreamFetch();
+    const app = createServer();
+    seedServerAndModel(mockServer.baseUrl, {
+      schemaFamily: ['anthropic'],
+      streaming: true,
+      authToken: 'anthropic-secret',
+      authHeader: 'x-api-key',
+      tools: true
+    });
+
+    const createResponse = await app.inject({
+      method: 'POST',
+      url: '/benchmark/instantiations',
+      headers: AUTH_HEADERS,
+      payload: {
+        template: toolBenchmarkTemplate(),
+        server_id: 'srv-runner',
+        model_id: 'mock-chat',
+        runtime_profile: streamingRuntimeProfile(),
+        dataset: toolDataset()
+      }
+    });
+    expect(createResponse.statusCode, JSON.stringify(createResponse.json())).toBe(201);
+    expect(createResponse.json().document.operation_spec).toMatchObject({
+      protocol: 'anthropic_messages',
+      supports_streaming: true,
+      endpoint: '/v1/messages'
+    });
+
+    const runResponse = await app.inject({
+      method: 'POST',
+      url: `/benchmark/instantiations/${createResponse.json().id}/run`,
+      headers: AUTH_HEADERS
+    });
+    expect(runResponse.statusCode, JSON.stringify(runResponse.json())).toBe(201);
+    const result = runResponse.json();
+    expect(result.document.status).toBe('completed');
+    expect(mockServer.headers?.[0]).toMatchObject({
+      'anthropic-version': '2023-06-01',
+      'x-api-key': 'anthropic-secret'
+    });
+    expect(mockServer.requests[0]).toMatchObject({ model: 'mock-chat', stream: true });
+    expect(result.document.raw_responses[0].stream.events[0]).toMatchObject({
+      event_name: 'message_start'
+    });
+    expect(result.document.normalized_responses[0].tool_calls[0]).toMatchObject({
+      id: 'toolu_1',
+      type: 'function',
+      function: {
+        name: 'get_weather',
+        arguments: { city: 'Paris', unit: 'celsius' }
+      }
+    });
+    expect(result.document.metric_results[0]).toMatchObject({
+      tool_call_count: 1,
+      tool_call_assertion_pass: true,
+      input_tokens: 21,
+      output_tokens: 9
+    });
+    await app.close();
+  });
+
+  it('executes streamed Gemini tool calls through streamGenerateContent without a stream body field', async () => {
+    mockServer = installMockGeminiStreamFetch();
+    const app = createServer();
+    seedServerAndModel(mockServer.baseUrl, {
+      schemaFamily: ['gemini'],
+      streaming: true,
+      authToken: 'gemini-secret',
+      authHeader: 'x-goog-api-key',
+      tools: true
+    });
+
+    const createResponse = await app.inject({
+      method: 'POST',
+      url: '/benchmark/instantiations',
+      headers: AUTH_HEADERS,
+      payload: {
+        template: toolBenchmarkTemplate(),
+        server_id: 'srv-runner',
+        model_id: 'mock-chat',
+        runtime_profile: streamingRuntimeProfile(),
+        dataset: toolDataset()
+      }
+    });
+    expect(createResponse.statusCode, JSON.stringify(createResponse.json())).toBe(201);
+    expect(createResponse.json().document.operation_spec).toMatchObject({
+      protocol: 'gemini_generate_content',
+      supports_streaming: true,
+      endpoint: '/v1beta/{model}:streamGenerateContent?alt=sse',
+      url: 'http://mock.local/v1beta/models/mock-chat:streamGenerateContent?alt=sse'
+    });
+
+    const runResponse = await app.inject({
+      method: 'POST',
+      url: `/benchmark/instantiations/${createResponse.json().id}/run`,
+      headers: AUTH_HEADERS
+    });
+    expect(runResponse.statusCode, JSON.stringify(runResponse.json())).toBe(201);
+    const result = runResponse.json();
+    expect(result.document.status).toBe('completed');
+    expect(mockServer.headers?.[0]).toMatchObject({ 'x-goog-api-key': 'gemini-secret' });
+    expect(mockServer.requests[0]).not.toHaveProperty('stream');
+    expect(result.document.normalized_responses[0].stream.done).toBe(true);
+    expect(result.document.normalized_responses[0].tool_calls[0]).toMatchObject({
+      type: 'function',
+      function: {
+        name: 'get_weather',
+        arguments: { city: 'Paris', unit: 'celsius' }
+      }
+    });
+    expect(result.document.metric_results[0]).toMatchObject({
+      tool_call_count: 1,
+      tool_call_assertion_pass: true,
+      input_tokens: 19,
+      output_tokens: 7,
+      total_tokens: 26
+    });
+    await app.close();
+  });
+
+  it('persists Anthropic provider stream errors separately from malformed streams', async () => {
+    mockServer = installMockAnthropicStreamFetch('error');
+    const app = createServer();
+    seedServerAndModel(mockServer.baseUrl, {
+      schemaFamily: ['anthropic'],
+      streaming: true,
+      tools: true
+    });
+
+    const createResponse = await app.inject({
+      method: 'POST',
+      url: '/benchmark/instantiations',
+      headers: AUTH_HEADERS,
+      payload: {
+        template: toolBenchmarkTemplate(),
+        server_id: 'srv-runner',
+        model_id: 'mock-chat',
+        runtime_profile: streamingRuntimeProfile(),
+        dataset: toolDataset()
+      }
+    });
+    expect(createResponse.statusCode, JSON.stringify(createResponse.json())).toBe(201);
+
+    const runResponse = await app.inject({
+      method: 'POST',
+      url: `/benchmark/instantiations/${createResponse.json().id}/run`,
+      headers: AUTH_HEADERS
+    });
+    expect(runResponse.statusCode, JSON.stringify(runResponse.json())).toBe(201);
+    const result = runResponse.json();
+    expect(result.document.status).toBe('completed_with_errors');
+    expect(result.document.errors[0]).toMatchObject({
+      code: 'upstream_stream_error',
+      message: 'Overloaded'
+    });
+    expect(result.document.raw_responses[0].stream.upstream_error).toBe('Overloaded');
+    expect(result.document.raw_responses[0].stream).not.toHaveProperty('parse_error');
     await app.close();
   });
 

--- a/backend/tests/unit/benchmark-runner-policy.test.ts
+++ b/backend/tests/unit/benchmark-runner-policy.test.ts
@@ -1,14 +1,23 @@
+import fs from 'fs';
+
 import { describe, expect, it } from 'vitest';
 
 import {
   BenchmarkStreamParseError,
+  BenchmarkUpstreamStreamError,
   buildBenchmarkRequestPayload,
   isRetryableError,
+  parseAnthropicSseStream,
   parseExecutionPolicy,
+  parseGeminiSseStream,
   parseOllamaJsonlStream,
   parseOpenAiSseStream,
   retryDelayMs
 } from '../../src/services/benchmark-runner.js';
+
+function streamFixture(name: string): string {
+  return fs.readFileSync(new URL(`../fixtures/streams/${name}`, import.meta.url), 'utf8');
+}
 
 describe('benchmark runner execution policy', () => {
   it('parses retry and cancellation defaults', () => {
@@ -89,6 +98,48 @@ describe('benchmark runner execution policy', () => {
     expect(stream.input_tokens).toBe(4);
     expect(stream.output_tokens).toBe(2);
     expect(stream.total_tokens).toBe(6);
+  });
+
+  it('normalizes streamed tool calls across supported protocols', () => {
+    const streams = [
+      parseOpenAiSseStream(streamFixture('openai-tool.sse')),
+      parseOllamaJsonlStream(streamFixture('ollama-tool.jsonl')),
+      parseAnthropicSseStream(streamFixture('anthropic-tool.sse')),
+      parseGeminiSseStream(streamFixture('gemini-tool.sse'))
+    ];
+    for (const stream of streams) {
+      expect(stream.tool_calls?.[0]).toMatchObject({
+        type: 'function',
+        function: {
+          name: 'get_weather',
+          arguments: { city: 'Paris', unit: 'celsius' }
+        }
+      });
+      expect(stream.done).toBe(true);
+      expect(stream.total_tokens).toBeGreaterThan(0);
+    }
+  });
+
+  it('preserves Anthropic event names and rejects provider stream errors', () => {
+    const stream = parseAnthropicSseStream(streamFixture('anthropic-tool.sse'));
+    expect(stream.events[0]).toMatchObject({ event_name: 'message_start' });
+    expect(() => parseAnthropicSseStream(streamFixture('anthropic-error.sse')))
+      .toThrow(BenchmarkUpstreamStreamError);
+  });
+
+  it('normalizes native text streams and retains unknown valid Anthropic events', () => {
+    const anthropic = parseAnthropicSseStream(streamFixture('anthropic-text.sse'));
+    const gemini = parseGeminiSseStream(streamFixture('gemini-text.sse'));
+    expect(anthropic.answer_text).toBe('benchmark answer');
+    expect(anthropic.events).toContainEqual(expect.objectContaining({ event_name: 'ping' }));
+    expect(gemini.answer_text).toBe('benchmark answer');
+    expect(gemini.total_tokens).toBe(7);
+  });
+
+  it('rejects incomplete Anthropic tool arguments', () => {
+    const malformed = streamFixture('anthropic-tool.sse')
+      .replace('is\\",\\"unit\\":\\"celsius\\"}', 'is');
+    expect(() => parseAnthropicSseStream(malformed)).toThrow(BenchmarkStreamParseError);
   });
 
   it('keeps whitespace-only Ollama chunks', () => {

--- a/backend/tests/unit/sse-parser.test.ts
+++ b/backend/tests/unit/sse-parser.test.ts
@@ -9,4 +9,22 @@ describe('parseSseEvents', () => {
     expect(events.length).toBeGreaterThan(0);
     expect(events[0]).toMatchObject({ type: 'data' });
   });
+
+  it('parses named multiline events with CRLF and ignores comments', () => {
+    const events = parseSseEvents([
+      ': keep-alive',
+      'event: content_block_delta',
+      'data: {"type":"content_block_delta",',
+      'data: "index":0}',
+      '',
+      ''
+    ].join('\r\n'));
+    expect(events).toEqual([
+      {
+        type: 'data',
+        event: 'content_block_delta',
+        payload: '{"type":"content_block_delta",\n"index":0}'
+      }
+    ]);
+  });
 });


### PR DESCRIPTION
Enable native Anthropic Messages and Gemini GenerateContent streaming while preserving their existing non-streaming request contracts.

Normalize streamed tool calls and usage across OpenAI-compatible SSE, Ollama JSONL, Anthropic SSE, and Gemini SSE responses, including provider stream errors and malformed argument diagnostics.

Add reusable protocol fixtures, parser and runner coverage, and update the README and changelog without changing metric definitions, TTFT behavior, schemas, or the benchmark engine version.