### PR TITLE
feat(frontend): establish design-system conformance foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 
 ### Added
 
+- **Design-system conformance guard** — added a PostCSS-based `check:design-system` release check that rejects documented/runtime token drift, unresolved CSS variables, and application-level hardcoded colors.
+- **Responsive navigation shell** — added an accessible off-canvas navigation dialog below 900px with native focus containment, Escape and route-change dismissal, focus restoration, and full access to navigation, health, counts, and Settings.
 - **Product roadmap** — added `docs/ROADMAP.md` to define InferHarness product intent, the five milestone outcomes, feature-family sequencing, completion criteria, and deferred capabilities without prematurely specifying implementation design.
 - **Native provider tool-call streaming** — benchmark execution now supports Anthropic Messages and Gemini GenerateContent SSE responses and normalizes streamed tool calls across OpenAI-compatible, Ollama, Anthropic, and Gemini protocols.
 - **Application architecture documentation** — added `docs/ARCHITECTURE.md` to describe the current InferHarness runtime topology, frontend and backend module boundaries, persistence model, provider integration, and major feature areas.
@@ -19,6 +21,7 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 
 ### Changed
 
+- **Design-system foundation** — promoted `docs/design-system/tokens/` as the durable byte-identical token source, standardized the desktop sidebar at 220px, added input and accessible semantic-status tokens, resolved invalid aliases, and restored readable template operation chips.
 - **Agent workflow commands** — `AGENTS.md` now records the common validation, development, E2E, and benchmark data persistence workflows agents should use when changing the repo.
 - **Documentation source-of-truth rules** — `AGENTS.md` now freezes `docs/` as the durable documentation home for product and engineering specifications, keeps `specs/` reserved for temporary implementation inputs, and requires runtime code to consume source-tree implementation copies.
 - **Provider-native metrics foundation** — expanded `docs/METRICS.md` with canonical Ollama timing mappings, cross-provider token accounting, native-field provenance, exact/qualified/provider-only mapping rules, and a clean database-reset transition to `metrics-v2` without legacy aliases or historical metric migration.

--- a/README.md
+++ b/README.md
@@ -399,6 +399,8 @@ Browser UI
 
 **Frontend**
 React single-page application served by Vite. It talks to the backend through the API and does not access the database directly.
+The browser interface uses a 220px navigation sidebar at desktop widths and an
+accessible off-canvas navigation dialog below 900px.
 
 **Backend**
 Fastify HTTP server responsible for server registration, model discovery, test execution, evaluation records, leaderboard data, and persistence.

--- a/docs/design-system/README.md
+++ b/docs/design-system/README.md
@@ -10,9 +10,10 @@ This document describes the current InferHarness design system at the token,
 component, and implementation-rule level. It is intended to help contributors
 extend the UI without inventing new visual language.
 
-The high-fidelity handoff source is
-`specs/new-layouts/design_handoff_01_design_system/`. This folder keeps a
-repository-maintained design-system snapshot:
+The original high-fidelity handoff was moved from
+`specs/new-layouts/design_handoff_01_design_system/` into this directory.
+`docs/design-system/tokens/` is now the durable design-system specification
+snapshot:
 
 - `docs/design-system/tokens/colors_and_type.css`;
 - `docs/design-system/tokens/components.css`;
@@ -23,9 +24,9 @@ The live frontend implementation uses:
 - `frontend/src/styles/tokens/colors_and_type.css`;
 - `frontend/src/styles/tokens/components.css`.
 
-Those live token files currently match both the handoff token files and the
-snapshot under this folder. Use the token CSS files as the source for exact CSS
-custom-property names and values.
+`frontend/src/styles/tokens/` is the runtime copy. Its CSS and font files must
+remain byte-identical to the durable snapshot. Use the documented token files
+as the source for exact CSS custom-property names and values.
 
 ## 2. Design Intent
 
@@ -165,11 +166,11 @@ Current layout tokens include:
 - `--sidebar-w`: token-level sidebar width;
 - `--nav-btn-size`: square nav button size;
 - `--input-h`: standard input height;
-- `--bp-mobile`: mobile breakpoint.
+- `900px`: canonical breakpoint for the compact top bar and off-canvas
+  navigation. Breakpoint values are written directly in media queries because
+  CSS custom properties cannot be used in media-query conditions.
 
-The current production shell uses a 220px expanded sidebar in
-`frontend/src/styles/index.css`. Treat page-level shell sizing as an app
-implementation layer above the base token file.
+The production shell uses `--sidebar-w` for its 220px desktop sidebar.
 
 ## 7. Radii and Shape
 

--- a/docs/design-system/tokens/colors_and_type.css
+++ b/docs/design-system/tokens/colors_and_type.css
@@ -136,7 +136,11 @@
                     rgba(240, 233, 223, 0.9));
   --bg-pre-dark:  var(--ink-1);
   --bg-pre-light: #f6f1e6;
+  --bg-input:     #fffdfa;
+  --bg-input-alt: #fffefa;
   --bg-error:     #ffe8e5;
+  --bg-error-soft: #fff8f5;
+  --bg-streaming: #fff9ec;
   --bg-tab-active:    #fff8ea;
   --bg-tab-inactive:  var(--paper-5);
   --bg-nav-active:    #fff4e6;
@@ -155,20 +159,42 @@
 
   /* ---- 6. Semantic ---------------------------------------- */
   --ok:           #2f9e44;
-  --ok-tint:      rgba(47, 158, 68, 0.12);
+  --ok-text:      #246b3d;
+  --ok-tint:      #ddf2e4;
+  --ok-border:    #8abf92;
   --ok-halo:      rgba(47, 158, 68, 0.2);
 
   --danger:       #c92a2a;
   --danger-icon:  #b42318;
-  --danger-tint:  rgba(201, 42, 42, 0.1);
+  --danger-text:  #93403d;
+  --danger-tint:  #f7dedb;
+  --danger-border: #d99a9a;
+  --danger-accent: #c95b45;
+  --danger-field-border: #9c3f2e;
+  --danger-soft-transparent: rgba(255, 248, 245, 0);
   --danger-halo:  rgba(201, 42, 42, 0.2);
 
   --pending:      #b3aca2;
   --pending-text: #766f66;
+  --pending-tint: #e9e3d9;
   --pending-halo: rgba(179, 172, 162, 0.2);
 
   --warning-dot:  #f2c94c;
-  --warning-tint: rgba(242, 201, 76, 0.18);
+  --warning-text: #7a5b11;
+  --warning-tint: #f8edc7;
+
+  --benchmark-text: #55601f;
+  --benchmark-tint: #e7ead8;
+
+  /* distinguish concurrent run targets */
+  --run-accent-1: #3776ab;
+  --run-accent-2: #cb6d1a;
+  --run-accent-3: #5b8a3a;
+  --run-accent-4: #8a4a9c;
+  --run-accent-5: #b85c5c;
+  --run-accent-6: #3a7a7a;
+  --run-accent-7: #7a6a3a;
+  --run-accent-8: #5c5c5c;
 
   /* ---- 7. Borders ----------------------------------------- */
   --border-default:    var(--paper-7);
@@ -211,6 +237,8 @@
                         0 2px 6px rgba(27, 26, 23, 0.12);
   --shadow-modal:       0 20px 40px rgba(27, 26, 23, 0.2);
   --shadow-popover:     0 8px 24px rgba(27, 26, 23, 0.14);
+  --shadow-drawer:      -12px 0 30px rgba(27, 26, 23, 0.18);
+  --shadow-button-hover: 0 6px 14px rgba(27, 26, 23, 0.18);
 
   --halo-focus:         0 0 0 3px var(--gold-1),
                         0 0 0 4px var(--gold-3);
@@ -219,6 +247,22 @@
   --halo-pending:       0 0 0 4px var(--pending-halo);
 
   --overlay-modal:      rgba(27, 26, 23, 0.4);
+  --halo-neutral:       0 0 0 3px rgba(55, 53, 47, 0.08);
+
+  /* dark structured-data editor */
+  --terminal-border:       #2a2722;
+  --terminal-surface:      #211e1a;
+  --terminal-control:      #3f3a33;
+  --terminal-warning:      #e0a23a;
+  --terminal-muted:        #5b554c;
+  --terminal-text:         #e7ddc9;
+  --terminal-text-muted:   #cabfa9;
+  --terminal-text-subtle:  #7c756a;
+  --terminal-field-border: #3a352d;
+  --terminal-field-text:   #b6a986;
+  --terminal-selection:    rgba(140, 115, 64, 0.22);
+  --terminal-highlight:    rgba(140, 115, 64, 0.16);
+  --terminal-pulse:        rgba(140, 115, 64, 0.55);
 
   /* ---- 10. Spacing scale (4-base, with 2px micro) -------- */
   --s-0:  0;
@@ -248,10 +292,9 @@
   /* ---- 12. Layout --------------------------------------- */
   --page-max:       960px;
   --page-max-wide:  1200px;
-  --sidebar-w:      72px;
+  --sidebar-w:      220px;
   --nav-btn-size:   44px;
   --input-h:        34px;
-  --bp-mobile:      900px;
 }
 
 /* ============================================================

--- a/docs/design-system/tokens/components.css
+++ b/docs/design-system/tokens/components.css
@@ -40,7 +40,7 @@ body.atb {
               background var(--t-fast) var(--ease-out);
   white-space: nowrap;
 }
-.btn:hover { transform: translateY(-1px); box-shadow: 0 6px 14px rgba(27,26,23,0.18); }
+.btn:hover { transform: translateY(-1px); box-shadow: var(--shadow-button-hover); }
 .btn:active { transform: var(--xfm-press); box-shadow: none; }
 .btn:focus-visible { outline: none; box-shadow: var(--halo-focus); }
 
@@ -110,7 +110,7 @@ body.atb {
   width: 100%;
   padding: 0 var(--s-10);
   font-family: var(--font-sans); font-size: var(--fs-md); color: var(--ink-9);
-  background: #fffdfa; border: 1px solid var(--border-input); border-radius: var(--r-input);
+  background: var(--bg-input); border: 1px solid var(--border-input); border-radius: var(--r-input);
   outline: none;
   transition: border-color var(--t-fast), box-shadow var(--t-fast);
 }
@@ -121,7 +121,7 @@ body.atb {
 .textarea {
   width: 100%; min-height: 220px; padding: var(--s-8) var(--s-10);
   font-family: var(--font-mono); font-size: var(--fs-base); color: var(--ink-9);
-  background: #fffdfa; border: 1px solid var(--border-input); border-radius: var(--r-input);
+  background: var(--bg-input); border: 1px solid var(--border-input); border-radius: var(--r-input);
   outline: none; resize: vertical;
 }
 .textarea:focus { border-color: var(--gold-3); box-shadow: 0 0 0 3px var(--gold-1); }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
     "@vitejs/plugin-react": "^6.0.1",
     "echarts": "^6.0.0",
     "echarts-for-react": "^3.0.6",
+    "lucide-react": "^0.468.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.30.3"

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,4 +1,6 @@
-import { NavLink } from 'react-router-dom';
+import { Menu, Settings, X } from 'lucide-react';
+import { useEffect, useRef } from 'react';
+import { NavLink, useLocation } from 'react-router-dom';
 
 import type { OnboardingStatus } from '../onboarding.js';
 import { RegLight } from './RegLight.js';
@@ -73,11 +75,26 @@ function RegLightRow({
   );
 }
 
-export function Sidebar({ version, health, modelCount, templateCount, datasetCount, runCount, onboarding, onSettings }: SidebarProps) {
+interface SidebarContentProps extends SidebarProps {
+  onNavigate?: () => void;
+}
+
+function SidebarContent({
+  version,
+  health,
+  modelCount,
+  templateCount,
+  datasetCount,
+  runCount,
+  onboarding,
+  onSettings,
+  onNavigate
+}: SidebarContentProps) {
   const onboardingActive = onboarding?.active === true;
   const unlockedIndex = onboardingActive ? navOrder.indexOf(onboarding.unlockedThrough) : navOrder.length - 1;
+
   return (
-    <aside className="sidebar">
+    <>
       <div className="sidebar-brand">
         <strong>InferHarness</strong>
         <span>v{version}</span>
@@ -100,7 +117,9 @@ export function Sidebar({ version, health, modelCount, templateCount, datasetCou
             onClick={(event) => {
               if (locked) {
                 event.preventDefault();
+                return;
               }
+              onNavigate?.();
             }}
           >
             <span className="sidebar-item__main">
@@ -141,11 +160,82 @@ export function Sidebar({ version, health, modelCount, templateCount, datasetCou
         </div>
       )}
       <div className="sidebar-settings">
-        <button type="button" onClick={onSettings}>
-          <span aria-hidden="true">S</span>
+        <button
+          type="button"
+          onClick={() => {
+            onNavigate?.();
+            onSettings();
+          }}
+        >
+          <span aria-hidden="true"><Settings size={15} strokeWidth={1.8} /></span>
           <strong>Settings</strong>
         </button>
       </div>
-    </aside>
+    </>
+  );
+}
+
+export function Sidebar(props: SidebarProps) {
+  const location = useLocation();
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const menuButtonRef = useRef<HTMLButtonElement>(null);
+
+  const closeDialog = () => {
+    if (dialogRef.current?.open) {
+      dialogRef.current.close();
+    }
+  };
+
+  useEffect(() => {
+    closeDialog();
+  }, [location.pathname, location.search]);
+
+  return (
+    <>
+      <header className="mobile-app-bar">
+        <div>
+          <strong>InferHarness</strong>
+          <span>v{props.version}</span>
+        </div>
+        <button
+          ref={menuButtonRef}
+          type="button"
+          className="mobile-app-bar__menu"
+          aria-label="Open navigation"
+          onClick={() => dialogRef.current?.showModal()}
+        >
+          <Menu aria-hidden="true" size={22} />
+        </button>
+      </header>
+
+      <aside className="sidebar sidebar--desktop">
+        <SidebarContent {...props} />
+      </aside>
+
+      <dialog
+        ref={dialogRef}
+        className="mobile-nav-dialog"
+        aria-label="Primary navigation"
+        onCancel={closeDialog}
+        onClose={() => menuButtonRef.current?.focus()}
+        onClick={(event) => {
+          if (event.target === dialogRef.current) {
+            closeDialog();
+          }
+        }}
+      >
+        <aside className="sidebar sidebar--mobile">
+          <button
+            type="button"
+            className="mobile-nav-dialog__close"
+            aria-label="Close navigation"
+            onClick={closeDialog}
+          >
+            <X aria-hidden="true" size={20} />
+          </button>
+          <SidebarContent {...props} onNavigate={closeDialog} />
+        </aside>
+      </dialog>
+    </>
   );
 }

--- a/frontend/src/services/run-unified-utils.ts
+++ b/frontend/src/services/run-unified-utils.ts
@@ -2,14 +2,14 @@ import type { InferenceServerRecord } from './inference-servers-api.js';
 import type { ModelRecord } from './models-api.js';
 
 export const RUN_ACCENTS = [
-  '#3776ab',
-  '#cb6d1a',
-  '#5b8a3a',
-  '#8a4a9c',
-  '#b85c5c',
-  '#3a7a7a',
-  '#7a6a3a',
-  '#5c5c5c'
+  'var(--run-accent-1)',
+  'var(--run-accent-2)',
+  'var(--run-accent-3)',
+  'var(--run-accent-4)',
+  'var(--run-accent-5)',
+  'var(--run-accent-6)',
+  'var(--run-accent-7)',
+  'var(--run-accent-8)'
 ] as const;
 
 export interface RunTarget {

--- a/frontend/src/styles/dashboard-results.css
+++ b/frontend/src/styles/dashboard-results.css
@@ -363,7 +363,7 @@
   place-items: center;
   border: 1px dashed var(--paper-7);
   border-radius: 14px;
-  color: var(--gold-9);
+  color: var(--gold-4);
   font-family: var(--font-mono);
   letter-spacing: 2px;
 }
@@ -453,23 +453,23 @@
 }
 
 .results-status--pass {
-  background: #ddf2e4;
-  color: #246b3d;
+  background: var(--ok-tint);
+  color: var(--ok-text);
 }
 
 .results-status--fail {
-  background: #f7dedb;
-  color: #93403d;
+  background: var(--danger-tint);
+  color: var(--danger-text);
 }
 
 .results-status--partial {
-  background: #f8edc7;
-  color: #7a5b11;
+  background: var(--warning-tint);
+  color: var(--warning-text);
 }
 
 .results-status--streaming {
-  background: #dfeaf7;
-  color: #315f8c;
+  background: var(--pending-tint);
+  color: var(--pending-text);
 }
 
 .results-toolbar {
@@ -577,7 +577,7 @@
   z-index: 20;
   display: flex;
   justify-content: flex-end;
-  background: rgba(0, 0, 0, 0.38);
+  background: var(--overlay-modal);
 }
 
 .results-drawer {
@@ -588,7 +588,7 @@
   overflow-x: hidden;
   overflow-y: auto;
   background: var(--paper-1);
-  box-shadow: -12px 0 30px rgba(0, 0, 0, 0.18);
+  box-shadow: var(--shadow-drawer);
 }
 
 .results-drawer__header {

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -29,6 +29,11 @@ body {
   background: var(--bg-page);
 }
 
+.mobile-app-bar,
+.mobile-nav-dialog {
+  display: none;
+}
+
 .subhead {
   margin: 6px 0 0;
   color: var(--ink-5);
@@ -94,8 +99,8 @@ h2 {
 .sidebar {
   position: sticky;
   top: 0;
-  width: 220px;
-  flex: 0 0 220px;
+  width: var(--sidebar-w);
+  flex: 0 0 var(--sidebar-w);
   height: 100vh;
   display: flex;
   flex-direction: column;
@@ -274,11 +279,11 @@ h2 {
 }
 
 .sidebar-health-row--up .sidebar-health-row__dot {
-  background: #2d8a4e;
+  background: var(--ok);
 }
 
 .sidebar-health-row--down .sidebar-health-row__dot {
-  background: #b94a48;
+  background: var(--danger);
 }
 
 .sidebar-health-row strong {
@@ -352,7 +357,7 @@ h2 {
   display: inline-block;
   border-radius: 999px;
   background: var(--ink-3);
-  box-shadow: 0 0 0 3px rgba(55, 53, 47, 0.08);
+  box-shadow: var(--halo-neutral);
 }
 
 .reg-light-dot--healthy {
@@ -537,7 +542,7 @@ h2 {
   border: 1px solid var(--gold-3);
   border-radius: 8px;
   background: var(--paper-1);
-  box-shadow: 0 20px 40px rgba(27, 26, 23, 0.18);
+  box-shadow: var(--shadow-modal);
 }
 
 .handoff-toast__bar {
@@ -1341,7 +1346,7 @@ button.is-pending::after {
 }
 
 .template-row.is-selected {
-  border-left-color: var(--gold-9);
+  border-left-color: var(--gold-4);
   background: var(--bg-selected);
 }
 
@@ -1375,8 +1380,8 @@ button.is-pending::after {
   max-width: 92px;
   overflow: hidden;
   text-overflow: ellipsis;
-  background: #e7ead8;
-  color: #55601f;
+  background: var(--benchmark-tint);
+  color: var(--benchmark-text);
 }
 
 .templates-preview {
@@ -1466,9 +1471,9 @@ button.is-pending::after {
 }
 
 .template-tool-status.is-pass {
-  border-color: #8abf92;
-  background: #edf8ef;
-  color: #1f6b35;
+  border-color: var(--ok-border);
+  background: var(--ok-tint);
+  color: var(--ok-text);
 }
 
 .template-tool-status.is-warning {
@@ -1478,15 +1483,15 @@ button.is-pending::after {
 }
 
 .template-field--schema-required {
-  color: #7d2e21;
+  color: var(--danger-text);
   font-weight: 700;
 }
 
 .template-field--schema-required input:not([type='checkbox']):not([type='radio']),
 .template-field--schema-required select {
-  border-color: #9c3f2e;
-  box-shadow: inset 3px 0 0 #c95b45;
-  background: #fff8f5;
+  border-color: var(--danger-field-border);
+  box-shadow: inset 3px 0 0 var(--danger-accent);
+  background: var(--bg-error-soft);
 }
 
 .template-editor-section {
@@ -1497,13 +1502,13 @@ button.is-pending::after {
 }
 
 .template-section--schema-required {
-  border-top-color: #c95b45;
-  background: linear-gradient(90deg, #fff8f5 0, rgba(255, 248, 245, 0) 42%);
+  border-top-color: var(--danger-accent);
+  background: linear-gradient(90deg, var(--bg-error-soft) 0, var(--danger-soft-transparent) 42%);
   padding: 10px 0 0 10px;
 }
 
 .template-section--schema-required h3 {
-  color: #7d2e21;
+  color: var(--danger-text);
 }
 
 .template-editor-section h3 {
@@ -2103,7 +2108,7 @@ button.is-pending::after {
 .run-response-header .run-avatar.is-large {
   padding: 6px 8px;
   border-radius: 10px;
-  color: #ffffff;
+  color: var(--paper-1);
   font-size: 14px;
 }
 
@@ -2117,19 +2122,19 @@ button.is-pending::after {
 }
 
 .status-completed {
-  background: #d7ebdd;
-  color: #1f6b3c;
+  background: var(--ok-tint);
+  color: var(--ok-text);
 }
 
 .status-running,
 .status-queued {
-  background: #f7e3c6;
-  color: #8a520f;
+  background: var(--warning-tint);
+  color: var(--warning-text);
 }
 
 .status-failed {
-  background: #f1d1d1;
-  color: #9a3030;
+  background: var(--danger-tint);
+  color: var(--danger-text);
 }
 
 .status-canceled {
@@ -2288,14 +2293,14 @@ button.is-pending::after {
 }
 
 .run-correctness-grid span.is-pass {
-  border-color: #8abf92;
-  background: #edf8ef;
-  color: #1f6b35;
+  border-color: var(--ok-border);
+  background: var(--ok-tint);
+  color: var(--ok-text);
 }
 
 .run-correctness-grid span.is-pass b,
 .run-correctness-grid span.is-pass small {
-  color: #1f6b35;
+  color: var(--ok-text);
 }
 
 .run-correctness-grid span.is-fail {
@@ -2310,11 +2315,11 @@ button.is-pending::after {
 }
 
 .run-metric-grid span.is-estimated {
-  color: #cc0000;
+  color: var(--danger);
 }
 
 .run-metric-grid span.is-estimated b {
-  color: #cc0000;
+  color: var(--danger);
 }
 
 .run-compare-grid {
@@ -2369,10 +2374,10 @@ button.is-pending::after {
 .run-error-card {
   margin-bottom: 10px;
   padding: 10px;
-  border: 1px solid #d99a9a;
+  border: 1px solid var(--danger-border);
   border-radius: 6px;
-  background: #f7e4e4;
-  color: #8a2929;
+  background: var(--danger-tint);
+  color: var(--danger-text);
   font-size: 12px;
 }
 
@@ -2386,10 +2391,10 @@ button.is-pending::after {
   gap: 12px;
   margin: 10px 20px 0;
   padding: 10px 14px;
-  border: 1px solid #d99a9a;
+  border: 1px solid var(--danger-border);
   border-radius: 8px;
-  background: #f7e4e4;
-  color: #8a2929;
+  background: var(--danger-tint);
+  color: var(--danger-text);
   font-size: 12px;
 }
 
@@ -2404,7 +2409,7 @@ button.is-pending::after {
 
 .run-message-card.is-streaming {
   border-color: var(--gold-4);
-  background: #fff9ec;
+  background: var(--bg-streaming);
 }
 
 .run-message-card small,
@@ -2422,7 +2427,7 @@ button.is-pending::after {
   height: 13px;
   margin-left: 4px;
   vertical-align: -2px;
-  background: var(--gold-9);
+  background: var(--gold-4);
   animation: stream-cursor-blink 1s steps(2, start) infinite;
 }
 
@@ -2490,7 +2495,7 @@ button.is-pending::after {
 }
 
 .evaluate-tabs button.is-active {
-  border-bottom: 2px solid var(--gold-9);
+  border-bottom: 2px solid var(--gold-4);
   background: var(--paper-1);
   color: var(--ink-9);
 }
@@ -2515,7 +2520,7 @@ button.is-pending::after {
 }
 
 .evaluate-queue-row.is-selected {
-  border-left-color: var(--gold-9);
+  border-left-color: var(--gold-4);
   background: var(--bg-selected);
 }
 
@@ -2607,7 +2612,7 @@ button.is-pending::after {
 }
 
 .score-row.is-active {
-  border-color: var(--gold-9);
+  border-color: var(--gold-4);
   background: var(--bg-selected);
 }
 
@@ -2646,13 +2651,13 @@ button.is-pending::after {
 }
 
 .status-pass {
-  background: #d7ebdd;
-  color: #1f6b3c;
+  background: var(--ok-tint);
+  color: var(--ok-text);
 }
 
 .status-fail {
-  background: #f1d1d1;
-  color: #9a3030;
+  background: var(--danger-tint);
+  color: var(--danger-text);
 }
 
 .run-summary-footer > span {
@@ -3737,7 +3742,7 @@ pre.code-block {
 
 .arch-node-row.selected {
   background: var(--bg-selected);
-  border-left: 2px solid var(--gold-9);
+  border-left: 2px solid var(--gold-4);
   font-weight: var(--fw-semibold);
 }
 
@@ -3822,7 +3827,7 @@ pre.code-block {
   padding: 10px 12px;
   color: var(--ink-2);
   background: var(--paper-1);
-  border: 1px solid var(--border-subtle);
+  border: 1px solid var(--border-divider);
   border-radius: 8px;
 }
 
@@ -3900,7 +3905,7 @@ pre.code-block {
 }
 
 .catalog-section-actions .is-active {
-  border-color: var(--gold-9);
+  border-color: var(--gold-4);
   background: var(--bg-selected);
   color: var(--ink-9);
 }
@@ -3946,7 +3951,7 @@ pre.code-block {
 
 .catalog-filter-group input[type="range"] {
   width: 100%;
-  accent-color: var(--color-info);
+  accent-color: var(--gold-5);
 }
 
 .catalog-param-slider-label {
@@ -3999,7 +4004,7 @@ pre.code-block {
 }
 
 .catalog-server-card--empty:hover {
-  border-color: var(--gold-9);
+  border-color: var(--gold-4);
   background: var(--bg-selected);
 }
 
@@ -4027,7 +4032,7 @@ pre.code-block {
 
 .catalog-server-card.is-selected,
 .catalog-model-card.is-selected {
-  border: 1.5px solid var(--gold-9);
+  border: 1.5px solid var(--gold-4);
   background: var(--bg-selected);
 }
 
@@ -4180,7 +4185,7 @@ pre.code-block {
 }
 
 .server-filter-row.is-selected {
-  border-color: var(--gold-9);
+  border-color: var(--gold-4);
   background: var(--bg-selected);
 }
 
@@ -4376,7 +4381,7 @@ pre.code-block {
   z-index: 40;
   display: flex;
   justify-content: flex-end;
-  background: rgba(27, 26, 23, 0.4);
+  background: var(--overlay-modal);
 }
 
 .server-drawer {
@@ -4446,7 +4451,7 @@ pre.code-block {
 
 .drawer-col--hosting.is-disabled {
   background: color-mix(in srgb, var(--paper-2) 88%, var(--paper-5));
-  color: var(--ink-muted);
+  color: var(--ink-3);
 }
 
 .drawer-col--hosting.is-disabled input,
@@ -4457,7 +4462,7 @@ pre.code-block {
 .drawer-disabled-note {
   border: 1px dashed var(--paper-7);
   border-radius: 8px;
-  color: var(--ink-muted);
+  color: var(--ink-3);
   font-size: 0.86rem;
   line-height: 1.45;
   margin: -2px 0 2px;
@@ -4491,8 +4496,8 @@ pre.code-block {
 }
 
 .probe-panel--failed {
-  border-color: var(--border-danger);
-  background: var(--bg-danger);
+  border-color: var(--danger-border);
+  background: var(--danger-tint);
 }
 
 .probe-panel ul {
@@ -4727,7 +4732,7 @@ pre.code-block {
   display: block;
   height: 100%;
   min-width: 2px;
-  background: var(--gold-9);
+  background: var(--gold-4);
 }
 
 .model-inspector-section-title {
@@ -4916,7 +4921,7 @@ pre.code-block {
   min-width: 0;
   height: 34px;
   padding: 0 12px;
-  background: #fffdfa;
+  background: var(--bg-input);
   border: 1px solid var(--border-input);
   border-radius: 8px;
   font-size: 13px;
@@ -5146,7 +5151,7 @@ pre.code-block {
   flex-direction: column;
   min-height: 0;
   overflow: hidden;
-  border: 1px solid #2a2722;
+  border: 1px solid var(--terminal-border);
   border-radius: 12px;
   background: var(--ink-1);
 }
@@ -5156,8 +5161,8 @@ pre.code-block {
   align-items: center;
   gap: 10px;
   padding: 9px 14px;
-  border-bottom: 1px solid #2a2722;
-  background: #211e1a;
+  border-bottom: 1px solid var(--terminal-border);
+  background: var(--terminal-surface);
 }
 
 .template-json-window__dots {
@@ -5170,26 +5175,26 @@ pre.code-block {
   width: 10px;
   height: 10px;
   border-radius: 999px;
-  background: #3f3a33;
+  background: var(--terminal-control);
 }
 
 .template-json-window__dots i:first-child {
-  background: #e0a23a;
+  background: var(--terminal-warning);
 }
 
 .template-json-window__dots i:nth-child(2) {
-  background: #5b554c;
+  background: var(--terminal-muted);
 }
 
 .template-json-window__filename,
 .template-json-window__state {
-  color: #cabfa9;
+  color: var(--terminal-text-muted);
   font-family: var(--font-mono);
   font-size: 12px;
 }
 
 .template-json-window__state {
-  color: #7c756a;
+  color: var(--terminal-text-subtle);
 }
 
 .template-json-window__spacer {
@@ -5198,16 +5203,16 @@ pre.code-block {
 
 .template-notes-toggle {
   padding: 3px 9px;
-  border: 1px solid #3a352d;
+  border: 1px solid var(--terminal-field-border);
   border-radius: 999px;
   background: transparent;
-  color: #b6a986;
+  color: var(--terminal-field-text);
   font-family: var(--font-mono);
   font-size: 11px;
 }
 
 .template-notes-toggle.is-on {
-  background: rgba(140, 115, 64, 0.22);
+  background: var(--terminal-selection);
   border-color: var(--gold-5);
   color: var(--gold-1);
 }
@@ -5218,7 +5223,7 @@ pre.code-block {
   margin: 0;
   overflow: auto;
   padding: 16px 18px;
-  color: #e7ddc9;
+  color: var(--terminal-text);
   font-family: var(--font-mono);
   font-size: 12.5px;
   line-height: 1.7;
@@ -5233,7 +5238,7 @@ pre.code-block {
 }
 
 .template-json-line.has-note {
-  background: rgba(140, 115, 64, 0.16);
+  background: var(--terminal-highlight);
   box-shadow: inset 2px 0 0 var(--gold-3);
 }
 
@@ -5242,8 +5247,8 @@ pre.code-block {
 }
 
 @keyframes template-json-flash {
-  0% { background: rgba(140, 115, 64, 0.55); }
-  100% { background: rgba(140, 115, 64, 0.16); }
+  0% { background: var(--terminal-pulse); }
+  100% { background: var(--terminal-highlight); }
 }
 
 .template-json-note {
@@ -5264,7 +5269,7 @@ pre.code-block {
   border: 0;
   border-radius: 0;
   background: var(--ink-1);
-  color: #e7ddc9;
+  color: var(--terminal-text);
   font-family: var(--font-mono);
   font-size: 12.5px;
   line-height: 1.7;
@@ -5274,8 +5279,8 @@ pre.code-block {
   display: flex;
   gap: 8px;
   padding: 12px 14px;
-  border-top: 1px solid #2a2722;
-  background: #211e1a;
+  border-top: 1px solid var(--terminal-border);
+  background: var(--terminal-surface);
 }
 
 .template-raw-actions button {
@@ -5446,7 +5451,7 @@ pre.code-block {
   padding: 11px 12px;
   border: 1px solid var(--border-input);
   border-radius: 10px;
-  background: #fffdfa;
+  background: var(--bg-input);
   color: var(--ink-9);
   font-size: 13px;
   line-height: 1.4;
@@ -5488,7 +5493,7 @@ pre.code-block {
   overflow: auto;
   border: 1px solid var(--border-divider);
   border-radius: 10px;
-  background: #fffdfa;
+  background: var(--bg-input);
 }
 
 .dataset-table {
@@ -5507,7 +5512,7 @@ pre.code-block {
 }
 
 .dataset-table th {
-  color: var(--muted);
+  color: var(--ink-3);
   font-size: 11px;
   font-weight: 600;
   text-align: left;
@@ -5536,7 +5541,7 @@ pre.code-block {
   min-width: 0;
   border: 1px solid var(--border-input);
   border-radius: 8px;
-  background: #fffefa;
+  background: var(--bg-input-alt);
   color: var(--ink-9);
   font: inherit;
 }
@@ -5605,7 +5610,7 @@ pre.code-block {
   display: flex;
   flex-direction: column;
   gap: 6px;
-  color: var(--muted);
+  color: var(--ink-3);
   font-size: 12px;
   font-weight: 600;
 }
@@ -5623,7 +5628,7 @@ pre.code-block {
   border: 1px solid var(--border-divider);
   border-radius: 8px;
   background: var(--paper-2);
-  color: var(--muted);
+  color: var(--ink-3);
   font-size: 11px;
 }
 
@@ -5658,7 +5663,7 @@ pre.code-block {
   padding: 12px;
   border: 1px solid var(--border-divider);
   border-radius: 12px;
-  background: #fffdfa;
+  background: var(--bg-input);
   box-shadow: var(--shadow-card);
 }
 
@@ -5861,7 +5866,7 @@ pre.code-block {
   padding: 0 12px;
   border: 1px solid var(--border-input);
   border-radius: 8px;
-  background: #fffdfa;
+  background: var(--bg-input);
   color: var(--ink-9);
   font-size: 13px;
 }
@@ -5969,6 +5974,22 @@ pre.code-block {
   font-size: 14px;
   font-weight: var(--fw-semibold);
   line-height: 1.3;
+}
+
+.template-card__chip {
+  flex-shrink: 0;
+  max-width: 45%;
+  overflow: hidden;
+  padding: 3px 7px;
+  border-radius: var(--r-pill);
+  background: var(--ink-9);
+  color: var(--paper-1);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-semibold);
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .template-card__description {
@@ -6082,6 +6103,110 @@ pre.code-block {
 .template-agent-draft-card {
   margin: 0 16px 12px;
   border-radius: 12px;
+}
+
+@media (max-width: 900px) {
+  body {
+    overflow-x: hidden;
+  }
+
+  .app-shell {
+    display: block;
+  }
+
+  .sidebar--desktop {
+    display: none;
+  }
+
+  .mobile-app-bar {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    min-height: 52px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--s-8);
+    padding: var(--s-4) var(--s-8) var(--s-4) var(--s-10);
+    border-bottom: 1px solid var(--border-default);
+    background: var(--paper-2);
+    box-shadow: var(--shadow-header);
+  }
+
+  .mobile-app-bar > div {
+    display: grid;
+    gap: var(--s-1);
+  }
+
+  .mobile-app-bar strong {
+    color: var(--ink-9);
+    font-size: var(--fs-md);
+  }
+
+  .mobile-app-bar span {
+    color: var(--ink-3);
+    font-family: var(--font-mono);
+    font-size: var(--fs-xs);
+  }
+
+  .mobile-app-bar__menu,
+  .mobile-nav-dialog__close {
+    width: 44px;
+    height: 44px;
+    display: inline-grid;
+    place-items: center;
+    padding: 0;
+    border: 1px solid var(--border-default);
+    border-radius: var(--r-input);
+    background: var(--paper-1);
+    color: var(--ink-9);
+    cursor: pointer;
+  }
+
+  .mobile-nav-dialog[open] {
+    position: fixed;
+    inset: 0 auto 0 0;
+    width: min(320px, calc(100vw - 48px));
+    max-width: none;
+    height: 100dvh;
+    max-height: none;
+    display: block;
+    margin: 0;
+    padding: 0;
+    overflow: visible;
+    border: 0;
+    background: var(--paper-2);
+    box-shadow: var(--shadow-modal);
+  }
+
+  .mobile-nav-dialog::backdrop {
+    background: var(--overlay-modal);
+  }
+
+  .sidebar--mobile {
+    position: static;
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+    padding-top: 0;
+    border-right: 0;
+  }
+
+  .mobile-nav-dialog__close {
+    position: absolute;
+    top: var(--s-4);
+    right: var(--s-4);
+    z-index: 1;
+  }
+
+  .sidebar--mobile .sidebar-brand {
+    min-height: 61px;
+    padding-right: 60px;
+  }
+
+  .app-main {
+    width: 100%;
+  }
 }
 
 @media (max-width: 980px) {

--- a/frontend/src/styles/tokens/colors_and_type.css
+++ b/frontend/src/styles/tokens/colors_and_type.css
@@ -136,7 +136,11 @@
                     rgba(240, 233, 223, 0.9));
   --bg-pre-dark:  var(--ink-1);
   --bg-pre-light: #f6f1e6;
+  --bg-input:     #fffdfa;
+  --bg-input-alt: #fffefa;
   --bg-error:     #ffe8e5;
+  --bg-error-soft: #fff8f5;
+  --bg-streaming: #fff9ec;
   --bg-tab-active:    #fff8ea;
   --bg-tab-inactive:  var(--paper-5);
   --bg-nav-active:    #fff4e6;
@@ -155,20 +159,42 @@
 
   /* ---- 6. Semantic ---------------------------------------- */
   --ok:           #2f9e44;
-  --ok-tint:      rgba(47, 158, 68, 0.12);
+  --ok-text:      #246b3d;
+  --ok-tint:      #ddf2e4;
+  --ok-border:    #8abf92;
   --ok-halo:      rgba(47, 158, 68, 0.2);
 
   --danger:       #c92a2a;
   --danger-icon:  #b42318;
-  --danger-tint:  rgba(201, 42, 42, 0.1);
+  --danger-text:  #93403d;
+  --danger-tint:  #f7dedb;
+  --danger-border: #d99a9a;
+  --danger-accent: #c95b45;
+  --danger-field-border: #9c3f2e;
+  --danger-soft-transparent: rgba(255, 248, 245, 0);
   --danger-halo:  rgba(201, 42, 42, 0.2);
 
   --pending:      #b3aca2;
   --pending-text: #766f66;
+  --pending-tint: #e9e3d9;
   --pending-halo: rgba(179, 172, 162, 0.2);
 
   --warning-dot:  #f2c94c;
-  --warning-tint: rgba(242, 201, 76, 0.18);
+  --warning-text: #7a5b11;
+  --warning-tint: #f8edc7;
+
+  --benchmark-text: #55601f;
+  --benchmark-tint: #e7ead8;
+
+  /* distinguish concurrent run targets */
+  --run-accent-1: #3776ab;
+  --run-accent-2: #cb6d1a;
+  --run-accent-3: #5b8a3a;
+  --run-accent-4: #8a4a9c;
+  --run-accent-5: #b85c5c;
+  --run-accent-6: #3a7a7a;
+  --run-accent-7: #7a6a3a;
+  --run-accent-8: #5c5c5c;
 
   /* ---- 7. Borders ----------------------------------------- */
   --border-default:    var(--paper-7);
@@ -211,6 +237,8 @@
                         0 2px 6px rgba(27, 26, 23, 0.12);
   --shadow-modal:       0 20px 40px rgba(27, 26, 23, 0.2);
   --shadow-popover:     0 8px 24px rgba(27, 26, 23, 0.14);
+  --shadow-drawer:      -12px 0 30px rgba(27, 26, 23, 0.18);
+  --shadow-button-hover: 0 6px 14px rgba(27, 26, 23, 0.18);
 
   --halo-focus:         0 0 0 3px var(--gold-1),
                         0 0 0 4px var(--gold-3);
@@ -219,6 +247,22 @@
   --halo-pending:       0 0 0 4px var(--pending-halo);
 
   --overlay-modal:      rgba(27, 26, 23, 0.4);
+  --halo-neutral:       0 0 0 3px rgba(55, 53, 47, 0.08);
+
+  /* dark structured-data editor */
+  --terminal-border:       #2a2722;
+  --terminal-surface:      #211e1a;
+  --terminal-control:      #3f3a33;
+  --terminal-warning:      #e0a23a;
+  --terminal-muted:        #5b554c;
+  --terminal-text:         #e7ddc9;
+  --terminal-text-muted:   #cabfa9;
+  --terminal-text-subtle:  #7c756a;
+  --terminal-field-border: #3a352d;
+  --terminal-field-text:   #b6a986;
+  --terminal-selection:    rgba(140, 115, 64, 0.22);
+  --terminal-highlight:    rgba(140, 115, 64, 0.16);
+  --terminal-pulse:        rgba(140, 115, 64, 0.55);
 
   /* ---- 10. Spacing scale (4-base, with 2px micro) -------- */
   --s-0:  0;
@@ -248,10 +292,9 @@
   /* ---- 12. Layout --------------------------------------- */
   --page-max:       960px;
   --page-max-wide:  1200px;
-  --sidebar-w:      72px;
+  --sidebar-w:      220px;
   --nav-btn-size:   44px;
   --input-h:        34px;
-  --bp-mobile:      900px;
 }
 
 /* ============================================================
@@ -367,4 +410,3 @@
   padding: 1px 5px;
   color: var(--ink-8);
 }
-

--- a/frontend/src/styles/tokens/components.css
+++ b/frontend/src/styles/tokens/components.css
@@ -40,7 +40,7 @@ body.atb {
               background var(--t-fast) var(--ease-out);
   white-space: nowrap;
 }
-.btn:hover { transform: translateY(-1px); box-shadow: 0 6px 14px rgba(27,26,23,0.18); }
+.btn:hover { transform: translateY(-1px); box-shadow: var(--shadow-button-hover); }
 .btn:active { transform: var(--xfm-press); box-shadow: none; }
 .btn:focus-visible { outline: none; box-shadow: var(--halo-focus); }
 
@@ -110,7 +110,7 @@ body.atb {
   width: 100%;
   padding: 0 var(--s-10);
   font-family: var(--font-sans); font-size: var(--fs-md); color: var(--ink-9);
-  background: #fffdfa; border: 1px solid var(--border-input); border-radius: var(--r-input);
+  background: var(--bg-input); border: 1px solid var(--border-input); border-radius: var(--r-input);
   outline: none;
   transition: border-color var(--t-fast), box-shadow var(--t-fast);
 }
@@ -121,7 +121,7 @@ body.atb {
 .textarea {
   width: 100%; min-height: 220px; padding: var(--s-8) var(--s-10);
   font-family: var(--font-mono); font-size: var(--fs-base); color: var(--ink-9);
-  background: #fffdfa; border: 1px solid var(--border-input); border-radius: var(--r-input);
+  background: var(--bg-input); border: 1px solid var(--border-input); border-radius: var(--r-input);
   outline: none; resize: vertical;
 }
 .textarea:focus { border-color: var(--gold-3); box-shadow: 0 0 0 3px var(--gold-1); }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "@typescript-eslint/parser": "^8.0.0",
         "concurrently": "^9.0.1",
         "eslint": "^8.57.0",
-        "eslint-plugin-import": "^2.31.0"
+        "eslint-plugin-import": "^2.31.0",
+        "postcss": "^8.5.23"
       },
       "engines": {
         "node": "25.x"
@@ -59,6 +60,7 @@
         "@vitejs/plugin-react": "^6.0.1",
         "echarts": "^6.0.0",
         "echarts-for-react": "^3.0.6",
+        "lucide-react": "^0.468.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.30.3"
@@ -4150,6 +4152,15 @@
       "version": "4.0.0",
       "license": "MIT"
     },
+    "node_modules/lucide-react": {
+      "version": "0.468.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.468.0.tgz",
+      "integrity": "sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "dev": true,
@@ -4633,9 +4644,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
-      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "build": "npm run build:frontend",
     "build:frontend": "npm -w frontend run build",
+    "check:design-system": "node scripts/check-design-system.mjs",
     "check:node": "node scripts/check-node-version.mjs",
     "dev": "concurrently \"npm -w backend run dev\" \"npm -w frontend run dev\"",
     "prebuild": "npm -w backend run bootstrap-env",
@@ -24,7 +25,7 @@
     "prestart": "npm -w backend run bootstrap-env",
     "e2e:serve": "concurrently --kill-others-on-fail \"npm run start:backend\" \"npm -w frontend run dev\"",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
-    "release:check": "npm run lint && npm test && npm run build",
+    "release:check": "npm run check:design-system && npm run lint && npm test && npm run build",
     "start": "concurrently \"npm run start:backend\" \"npm run start:frontend\"",
     "start:backend": "npm -w backend run start",
     "start:frontend": "npm -w frontend run preview",
@@ -44,6 +45,7 @@
     "@typescript-eslint/parser": "^8.0.0",
     "concurrently": "^9.0.1",
     "eslint": "^8.57.0",
-    "eslint-plugin-import": "^2.31.0"
+    "eslint-plugin-import": "^2.31.0",
+    "postcss": "^8.5.23"
   }
 }

--- a/scripts/check-design-system.mjs
+++ b/scripts/check-design-system.mjs
@@ -1,0 +1,100 @@
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import postcss from 'postcss';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const documentedTokens = path.join(root, 'docs/design-system/tokens');
+const runtimeTokens = path.join(root, 'frontend/src/styles/tokens');
+const stylesRoot = path.join(root, 'frontend/src/styles');
+const colorTokenFile = path.join(runtimeTokens, 'colors_and_type.css');
+const errors = [];
+
+async function listFiles(directory) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = await Promise.all(entries.map(async (entry) => {
+    const entryPath = path.join(directory, entry.name);
+    return entry.isDirectory() ? listFiles(entryPath) : [entryPath];
+  }));
+  return files.flat().sort();
+}
+
+function relative(file) {
+  return path.relative(root, file);
+}
+
+const documentedFiles = await listFiles(documentedTokens);
+const runtimeFiles = await listFiles(runtimeTokens);
+const documentedNames = documentedFiles.map((file) => path.relative(documentedTokens, file));
+const runtimeNames = runtimeFiles.map((file) => path.relative(runtimeTokens, file));
+
+if (documentedNames.join('\n') !== runtimeNames.join('\n')) {
+  errors.push('Token snapshot file lists differ between docs/design-system/tokens and frontend/src/styles/tokens.');
+}
+
+for (const name of documentedNames) {
+  const documented = await readFile(path.join(documentedTokens, name));
+  const runtime = await readFile(path.join(runtimeTokens, name)).catch(() => null);
+  if (runtime === null || !documented.equals(runtime)) {
+    errors.push(`Token snapshot drift: ${name}`);
+  }
+}
+
+const cssFiles = (await listFiles(stylesRoot)).filter((file) => file.endsWith('.css'));
+const parsedFiles = await Promise.all(cssFiles.map(async (file) => ({
+  file,
+  root: postcss.parse(await readFile(file, 'utf8'), { from: file })
+})));
+const definitions = new Set();
+const usages = [];
+const hardcodedColor = /(?:#[\da-f]{3,8}\b|(?:rgb|hsl)a?\()/i;
+
+for (const parsed of parsedFiles) {
+  parsed.root.walkDecls((declaration) => {
+    if (declaration.prop.startsWith('--')) {
+      definitions.add(declaration.prop);
+    }
+
+    for (const match of declaration.value.matchAll(/var\(\s*(--[\w-]+)/g)) {
+      usages.push({
+        name: match[1],
+        file: parsed.file,
+        line: declaration.source?.start?.line ?? 0
+      });
+    }
+
+    if (parsed.file !== colorTokenFile && hardcodedColor.test(declaration.value)) {
+      errors.push(
+        `${relative(parsed.file)}:${declaration.source?.start?.line ?? 0} uses a hardcoded color in ${declaration.prop}.`
+      );
+    }
+  });
+}
+
+for (const usage of usages) {
+  if (!definitions.has(usage.name)) {
+    errors.push(`${relative(usage.file)}:${usage.line} uses unresolved variable ${usage.name}.`);
+  }
+}
+
+const frontendSourceFiles = (await listFiles(path.join(root, 'frontend/src')))
+  .filter((file) => /\.(?:css|ts|tsx)$/.test(file) && file !== colorTokenFile);
+for (const file of frontendSourceFiles) {
+  const lines = (await readFile(file, 'utf8')).split('\n');
+  lines.forEach((line, index) => {
+    if (hardcodedColor.test(line)) {
+      errors.push(`${relative(file)}:${index + 1} uses a hardcoded color.`);
+    }
+  });
+}
+
+if (errors.length > 0) {
+  console.error('Design-system conformance check failed:');
+  for (const error of errors) {
+    console.error(`- ${error}`);
+  }
+  process.exitCode = 1;
+} else {
+  console.log(`Design-system conformance check passed (${documentedFiles.length} token assets, ${cssFiles.length} CSS files).`);
+}


### PR DESCRIPTION
Promote docs/design-system/tokens as the durable token snapshot and keep the frontend runtime copy byte-identical.

Add semantic tokens, remove unresolved aliases and application hardcoded colors, and enforce conformance through a PostCSS release check.

Introduce the accessible off-canvas navigation shell below 900px, standardize the desktop sidebar at 220px, and restore readable template operation chips.

Document responsive support and update the changelog and package dependencies.